### PR TITLE
Make Docker build image nonroot

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+FROM sls-registry.cn-beijing.cr.aliyuncs.com/sls-microservices/ilogtail-build-linux-amd64:admin
+
+ARG USERNAME=admin
+USER root
+
+# Create the user
+COPY .env /tmp/.env
+RUN source /tmp/.env && rm /tmp/.env && \
+    if getent passwd $USERNAME; then userdel -f $USERNAME; fi && \
+    if getent group $GROUPNAME; then groupdel $GROUPNAME; fi && \
+    groupadd --gid $GROUP_GID $GROUPNAME && \
+    useradd --uid $USER_UID --gid $GROUP_GID -m $USERNAME && \
+    echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME && \
+    chmod 0440 /etc/sudoers.d/$USERNAME && \
+    chown -R $USERNAME:$GROUPNAME /root/go /opt/logtail $(eval echo ~$USERNAME) && \
+    chmod 755 $(eval echo ~$USERNAME)
+
+USER $USERNAME

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,14 +5,16 @@ USER root
 
 # Create the user
 COPY .env /tmp/.env
-RUN source /tmp/.env && rm /tmp/.env && \
-    if getent passwd $USERNAME; then userdel -f $USERNAME; fi && \
-    if getent group $GROUPNAME; then groupdel $GROUPNAME; fi && \
-    groupadd --gid $GROUP_GID $GROUPNAME && \
-    useradd --uid $USER_UID --gid $GROUP_GID -m $USERNAME && \
-    echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME && \
-    chmod 0440 /etc/sudoers.d/$USERNAME && \
-    chown -R $USERNAME:$GROUPNAME /root/go /opt/logtail $(eval echo ~$USERNAME) && \
-    chmod 755 $(eval echo ~$USERNAME)
+RUN source /tmp/.env && rm /tmp/.env; \
+    if getent passwd $USERNAME; then userdel -f $USERNAME; fi; \
+    if [ $HOST_OS = "Linux" ]; then \
+    if getent group $GROUPNAME; then groupdel $GROUPNAME; fi; \
+    groupadd --gid $GROUP_GID $GROUPNAME; \
+    fi; \
+    useradd --uid $USER_UID --gid $GROUP_GID -m $USERNAME; \
+    echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME; \
+    chmod 0440 /etc/sudoers.d/$USERNAME; \
+    chown -R $USERNAME:$GROUPNAME /root/go /opt/logtail $(eval echo ~$USERNAME); \
+    chmod 755 $(eval echo ~$USERNAME);
 
 USER $USERNAME

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM sls-registry.cn-beijing.cr.aliyuncs.com/sls-microservices/ilogtail-build-linux-amd64:admin
+FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:latest
 
 ARG USERNAME=admin
 USER root

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,11 @@
 {
-  "image": "sls-registry.cn-beijing.cr.aliyuncs.com/sls-microservices/ilogtail-build-linux:latest",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "USERNAME": "${localEnv:USER}"
+    }
+  },
+  "initializeCommand": "echo -e \"USERNAME=$USER\nUSER_UID=$(id -u $USER)\nGROUPNAME=$(id -gn $USER)\nGROUP_GID=$(id -g $USER)\" > .devcontainer/.env",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
       "USERNAME": "${localEnv:USER}"
     }
   },
-  "initializeCommand": "echo -e \"USERNAME=$USER\nUSER_UID=$(id -u $USER)\nGROUPNAME=$(id -gn $USER)\nGROUP_GID=$(id -g $USER)\" > .devcontainer/.env",
+  "initializeCommand": ".devcontainer/gen_env.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/gen_env.sh
+++ b/.devcontainer/gen_env.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+
+# Copyright 2021 iLogtail Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ue
+set -o pipefail
+
+if uname -s | grep Linux; then
+  echo -e "HOST_OS=Linux\nUSERNAME=$USER\nUSER_UID=$(id -u $USER)\nGROUPNAME=$(id -gn $USER)\nGROUP_GID=$(id -g $USER)" > .devcontainer/.env;
+else
+  echo "HOST_OS=Darwin\nUSERNAME=$USER\nUSER_UID=$(id -u $USER)\nGROUPNAME=root\nGROUP_GID=0" > .devcontainer/.env;  
+fi

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,10 @@ plugin: clean
 	./scripts/docker_build.sh build $(GENERATED_HOME) $(VERSION) $(BUILD_REPOSITORY) false
 	./$(GENERATED_HOME)/gen_copy_docker.sh
 
