### PR TITLE
feat: check docker version to determine whether using docker buildkit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,6 @@ clean:
 	rm -rf plugins/all/all_windows.go
 	rm -rf plugins/all/all_linux.go
 	go mod tidy -modfile $(GO_MOD_FILE) || true
-	echo $(DOCKER_BUILD_USE_BUILDKIT)
 
 .PHONY: license
 license:  clean tools import_plugins

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,14 @@ else
 endif
 
 ifndef DOCKER_BUILD_USE_BUILDKIT
-	ifdef SSH_AUTH_SOCK
-		DOCKER_BUILD_USE_BUILDKIT = true
-	else
+	docker_version := $(shell docker version --format '{{.Server.Version}}')
+	least_version := "19.03"
+
+	# docker BuildKit supported start from 19.03
+	ifeq ($(shell printf "$(least_version)\n$(docker_version)" | sort -V | tail -n 1),$(least_version))
 		DOCKER_BUILD_USE_BUILDKIT = false
+	else
+		DOCKER_BUILD_USE_BUILDKIT = true
 	endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -39,14 +39,18 @@ else
 endif
 
 ifndef DOCKER_BUILD_USE_BUILDKIT
-	docker_version := $(shell docker version --format '{{.Server.Version}}')
-	least_version := "19.03"
+	DOCKER_BUILD_USE_BUILDKIT = true
 
 	# docker BuildKit supported start from 19.03
+	docker_version := $(shell docker version --format '{{.Server.Version}}')
+	least_version := "19.03"
 	ifeq ($(shell printf "$(least_version)\n$(docker_version)" | sort -V | tail -n 1),$(least_version))
 		DOCKER_BUILD_USE_BUILDKIT = false
-	else
-		DOCKER_BUILD_USE_BUILDKIT = true
+	endif
+
+	# check if SSH_AUTH_SOCK env set which means ssh-agent running
+	ifndef SSH_AUTH_SOCK
+		DOCKER_BUILD_USE_BUILDKIT = false
 	endif
 endif
 
@@ -92,6 +96,7 @@ clean:
 	rm -rf plugins/all/all_windows.go
 	rm -rf plugins/all/all_linux.go
 	go mod tidy -modfile $(GO_MOD_FILE) || true
+	echo $(DOCKER_BUILD_USE_BUILDKIT)
 
 .PHONY: license
 license:  clean tools import_plugins

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -27,6 +27,18 @@ function arch() {
   fi
 }
 
+function check_docker_version {
+    docker_version=$(docker version --format '{{.Server.Version}}' | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
+    least_version="19.03"
+
+    # docker BuildKit supported start from 19.03
+    if [[ $(printf "%s\n%s" "$least_version" "$docker_version" | sort -V | tail -n 1) == "$least_version" ]]; then
+        echo "false"
+    else
+        echo "true"
+    fi
+}
+
 # Currently, there are 4 supported docker categories, which are goc, build, development and production.
 #
 # goc: build goc server with Dockerfile_doc
@@ -40,7 +52,7 @@ GENERATED_HOME=$2
 VERSION=${3:-1.4.0}
 REPOSITORY=${4:-aliyun/ilogtail}
 PUSH=${5:-false}
-USE_DOCKER_BUILDKIT=${6:-${DOCKER_BUILD_USE_BUILDKIT:-$(if [[ -n "${SSH_AUTH_SOCK}" ]];then echo "true";else echo "false";fi)}}
+USE_DOCKER_BUILDKIT=${6:-${DOCKER_BUILD_USE_BUILDKIT:-$(check_docker_version)}}
 
 HOST_OS=`uname -s`
 ROOTDIR=$(cd $(dirname "${BASH_SOURCE[0]}") && cd .. && pwd)

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -90,15 +90,16 @@ else
   REMOVE_SSH_MOUNT='sed s/--mount=type=ssh//'
 fi
 
+echo "# syntax=docker/dockerfile:1.5" > $GEN_DOCKERFILE;
 if [[ $CATEGORY = "goc" || $CATEGORY = "build" ]]; then
-    cat $ROOTDIR/docker/Dockerfile_$CATEGORY | grep -v "^#" | sed "s/$CN_REGION/$REG_REGION/" | $REMOVE_SSH_MOUNT > $GEN_DOCKERFILE;
+    cat $ROOTDIR/docker/Dockerfile_$CATEGORY | grep -v "^#" | sed "s/$CN_REGION/$REG_REGION/" | $REMOVE_SSH_MOUNT >> $GEN_DOCKERFILE;
 elif [[ $CATEGORY = "development" ]]; then
-    cat $ROOTDIR/docker/Dockerfile_build | grep -v "^#" | sed "s/$CN_REGION/$REG_REGION/" | $REMOVE_SSH_MOUNT > $GEN_DOCKERFILE;
+    cat $ROOTDIR/docker/Dockerfile_build | grep -v "^#" | sed "s/$CN_REGION/$REG_REGION/" | $REMOVE_SSH_MOUNT >> $GEN_DOCKERFILE;
     cat $ROOTDIR/docker/Dockerfile_development_part |grep -v "^#" | sed "s/$CN_REGION/$REG_REGION/" >> $GEN_DOCKERFILE;
 elif [[ $CATEGORY = "production" ]]; then
-    cat $ROOTDIR/docker/Dockerfile_production | grep -v "^#" | sed 's/ --platform=$TARGETPLATFORM//' > $GEN_DOCKERFILE;
+    cat $ROOTDIR/docker/Dockerfile_production | grep -v "^#" | sed 's/ --platform=$TARGETPLATFORM//' >> $GEN_DOCKERFILE;
 elif [[ $CATEGORY = "multi-arch-production" ]]; then
-    cat $ROOTDIR/docker/Dockerfile_production | grep -v "^#" > $GEN_DOCKERFILE;
+    cat $ROOTDIR/docker/Dockerfile_production | grep -v "^#" >> $GEN_DOCKERFILE;
 fi
 
 echo "=============DOCKERFILE=================="


### PR DESCRIPTION
1. enable docker buildkit only if both docker_version >= 19.03 && SSH_AUTH_SOCK env set
2. fix bug that fail to run docker_build.sh directly if SSH_AUTH_SOCK not set

reference: https://pythonspeed.com/articles/docker-buildkit/