### PR TITLE
feature: add logical_offset tag to file_log plugin

### DIFF
--- a/core/checkpoint/CheckPointManager.h
+++ b/core/checkpoint/CheckPointManager.h
@@ -38,16 +38,18 @@ public:
     std::string mFileName;
     std::string mRealFileName;
     int64_t mOffset;
+    int64_t mLogicalOffset;
     uint32_t mSignatureSize;
     uint64_t mSignatureHash;
     int32_t mLastUpdateTime;
     DevInode mDevInode;
     int32_t mFileOpenFlag;
     std::string mConfigName;
-
+  
     CheckPoint() {}
 
     CheckPoint(const std::string& filename,
+               int64_t logicalOffset,
                int64_t offset,
                uint32_t signatureSize,
                uint64_t signatureHash,
@@ -58,6 +60,7 @@ public:
         : mFileName(filename),
           mRealFileName(realFileName),
           mOffset(offset),
+          mLogicalOffset(logicalOffset),
           mSignatureSize(signatureSize),
           mSignatureHash(signatureHash),
           mLastUpdateTime(0),

--- a/core/common/Constants.cpp
+++ b/core/common/Constants.cpp
@@ -33,6 +33,7 @@ const std::string LOG_RESERVED_KEY_TRUNCATE_INFO = "__truncate_info__";
 const std::string LOG_RESERVED_KEY_ALIPAY_ZONE = "__alipay_zone__";
 const std::string LOG_RESERVED_KEY_INODE = "__inode__";
 const std::string LOG_RESERVED_KEY_FILE_OFFSET = "__file_offset__";
+const std::string LOG_RESERVED_KEY_LOGICAL_OFFSET = "__logical_offset__";
 
 const char* SLS_EMPTY_STR_FOR_INDEX = "\01";
 

--- a/core/common/Constants.h
+++ b/core/common/Constants.h
@@ -34,6 +34,7 @@ extern const std::string LOG_RESERVED_KEY_TRUNCATE_INFO;
 extern const std::string LOG_RESERVED_KEY_ALIPAY_ZONE;
 extern const std::string LOG_RESERVED_KEY_INODE;
 extern const std::string LOG_RESERVED_KEY_FILE_OFFSET;
+extern const std::string LOG_RESERVED_KEY_LOGICAL_OFFSET;
 
 extern const char* SLS_EMPTY_STR_FOR_INDEX;
 

--- a/core/controller/EventDispatcherBase.cpp
+++ b/core/controller/EventDispatcherBase.cpp
@@ -619,6 +619,7 @@ void EventDispatcherBase::AddExistedCheckPointFileEvents() {
             auto& cpt = cptPair.second;
             auto v1Cpt = std::make_shared<CheckPoint>(cpt.log_path(),
                                                       0,
+                                                      0,
                                                       cpt.sig_size(),
                                                       cpt.sig_hash(),
                                                       DevInode(cpt.dev(), cpt.inode()),

--- a/core/event_handler/EventHandler.cpp
+++ b/core/event_handler/EventHandler.cpp
@@ -385,6 +385,7 @@ LogFileReaderPtr ModifyHandler::CreateLogFileReaderPtr(
         if (readerArray.size() > 0 && !readerPtr->IsFromCheckPoint()) {
             LOG_DEBUG(sLogger, ("file rotate, reset new reader pos", PathJoin(path, name)));
             readerPtr->ResetLastFilePos();
+            readerPtr->ResetLogicalOffset();
         }
     } else {
         backFlag = false;

--- a/core/processor/LogProcess.cpp
+++ b/core/processor/LogProcess.cpp
@@ -316,6 +316,12 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
                         .append(TAG_SEPARATOR)
                         .append(logPath.substr(0, 511));
 
+                    passingTags.append(TAG_DELIMITER)
+                        .append(TAG_PREFIX)
+                        .append(LOG_RESERVED_KEY_LOGICAL_OFFSET)
+                        .append(TAG_SEPARATOR)
+                        .append(std::to_string(logBuffer->logicalOffset));
+
                     std::string userDefinedId = ConfigManager::GetInstance()->GetUserDefinedIdSet();
                     if (!userDefinedId.empty()) {
                         passingTags.append(TAG_DELIMITER)

--- a/core/reader/LogFileReader.h
+++ b/core/reader/LogFileReader.h
@@ -131,7 +131,9 @@ public:
 
     int64_t GetLastFilePos() const { return mLastFilePos; }
 
-    void ResetLastFilePos() { mLastFilePos = 0; }
+    void ResetLastFilePos() { mLastFilePos = 0;}
+
+    void ResetLogicalOffset() { mLogicalOffset = 0;}
 
     bool NeedSkipFirstModify() const { return mSkipFirstModify; }
 
@@ -382,6 +384,8 @@ protected:
 
     int32_t mTzOffsetSecond;
     bool mAdjustApsaraMicroTimezone;
+    // logical read offset, for log backend order feature.
+    int64_t mLogicalOffset = 0;
 
 private:
     // Initialized when the exactly once feature is enabled.
@@ -522,6 +526,8 @@ struct LogBuffer {
     RangeCheckpointPtr exactlyOnceCheckpoint;
     // Current buffer's offset in file, for log position meta feature.
     uint64_t beginOffset;
+    // Current buffer's logical read offset, for log backend order feature.
+    int64_t logicalOffset;
 
     LogBuffer(char* buf,
               int32_t size,

--- a/core/unittest/config/ConfigUpdatorUnittest.cpp
+++ b/core/unittest/config/ConfigUpdatorUnittest.cpp
@@ -573,6 +573,7 @@ void ConfigUpdatorUnittest::TestCheckPointManager() {
                           "tmp" + PS + "apsara.log.2",
                           PS + "apsara" + PS + "tmp" + PS + "log.3",
                           PS + "apsara" + PS + "tmp" + PS + "log.3"};
+    int64_t logicalOffsets[] = {1001, 1002, 1003, 1004};
     int64_t offsets[] = {100, 10000, 200000, 200000};
     uint64_t devs[] = {34, 56, 98, 98};
     uint64_t inodes[] = {100, 2006, 3000008, 3000008};
@@ -630,7 +631,7 @@ void ConfigUpdatorUnittest::TestCheckPointManager() {
     // case 2 : add filecheckpoint
     for (int i = 0; i < 4; ++i) {
         CheckPoint* checkPointPtr = new CheckPoint(
-            filenames[i], offsets[i], sigSizes[i], sigHashs[i], DevInode(devs[i], inodes[i]), configs[i]);
+            filenames[i], logicalOffsets[i], offsets[i], sigSizes[i], sigHashs[i], DevInode(devs[i], inodes[i]), configs[i]);
         checkpointManager->AddCheckPoint(checkPointPtr);
     }
     // timeout checkpoint
@@ -1913,7 +1914,7 @@ void ConfigUpdatorUnittest::TestCheckPointSaveInterval() {
 
     for (int i = 0; i < 3; ++i) {
         CheckPoint* checkPointPtr = new CheckPoint(
-            filenames[i], offsets[i], sigSizes[i], sigHashs[i], DevInode(devs[i], inodes[i]), configs[i]);
+            filenames[i], logicalOffsets[i], offsets[i], sigSizes[i], sigHashs[i], DevInode(devs[i], inodes[i]), configs[i]);
         CheckPointManager::Instance()->AddCheckPoint(checkPointPtr);
     }
 
@@ -2000,7 +2001,7 @@ void ConfigUpdatorUnittest::TestCheckPointUserDefinedFilePath() {
     }
     for (int i = 0; i < 3; ++i) {
         CheckPoint* checkPointPtr = new CheckPoint(
-            filenames[i], offsets[i], sigSizes[i], sigHashs[i], DevInode(devs[i], inodes[i]), configs[i]);
+            filenames[i], logicalOffsets[i], offsets[i], sigSizes[i], sigHashs[i], DevInode(devs[i], inodes[i]), configs[i]);
         CheckPointManager::Instance()->AddCheckPoint(checkPointPtr);
     }
 
@@ -2086,7 +2087,7 @@ void ConfigUpdatorUnittest::TestCheckPointLoadDefaultFile() {
     }
     for (int i = 0; i < 3; ++i) {
         CheckPoint* checkPointPtr = new CheckPoint(
-            filenames[i], offsets[i], sigSizes[i], sigHashs[i], DevInode(devs[i], inodes[i]), configs[i]);
+            filenames[i], logicalOffsets[i], offsets[i], sigSizes[i], sigHashs[i], DevInode(devs[i], inodes[i]), configs[i]);
         CheckPointManager::Instance()->AddCheckPoint(checkPointPtr);
     }
     bfs::remove(STRING_FLAG(check_point_filename));

--- a/plugins/flusher/otlplog/flusher_otlp_log_test.go
+++ b/plugins/flusher/otlplog/flusher_otlp_log_test.go
@@ -34,7 +34,7 @@ func (t *TestOtlpLogService) Export(ctx context.Context, request *otlpv1.ExportL
 
 func Test_Flusher_Init(t *testing.T) {
 	convey.Convey("When init grpc service", t, func() {
-		_, server := newTestGrpcService(t, ":8080", time.Nanosecond)
+		_, server := newTestGrpcService(t, ":18176", time.Nanosecond)
 		defer func() {
 			server.Stop()
 		}()
@@ -50,14 +50,14 @@ func Test_Flusher_Init(t *testing.T) {
 
 func Test_Flusher_Flush(t *testing.T) {
 	convey.Convey("When init grpc service", t, func() {
-		service, server := newTestGrpcService(t, ":8176", time.Nanosecond*0)
+		service, server := newTestGrpcService(t, ":18176", time.Nanosecond*0)
 		defer func() {
 			server.Stop()
 		}()
 		logCtx := mock.NewEmptyContext("p", "l", "c")
 
 		convey.Convey("When FlusherOTLPLog init", func() {
-			f := &FlusherOTLPLog{Version: v1, GrpcConfig: &helper.GrpcClientConfig{Endpoint: ":8176", WaitForReady: true}}
+			f := &FlusherOTLPLog{Version: v1, GrpcConfig: &helper.GrpcClientConfig{Endpoint: ":18176", WaitForReady: true}}
 			err := f.Init(logCtx)
 			convey.So(err, convey.ShouldBeNil)
 


### PR DESCRIPTION
在读取日志文件时，添加`logical_offset`字段
输出的日志内容如下
```
2022-10-17 11:08:58 {"__tag__:__path__":"/opt/nginx/log/access.log","__tag__:__logical_offset__":"41","content":"10.255.3.37 - - [17/Oct/2022:03:08:57 +0000] GET / HTTP/1.1","__time__":"1665976137"}
```
支持记录字段值到checkpointv1中, checkpoint 保持向前兼容，新的checkpoint内容：
```
		{
			"config_name" : "config#/data00/ilogtail/ilogtail/./user_yaml_config.d/nginx.yaml",
                         ....
			"inode" : 29097995,
			"logical_offset" : 36,
			"offset" : "143383",
			"real_file_name" : "/data00/nginx/log/access.log",
                        ....
		}
```