+.PHONY: upgrade_adapter_lib
+upgrade_adapter_lib:
+	./scripts/upgrade_adapter_lib.sh ${OUT_DIR}
+
 .PHONY: plugin_main
 plugin_main: clean
 	./scripts/plugin_build.sh vendor default $(OUT_DIR)

--- a/docker/Dockerfile.ilogtail-build-linux-amd64
+++ b/docker/Dockerfile.ilogtail-build-linux-amd64
@@ -10,6 +10,23 @@ FROM local/ilogtail-toolchain-linux-amd64
 RUN mkdir -p /usr/local/bin /opt/logtail
 # install goc for coverage
 COPY --from=dep-build goc /usr/local/bin
+
+ARG USERNAME=admin
+ARG USER_UID=1000
+ARG GROUPNAME=$USERNAME
+ARG GROUP_GID=$USER_UID
+
+# Create the user
+RUN if getent passwd $USERNAME; then userdel -f $USERNAME; fi && \
+    if getent group $GROUPNAME; then groupdel $GROUPNAME; fi && \
+    groupadd --gid $GROUP_GID $USERNAME && \
+    useradd --uid $USER_UID --gid $GROUP_GID -m $USERNAME && \
+    echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME && \
+    chmod 0440 /etc/sudoers.d/$USERNAME && \
+    chown -R $USERNAME:$GROUPNAME /opt/logtail $(eval echo ~$USERNAME) && \
+    chmod 755 $(eval echo ~$USERNAME)
+
+USER $USERNAME
+
 # install c++ deps
 COPY --from=dep-build ilogtail-deps.linux-amd64 /opt/logtail/deps
-

--- a/docker/Dockerfile.ilogtail-build-linux-amd64
+++ b/docker/Dockerfile.ilogtail-build-linux-amd64
@@ -10,9 +10,11 @@ FROM local/ilogtail-toolchain-linux-amd64
 RUN mkdir -p /usr/local/bin /opt/logtail
 # install goc for coverage
 COPY --from=dep-build goc /usr/local/bin
+# install c++ deps
+COPY --from=dep-build ilogtail-deps.linux-amd64 /opt/logtail/deps
 
 ARG USERNAME=admin
-ARG USER_UID=1000
+ARG USER_UID=500
 ARG GROUPNAME=$USERNAME
 ARG GROUP_GID=$USER_UID
 
@@ -23,10 +25,7 @@ RUN if getent passwd $USERNAME; then userdel -f $USERNAME; fi && \
     useradd --uid $USER_UID --gid $GROUP_GID -m $USERNAME && \
     echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME && \
     chmod 0440 /etc/sudoers.d/$USERNAME && \
-    chown -R $USERNAME:$GROUPNAME /opt/logtail $(eval echo ~$USERNAME) && \
+    chown -R $USERNAME:$GROUPNAME $(eval echo ~$USERNAME) && \
     chmod 755 $(eval echo ~$USERNAME)
 
 USER $USERNAME
-
-# install c++ deps
-COPY --from=dep-build ilogtail-deps.linux-amd64 /opt/logtail/deps

--- a/docker/Dockerfile.ilogtail-build-linux-arm64
+++ b/docker/Dockerfile.ilogtail-build-linux-arm64
@@ -13,3 +13,18 @@ COPY --from=dep-build goc /usr/local/bin
 # install c++ deps
 COPY --from=dep-build ilogtail-deps.linux-arm64 /opt/logtail/deps
 
+ARG USERNAME=admin
+ARG USER_UID=1000
+ARG GROUPNAME=$USERNAME
+ARG GROUP_GID=$USER_UID
+
+# Create the user
+RUN if getent passwd $USERNAME; then userdel -f $USERNAME; fi && \
+    if getent group $GROUPNAME; then groupdel $GROUPNAME; fi && \
+    groupadd --gid $GROUP_GID $USERNAME && \
+    useradd --uid $USER_UID --gid $GROUP_GID -m $USERNAME && \
+    echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME && \
+    chmod 0440 /etc/sudoers.d/$USERNAME && \
+    chown -R admin:admin /root/go /opt/logtail
+
+USER $USERNAME

--- a/docker/Dockerfile.ilogtail-build-linux-arm64
+++ b/docker/Dockerfile.ilogtail-build-linux-arm64
@@ -14,7 +14,7 @@ COPY --from=dep-build goc /usr/local/bin
 COPY --from=dep-build ilogtail-deps.linux-arm64 /opt/logtail/deps
 
 ARG USERNAME=admin
-ARG USER_UID=1000
+ARG USER_UID=500
 ARG GROUPNAME=$USERNAME
 ARG GROUP_GID=$USER_UID
 
