### PR TITLE
fix: fix metric name field name split error when contains ":"

### DIFF
--- a/helper/decoder/influxdb/decoder.go
+++ b/helper/decoder/influxdb/decoder.go
@@ -33,6 +33,7 @@ const (
 	timeNanoKey   = "__time_nano__"
 	valueKey      = "__value__"
 	typeKey       = "__type__"
+	fieldNameKey  = "__field__"
 )
 
 const (
@@ -78,7 +79,7 @@ func (d *Decoder) parsePointsToLogs(points []models.Point, req *http.Request) []
 		contentLen++
 	}
 	if d.FieldsExtend {
-		contentLen++
+		contentLen += 2
 	}
 
 	logs := make([]*protocol.Log, 0, len(points))
@@ -156,6 +157,9 @@ func (d *Decoder) parsePointsToLogs(points []models.Point, req *http.Request) []
 				contents = append(contents, &protocol.Log_Content{
 					Key:   typeKey,
 					Value: valueType,
+				}, &protocol.Log_Content{
+					Key:   fieldNameKey,
+					Value: field,
 				})
 			}
 			if d.FieldsExtend && len(db) > 0 {

--- a/helper/decoder/influxdb/decoder_test.go
+++ b/helper/decoder/influxdb/decoder_test.go
@@ -85,6 +85,7 @@ func TestFieldsExtend(t *testing.T) {
 						{Key: "__labels__", Value: "host#$#server01|region#$#uswest"},
 						{Key: "__time_nano__", Value: "1434055562000000000"},
 						{Key: "__type__", Value: "float"},
+						{Key: "__field__", Value: "value"},
 					},
 				},
 				{
@@ -94,6 +95,7 @@ func TestFieldsExtend(t *testing.T) {
 						{Key: "__labels__", Value: "host.dd#$#server02|region#$#uswest"},
 						{Key: "__time_nano__", Value: "1434055562000010000"},
 						{Key: "__type__", Value: "float"},
+						{Key: "__field__", Value: "value"},
 					},
 				},
 			},

--- a/pkg/protocol/converter/converter_metric_test.go
+++ b/pkg/protocol/converter/converter_metric_test.go
@@ -99,6 +99,14 @@ func Test_metricReader_readNames(t *testing.T) {
 			reader: &metricReader{
 				name: "aa:bb",
 			},
+			wantMetricName: "aa:bb",
+			wantFieldName:  "value",
+		},
+		{
+			reader: &metricReader{
+				name:      "aa:bb",
+				fieldName: "bb",
+			},
 			wantMetricName: "aa",
 			wantFieldName:  "bb",
 		},
@@ -107,6 +115,14 @@ func Test_metricReader_readNames(t *testing.T) {
 				name: ":",
 			},
 			wantMetricName: ":",
+			wantFieldName:  "value",
+		},
+		{
+			reader: &metricReader{
+				name:      "aa:value",
+				fieldName: "value",
+			},
+			wantMetricName: "aa:value",
 			wantFieldName:  "value",
 		},
 	}


### PR DESCRIPTION
问题：
对于 influxdb 协议，当metric name本身就包含“:”时，如 metric name: a:b，field name: value，经过input后，会变为 __name__: a:b
在后续的flusher环节，当前的处理环节，会错误的识别为 metric name: a，field name: b

解决：
input_httpserver中，对于influxdb，添加一个__filed__字段，来记录真实的field，这样后续在还原的时候，便有了可靠的依据
__field__字段是否添加，也通过现有的FieldsExtend来控制