### PR TITLE
Fix user privilege problem in Developping-docker-env 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,6 +9,7 @@ RUN source /tmp/.env && rm /tmp/.env; \
     if getent passwd $USERNAME; then userdel -f $USERNAME; fi; \
     if [ $HOST_OS = "Linux" ]; then \
     if getent group $GROUPNAME; then groupdel $GROUPNAME; fi; \
+    if getent group $GROUP_GID; then TMP_NAME=$(getent group $GROUP_GID | cut -d: -f1); groupdel $TMP_NAME; fi; \
     groupadd --gid $GROUP_GID $GROUPNAME; \
     fi; \
     useradd --uid $USER_UID --gid $GROUP_GID -m $USERNAME; \


### PR DESCRIPTION
When groups with the same group_name or group_id exist in the docker environment, it causes the user added in a wrong group and  fail to get write permission of `/opt` directory.