@@ -25,6 +25,7 @@ RUN if getent passwd $USERNAME; then userdel -f $USERNAME; fi && \
     useradd --uid $USER_UID --gid $GROUP_GID -m $USERNAME && \
     echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME && \
     chmod 0440 /etc/sudoers.d/$USERNAME && \
-    chown -R admin:admin /root/go /opt/logtail
+    chown -R $USERNAME:$GROUPNAME $(eval echo ~$USERNAME) && \
+    chmod 755 $(eval echo ~$USERNAME)
 
 USER $USERNAME

--- a/docker/Dockerfile.ilogtail-toolchain-linux-amd64
+++ b/docker/Dockerfile.ilogtail-toolchain-linux-amd64
@@ -18,18 +18,16 @@ ENV MANPATH=/opt/rh/devtoolset-8/root/usr/share/man \
     INFOPATH=/opt/rh/devtoolset-8/root/usr/share/info
 
 WORKDIR /
-RUN wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/cmake-3.23.2-linux-x86_64.tar.gz && \
-    wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/llvm-project-14.0.0.src.tar.xz && \
-    wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/go1.18.5.linux-amd64.tar.gz && \
-    wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/git-2.29.3.tar.xz
 
 # prepare cmake
-RUN tar -xzf cmake-3.23.2-linux-x86_64.tar.gz
+RUN wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/cmake-3.23.2-linux-x86_64.tar.gz && \
+    tar -xzf cmake-3.23.2-linux-x86_64.tar.gz
 ENV CMAKE_ROOT=/cmake-3.23.2-linux-x86_64 \
     PATH=/cmake-3.23.2-linux-x86_64/bin:$PATH
 
 # build clang
-RUN tar -xf llvm-project-14.0.0.src.tar.xz && \
+RUN wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/llvm-project-14.0.0.src.tar.xz && \
+    tar -xf llvm-project-14.0.0.src.tar.xz && \
     mkdir llvm-project-14.0.0.src/build && \
     cd llvm-project-14.0.0.src/build && \
     cmake -G 'Unix Makefiles' -D CMAKE_C_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/gcc \
@@ -40,18 +38,25 @@ RUN tar -xf llvm-project-14.0.0.src.tar.xz && \
     cd /
 
 # build git
-RUN tar -xf git-2.29.3.tar.xz && \
+RUN wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/git-2.29.3.tar.xz && \
+    tar -xf git-2.29.3.tar.xz && \
     cd git-2.29.3 && \
     make -sj$(nproc) install install-man prefix=$PWD/build && \
     cd /
 
 # prepare go
-RUN tar -xzf go1.18.5.linux-amd64.tar.gz
+RUN wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/go1.18.5.linux-amd64.tar.gz && \
+    tar -xzf go1.18.5.linux-amd64.tar.gz
+
+# prepare golangci-lint
+RUN wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/golangci-lint-1.49.0-linux-amd64.tar.gz && \
+    tar -xzf golangci-lint-1.49.0-linux-amd64.tar.gz
 
 FROM local/c7-systemd-linux-amd64
 
 # install dev tool set and debug utilities
-RUN yum -y install gcc gcc-c++ make libuuid-devel libstdc++-static systemd-devel iproute gdb net-tools which wget vim tree man openssh-clients
+RUN yum -y install gcc gcc-c++ make libuuid-devel libstdc++-static systemd-devel iproute gdb net-tools which wget vim tree man openssh-clients sudo && \
+    yum -y clean all && rm -fr /var/cache && rm -rf /core.*
 RUN debuginfo-install -y glibc-2.17-326.el7_9.x86_64 libuuid-2.23.2-65.el7_9.1.x86_64
 
 # install cmake
@@ -66,9 +71,12 @@ WORKDIR /
 COPY --from=toolchain-build /go /go
 ENV GOROOT=/go GOPATH=/root/go PATH=/go/bin:$PATH
 
+# install golangci-lint
+COPY --from=toolchain-build /golangci-lint-1.49.0-linux-amd64/golangci-lint /root/go/bin/
+
 # install go language server
 RUN go env -w GOPROXY="https://goproxy.cn,direct"
-RUN go install golang.org/x/tools/gopls@v0.9.1 && \
+RUN go install golang.org/x/tools/gopls@v0.9.3 && \
     go install github.com/go-delve/delve/cmd/dlv@v1.6.1 && \
     go install github.com/josharian/impl@v1.1.0 && \
     go install github.com/fatih/gomodifytags@v1.16.0 && \

--- a/docker/Dockerfile.ilogtail-toolchain-linux-arm64
+++ b/docker/Dockerfile.ilogtail-toolchain-linux-arm64
@@ -18,18 +18,16 @@ ENV MANPATH=/opt/rh/devtoolset-8/root/usr/share/man \
     INFOPATH=/opt/rh/devtoolset-8/root/usr/share/info
 
 WORKDIR /
-RUN wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/cmake-3.23.2-linux-aarch64.tar.gz && \
-    wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/llvm-project-14.0.0.src.tar.xz && \
-    wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/go1.18.5.linux-arm64.tar.gz && \
-    wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/git-2.29.3.tar.xz
 
 # prepare cmake
-RUN tar -xzf cmake-3.23.2-linux-aarch64.tar.gz
+RUN wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/cmake-3.23.2-linux-aarch64.tar.gz && \
+    tar -xzf cmake-3.23.2-linux-aarch64.tar.gz
 ENV CMAKE_ROOT=/cmake-3.23.2-linux-aarch64 \
     PATH=/cmake-3.23.2-linux-aarch64/bin:$PATH
 
 # build clang
-RUN tar -xf llvm-project-14.0.0.src.tar.xz && \
+RUN wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/llvm-project-14.0.0.src.tar.xz && \
+    tar -xf llvm-project-14.0.0.src.tar.xz && \
     mkdir llvm-project-14.0.0.src/build && \
     cd llvm-project-14.0.0.src/build && \
     cmake -G 'Unix Makefiles' -D CMAKE_C_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/gcc \
@@ -40,18 +38,25 @@ RUN tar -xf llvm-project-14.0.0.src.tar.xz && \
     cd /
 
 # build git
-RUN tar -xf git-2.29.3.tar.xz && \
+RUN wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/git-2.29.3.tar.xz && \
+    tar -xf git-2.29.3.tar.xz && \
     cd git-2.29.3 && \
     make -sj$(nproc) install install-man prefix=$PWD/build && \
     cd /
 
 # prepare go
-RUN tar -xzf go1.18.5.linux-arm64.tar.gz
+RUN wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/go1.18.5.linux-arm64.tar.gz && \
+    tar -xzf go1.18.5.linux-arm64.tar.gz
+
+# prepare golangci-lint
+RUN wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/golangci-lint-1.49.0-linux-arm64.tar.gz && \
+    tar -xzf golangci-lint-1.49.0-linux-arm64.tar.gz
 
 FROM local/c7-systemd-linux-arm64
 
 # install dev tool set and debug utilities
-RUN yum -y install gcc gcc-c++ make libuuid-devel libstdc++-static systemd-devel iproute gdb net-tools which wget vim tree man openssh-clients
+RUN yum -y install gcc gcc-c++ make libuuid-devel libstdc++-static systemd-devel iproute gdb net-tools which wget vim tree man openssh-clients sudo && \
+    yum -y clean all && rm -fr /var/cache && rm -rf /core.*
 RUN debuginfo-install -y glibc-2.17-326.el7_9.aarch64 libuuid-2.23.2-65.el7_9.1.aarch64
 
 # install cmake
@@ -66,9 +71,12 @@ WORKDIR /
 COPY --from=toolchain-build /go /go
 ENV GOROOT=/go GOPATH=/root/go PATH=/go/bin:$PATH
 
+# install golangci-lint
+COPY --from=toolchain-build /golangci-lint-1.49.0-linux-arm64/golangci-lint /root/go/bin/
+
 # install go language server
 RUN go env -w GOPROXY="https://goproxy.cn,direct"
-RUN go install golang.org/x/tools/gopls@v0.9.1 && \
+RUN go install golang.org/x/tools/gopls@v0.9.3 && \
     go install github.com/go-delve/delve/cmd/dlv@v1.6.1 && \
     go install github.com/josharian/impl@v1.1.0 && \
     go install github.com/fatih/gomodifytags@v1.16.0 && \

--- a/docker/Dockerfile_build
+++ b/docker/Dockerfile_build
@@ -21,4 +21,4 @@ COPY . .
 ARG HOST_OS=Linux
 ARG VERSION=1.1.2
 
-RUN sh generated_files/gen_build.sh
+RUN sudo chown -R $(whoami) /src /opt/logtail && sh generated_files/gen_build.sh

--- a/docker/Dockerfile_build
+++ b/docker/Dockerfile_build
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM sls-registry.cn-beijing.cr.aliyuncs.com/sls-microservices/ilogtail-build-linux:latest as build
+FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:latest as build
 
 WORKDIR /src
 

--- a/docker/Dockerfile_development_part
+++ b/docker/Dockerfile_development_part
@@ -17,16 +17,17 @@ FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edit
 ARG HOST_OS=Linux
 ARG VERSION=1.1.2
 
+USER root
 WORKDIR /ilogtail
 
 COPY --from=build /src/core/build/ilogtail /ilogtail/
 COPY ./scripts/download_ebpflib.sh /tmp/
 
-RUN sudo chown -R $(whoami) /ilogtail && \
-    sudo chmod 755 /ilogtail/ilogtail && \
+RUN chown -R $(whoami) /ilogtail && \
+    chmod 755 /ilogtail/ilogtail && \
     mkdir /ilogtail/checkpoint && \
     if [ `uname -m` = "x86_64" ]; then /tmp/download_ebpflib.sh /ilogtail; fi && \
-    sudo rm /tmp/download_ebpflib.sh
+    rm /tmp/download_ebpflib.sh
 
 COPY --from=build /src/output/libPluginBase.so /ilogtail/
 COPY --from=build /src/example_config/quick_start/ilogtail_config.json /ilogtail/

--- a/docker/Dockerfile_development_part
+++ b/docker/Dockerfile_development_part
@@ -19,18 +19,21 @@ ARG VERSION=1.1.2
 
 WORKDIR /ilogtail
 
+COPY --from=build /src/core/build/ilogtail /ilogtail/
+COPY ./scripts/download_ebpflib.sh /tmp/
+
+RUN sudo chown -R $(whoami) /ilogtail && \
+    sudo chmod 755 /ilogtail/ilogtail && \
+    mkdir /ilogtail/checkpoint && \
+    if [ `uname -m` = "x86_64" ]; then /tmp/download_ebpflib.sh /ilogtail; fi && \
+    sudo rm /tmp/download_ebpflib.sh
+
 COPY --from=build /src/output/libPluginBase.so /ilogtail/
 COPY --from=build /src/example_config/quick_start/ilogtail_config.json /ilogtail/
-COPY --from=build /src/core/build/ilogtail /ilogtail/
 COPY --from=build /src/core/build/plugin/libPluginAdapter.so /ilogtail/
-
-RUN sudo chown -R $(whoami) /ilogtail && curl --connect-timeout 5 -m 10 https://logtail-release-us-west-1.oss-us-west-1.aliyuncs.com/kubernetes/libebpf.so -o /ilogtail/libebpf.so
-RUN mkdir /ilogtail/checkpoint
-RUN sudo yum install -y iproute
 
 ENV HOST_OS=$HOST_OS
 ENV LOGTAIL_VERSION=$VERSION
-
 
 EXPOSE 18689
 

--- a/docker/Dockerfile_development_part
+++ b/docker/Dockerfile_development_part
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM sls-registry.cn-beijing.cr.aliyuncs.com/sls-microservices/ilogtail-build-linux:latest
+FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:latest as build
 
 ARG HOST_OS=Linux
 ARG VERSION=1.1.2

--- a/docker/Dockerfile_development_part
+++ b/docker/Dockerfile_development_part
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:latest as build
+FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:latest
 
 ARG HOST_OS=Linux
 ARG VERSION=1.1.2

--- a/docker/Dockerfile_development_part
+++ b/docker/Dockerfile_development_part
@@ -24,10 +24,9 @@ COPY --from=build /src/example_config/quick_start/ilogtail_config.json /ilogtail
 COPY --from=build /src/core/build/ilogtail /ilogtail/
 COPY --from=build /src/core/build/plugin/libPluginAdapter.so /ilogtail/
 
-RUN curl --connect-timeout 5 -m 10 https://logtail-release-us-west-1.oss-us-west-1.aliyuncs.com/kubernetes/libebpf.so -o  /ilogtail/libebpf.so
-RUN chmod -R 755 /ilogtail/
+RUN sudo chown -R $(whoami) /ilogtail && curl --connect-timeout 5 -m 10 https://logtail-release-us-west-1.oss-us-west-1.aliyuncs.com/kubernetes/libebpf.so -o /ilogtail/libebpf.so
 RUN mkdir /ilogtail/checkpoint
-RUN yum install -y iproute
+RUN sudo yum install -y iproute
 
 ENV HOST_OS=$HOST_OS
 ENV LOGTAIL_VERSION=$VERSION

--- a/docker/Dockerfile_goc
+++ b/docker/Dockerfile_goc
@@ -14,6 +14,6 @@
 
 # goc server is only for e2e test to analysis code coverage.
 
-FROM sls-registry.cn-beijing.cr.aliyuncs.com/sls-microservices/ilogtail-build-linux:latest
+FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:latest as build
 
 ENTRYPOINT ["goc","server"]

--- a/docker/Dockerfile_goc
+++ b/docker/Dockerfile_goc
@@ -16,4 +16,5 @@
 
 FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:latest as build
 
+USER root
 ENTRYPOINT ["goc","server"]

--- a/docker/Dockerfile_production
+++ b/docker/Dockerfile_production
@@ -32,7 +32,8 @@ ARG VERSION=1.1.2
 
 ADD ilogtail-${VERSION}.tar.gz /usr/local/
 RUN mv /usr/local/ilogtail-${VERSION} /usr/local/ilogtail && \
-    chmod -R 755 /usr/local/ilogtail/ && \
+    chown -R $(whoami) /usr/local/ilogtail/ && \
+    chmod 755 /usr/local/ilogtail/ilogtail && \
     mkdir /usr/local/ilogtail/checkpoint
 
 WORKDIR /usr/local/ilogtail

--- a/docker/build-mono-arch-build-image.sh
+++ b/docker/build-mono-arch-build-image.sh
@@ -17,9 +17,13 @@
 set -ue
 set -o pipefail
 
+cd $(dirname "${BASH_SOURCE[0]}")
+
 machine=`uname -m`
 [[ $machine = 'aarch64' ]] && arch=arm64 || arch=amd64
 
 docker build --rm -t local/c7-systemd-linux-${arch} . -f Dockerfile.c7-systemd-linux
 docker build --rm -t local/ilogtail-toolchain-linux-${arch} . -f Dockerfile.ilogtail-toolchain-linux-${arch}
 docker build --rm -t local/ilogtail-build-linux-${arch} . -f Dockerfile.ilogtail-build-linux-${arch}
+
+cd -

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -30,6 +30,7 @@ cp "${ROOTDIR}/${OUT_DIR}/libPluginAdapter.so" "${ROOTDIR}/${DIST_DIR}"
 cp "${ROOTDIR}/${OUT_DIR}/libPluginBase.so" "${ROOTDIR}/${DIST_DIR}"
 cp "${ROOTDIR}/${OUT_DIR}/ilogtail_config.json" "${ROOTDIR}/${DIST_DIR}"
 cp -a "${ROOTDIR}/${OUT_DIR}/user_yaml_config.d" "${ROOTDIR}/${DIST_DIR}"
+if file "${ROOTDIR}/${DIST_DIR}/ilogtail" | grep x86-64; then ./scripts/download_ebpflib.sh "${ROOTDIR}/${DIST_DIR}"; fi
 
 # pack dist dir
 cd "${ROOTDIR}"

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -40,8 +40,9 @@ cn_rtt=$(ping -c 3 -W 1 $CN_REGION | grep rtt | awk '{print $4}' | awk -F'/' '{p
 us_rtt=$(ping -c 3 -W 1 $US_REGION | grep rtt | awk '{print $4}' | awk -F'/' '{print $2}' | awk -F '.' '{print $1}') || us_rtt=99999
 REG_REGION=$CN_REGION
 if [[ "$us_rtt" -lt "$cn_rtt" ]]; then
-  REG_REGION=$US_REGION
+    REG_REGION=$US_REGION
 fi
+echo "cn_rtt=$cn_rtt us_rtt=$us_rtt REG_REGION=$REG_REGION"
 
 mkdir -p $GENERATED_HOME
 rm -rf $GEN_DOCKERFILE

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -36,13 +36,13 @@ GEN_DOCKERFILE=$GENERATED_HOME/Dockerfile
 # automatically replace registery address to the fastest mirror
 CN_REGION=sls-opensource-registry.cn-shanghai.cr.aliyuncs.com
 US_REGION=sls-opensource-registry.us-east-1.cr.aliyuncs.com
-cn_rtt=$(ping -c 3 -W 1 $CN_REGION | grep rtt | awk '{print $4}' | awk -F'/' '{print $2}' | awk -F '.' '{print $1}') || cn_rtt=99999
-us_rtt=$(ping -c 3 -W 1 $US_REGION | grep rtt | awk '{print $4}' | awk -F'/' '{print $2}' | awk -F '.' '{print $1}') || us_rtt=99999
+cn_time_connect=$(curl -o /dev/null -s -m 3 -w "%{time_total}" https://$CN_REGION) || cn_time_connect=9999
+us_time_connect=$(curl -o /dev/null -s -m 4 -w "%{time_total}" https://$US_REGION) || us_time_connect=9999
 REG_REGION=$CN_REGION
-if [[ "$us_rtt" -lt "$cn_rtt" ]]; then
+if (( $(echo "$us_time_connect < $cn_time_connect" | bc) )); then
     REG_REGION=$US_REGION
 fi
-echo "cn_rtt=$cn_rtt us_rtt=$us_rtt REG_REGION=$REG_REGION"
+echo "cn_time_connect=$cn_time_connect us_time_connect=$us_time_connect REG_REGION=$REG_REGION"
 
 mkdir -p $GENERATED_HOME
 rm -rf $GEN_DOCKERFILE

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -36,8 +36,8 @@ GEN_DOCKERFILE=$GENERATED_HOME/Dockerfile
 # automatically replace registery address to the fastest mirror
 CN_REGION=sls-opensource-registry.cn-shanghai.cr.aliyuncs.com
 US_REGION=sls-opensource-registry.us-east-1.cr.aliyuncs.com
-cn_rtt=$(ping -c 3 -W 1 $CN_REGION | grep rtt | awk '{print $4}' | awk -F'/' '{print $2}'|awk -F '.' '{print $1}')
-us_rtt=$(ping -c 3 -W 1 $US_REGION | grep rtt | awk '{print $4}' | awk -F'/' '{print $2}'|awk -F '.' '{print $1}')
+cn_rtt=$(ping -c 3 -W 1 $CN_REGION | grep rtt | awk '{print $4}' | awk -F'/' '{print $2}' | awk -F '.' '{print $1}') || cn_rtt=99999
+us_rtt=$(ping -c 3 -W 1 $US_REGION | grep rtt | awk '{print $4}' | awk -F'/' '{print $2}' | awk -F '.' '{print $1}') || us_rtt=99999
 REG_REGION=$CN_REGION
 if [[ "$us_rtt" -lt "$cn_rtt" ]]; then
       REGION=$US_REGION

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -40,7 +40,7 @@ cn_rtt=$(ping -c 3 -W 1 $CN_REGION | grep rtt | awk '{print $4}' | awk -F'/' '{p
 us_rtt=$(ping -c 3 -W 1 $US_REGION | grep rtt | awk '{print $4}' | awk -F'/' '{print $2}' | awk -F '.' '{print $1}') || us_rtt=99999
 REG_REGION=$CN_REGION
 if [[ "$us_rtt" -lt "$cn_rtt" ]]; then
-      REGION=$US_REGION
+  REG_REGION=$US_REGION
 fi
 
 mkdir -p $GENERATED_HOME

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -33,17 +33,27 @@ HOST_OS=`uname -s`
 ROOTDIR=$(cd $(dirname "${BASH_SOURCE[0]}") && cd .. && pwd)
 GEN_DOCKERFILE=$GENERATED_HOME/Dockerfile
 
+# automatically replace registery address to the fastest mirror
+CN_REGION=sls-opensource-registry.cn-shanghai.cr.aliyuncs.com
+US_REGION=sls-opensource-registry.us-east-1.cr.aliyuncs.com
+cn_rtt=$(ping -c 3 -W 1 $CN_REGION | grep rtt | awk '{print $4}' | awk -F'/' '{print $2}'|awk -F '.' '{print $1}')
+us_rtt=$(ping -c 3 -W 1 $US_REGION | grep rtt | awk '{print $4}' | awk -F'/' '{print $2}'|awk -F '.' '{print $1}')
+REG_REGION=$CN_REGION
+if [[ "$us_rtt" -lt "$cn_rtt" ]]; then
+      REGION=$US_REGION
+fi
+
 mkdir -p $GENERATED_HOME
 rm -rf $GEN_DOCKERFILE
 touch $GEN_DOCKERFILE
 
 if [[ $CATEGORY = "goc" || $CATEGORY = "build" ]]; then
-    cat $ROOTDIR/docker/Dockerfile_$CATEGORY|grep -v "#" > $GEN_DOCKERFILE;
+    cat $ROOTDIR/docker/Dockerfile_$CATEGORY | grep -v "^#" | sed "s/$CN_REGION/$REG_REGION/" > $GEN_DOCKERFILE;
 elif [[  $CATEGORY = "development" ]]; then
-    cat $ROOTDIR/docker/Dockerfile_build |grep -v "#" > $GEN_DOCKERFILE;
-    cat $ROOTDIR/docker/Dockerfile_development_part |grep -v "#">> $GEN_DOCKERFILE;
+    cat $ROOTDIR/docker/Dockerfile_build | grep -v "^#" | sed "s/$CN_REGION/$REG_REGION/" > $GEN_DOCKERFILE;
+    cat $ROOTDIR/docker/Dockerfile_development_part |grep -v "^#" | sed "s/$CN_REGION/$REG_REGION/" >> $GEN_DOCKERFILE;
 elif [[  $CATEGORY = "production" ]]; then
-    cat $ROOTDIR/docker/Dockerfile_production |grep -v "#"> $GEN_DOCKERFILE;
+    cat $ROOTDIR/docker/Dockerfile_production |grep -v "^#" | sed "s/$CN_REGION/$REG_REGION/" > $GEN_DOCKERFILE;
 fi
 
 echo "=============DOCKERFILE=================="

--- a/scripts/download_ebpflib.sh
+++ b/scripts/download_ebpflib.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 iLogtail Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ue
+set -o pipefail
+
+DOWNLOAD_DIR=${1:-.}
+
+US_REGION="logtail-release-us-west-1.oss-us-west-1.aliyuncs.com"
+CN_REGION="logtail-release-cn-beijing.oss-cn-beijing.aliyuncs.com"
+cn_time_connect=$(curl -o /dev/null -s -m 3 -w "%{time_total}" https://$CN_REGION) || cn_time_connect=9999
+us_time_connect=$(curl -o /dev/null -s -m 4 -w "%{time_total}" https://$US_REGION) || us_time_connect=9999
+OSS_REGION=$CN_REGION
+if (( $(echo "$us_time_connect < $cn_time_connect" | bc) )); then
+    OSS_REGION=$US_REGION
+fi
+echo "cn_time_connect=$cn_time_connect us_time_connect=$us_time_connect OSS_REGION=$OSS_REGION"
+
+curl -sfL -m 30 https://$OSS_REGION/kubernetes/libebpf.so -o ${DOWNLOAD_DIR}/libebpf.so

--- a/scripts/gen_build_scripts.sh
+++ b/scripts/gen_build_scripts.sh
@@ -61,7 +61,7 @@ EOF
   elif [ $CATEGORY = "core" ]; then
     echo "mkdir -p core/build && cd core/build && cmake -DCMAKE_BUILD_TYPE=Release -DLOGTAIL_VERSION=${VERSION} -DBUILD_LOGTAIL_UT=${BUILD_LOGTAIL_UT} -DENABLE_COMPATIBLE_MODE=${ENABLE_COMPATIBLE_MODE} -DENABLE_STATIC_LINK_CRT=${ENABLE_STATIC_LINK_CRT} .. && make -sj\$nproc" >>  $BUILD_SCRIPT_FILE;
   elif [ $CATEGORY = "all" ]; then
-    echo "mkdir -p core/build && cd core/build && cmake -DCMAKE_BUILD_TYPE=Release -DLOGTAIL_VERSION=${VERSION} -DBUILD_LOGTAIL_UT=${BUILD_LOGTAIL_UT} -DENABLE_COMPATIBLE_MODE=${ENABLE_COMPATIBLE_MODE} -DENABLE_STATIC_LINK_CRT=${ENABLE_STATIC_LINK_CRT} .. && make -sj\$nproc && cd - && ./scripts/plugin_build.sh vendor c-shared ${OUT_DIR}" >> $BUILD_SCRIPT_FILE;
+    echo "mkdir -p core/build && cd core/build && cmake -DCMAKE_BUILD_TYPE=Release -DLOGTAIL_VERSION=${VERSION} -DBUILD_LOGTAIL_UT=${BUILD_LOGTAIL_UT} -DENABLE_COMPATIBLE_MODE=${ENABLE_COMPATIBLE_MODE} -DENABLE_STATIC_LINK_CRT=${ENABLE_STATIC_LINK_CRT} .. && make -sj\$nproc && cd - && ./scripts/upgrade_adapter_lib.sh && ./scripts/plugin_build.sh vendor c-shared ${OUT_DIR}" >> $BUILD_SCRIPT_FILE;
   elif [ $CATEGORY = "e2e" ]; then
     echo "mkdir -p core/build && cd core/build && cmake -DLOGTAIL_VERSION=${VERSION} -DBUILD_LOGTAIL_UT=${BUILD_LOGTAIL_UT} -DENABLE_COMPATIBLE_MODE=${ENABLE_COMPATIBLE_MODE} -DENABLE_STATIC_LINK_CRT=${ENABLE_STATIC_LINK_CRT} .. && make -sj\$nproc && cd - && ./scripts/plugin_gocbuild.sh ${OUT_DIR}" >> $BUILD_SCRIPT_FILE;
   fi


### PR DESCRIPTION
Resolves:
1. some building system requires no root user
2. do not pollute the host's filesystem with root-owned files when dev in container
3. auto choose nearest repository to get build image
4. auto choose nearest oss to get libebpf.so