### PR TITLE
fix: processor_gotime empty time zone

### DIFF
--- a/docs/cn/data-pipeline/processor/processor-gotime.md
+++ b/docs/cn/data-pipeline/processor/processor-gotime.md
@@ -1,0 +1,58 @@
+# Gotime
+
+## 版本
+
+[Stable](../stability-level.md)
+
+## 配置参数
+
+| 参数 | 类型 | 是否必选 | 说明 |
+| - | - | - | - |
+| SourceKey | String | 是 | 原始字段名。 |
+| SourceFormat | String | 是 | 原始时间的格式。 |
+| SourceLocation | Int | 是 | 原始时间的时区。参数值为空时，表示iLogtail所在主机或容器的时区。 |
+| DestKey | String | 是 | 解析后的目标字段。 |
+| DestFormat | String | 是 | 解析后的时间格式。 |
+| DestLocation | Int | 否 | 解析后的时区。参数值为空时，表示本机时区。 |
+| SetTime | Boolean | 否 | 是否将解析后的时间设置为日志时间。true（默认值）：是。false：否。 |
+| KeepSource | Boolean | 否 | 被解析后的日志中是否保留原始字段。true（默认值）：保留。false：不保留。 |
+| NoKeyError | Boolean | 否 | 原始日志中无您所指定的原始字段时，系统是否报错。true（默认值）：报错。false：不报错。 |
+| AlarmIfFail | Boolean | 否 | 提取日志时间失败，系统是否报错。true（默认值）：报错。false：不报错。 |
+
+## 样例
+
+采集当前路径下的`simple.log`文件，根据指定的配置选项提取日志信息。
+
+```yaml
+enable: true
+inputs:
+  - Type: file_log
+    LogPath: .
+    FilePattern: simple.log
+processors:
+  - Type: processor_gotime
+    SourceKey: "content"
+    SourceFormat: "2006-01-02 15:04:05"
+    SourceLocation: 8
+    DestKey: "d_key"
+    DestFormat: "2006/01/02 15:04:05"
+    DestLocation: 9
+flushers:
+  - Type: flusher_stdout
+    OnlyStdout: true
+```
+
+* 输入
+
+```bash
+echo "2006-01-02 15:04:05" >> simple.log
+```
+
+* 输出
+
+```json
+{
+    "content":"2006-01-02 15:04:05",
+    "d_key":"2006/01/02 16:04:05"
+}
+```

--- a/docs/en/plugins/processor/processor_gotime.md
+++ b/docs/en/plugins/processor/processor_gotime.md
@@ -1,16 +1,58 @@
 # processor_gotime
+
 ## Description
+
 the time format processor to parse time field with golang format pattern. More details please see [here](https://golang.org/pkg/time/#Time.Format)
+
 ## Config
-|  field   |   type   |   description   | default value   |
-| ---- | ---- | ---- | ---- |
-|SourceKey|string|the source key prepared to be formatted|""|
-|SourceFormat|string|the source key formatted pattern, more details please see [here](https://golang.org/pkg/time/#Time.Format). Furthermore，there are 3 fixed pattern supported to parse timestamp, which are 'seconds','milliseconds' and 'microseconds'.|""|
-|SourceLocation|int|the source key time zone, such beijing timezone is 8. And the parameter would be ignored when 'SourceFormat' configured with timestamp format pattern.|0|
-|DestKey|string|the generated key name.|""|
-|DestFormat|string|the generated key formatted pattern, more details please see [here](https://golang.org/pkg/time/#Time.Format).|""|
-|DestLocation|int|the generated key time zone, such beijing timezone is 8.|0|
-|SetTime|bool|Whether to config the unix time of the source key to the log time. |true|
-|KeepSource|bool|Whether to keep the source key in the log content after the processing.|true|
-|NoKeyError|bool|Whether to alarm when not found the source key to parse and format.|true|
-|AlarmIfFail|bool|Whether to alarm when the source key is failed to parse.|true|
+
+| Parameter | Type | Required | Description |
+| - | - | - | - |
+| SourceKey | String | Yes | The name of the original field. |
+| SourceFormat | String | Yes | The format of the original time. |
+| SourceLocation | Int | Yes | The time zone of the original time. If the parameter value is empty, it indicates the time zone of the host or container where iLogtail is located. |
+| DestKey | String | Yes | The name of the target field after parsing. |
+| DestFormat | String | Yes | The format of the parsed time. |
+| DestLocation | Int | No | The time zone of the parsed time. If the parameter value is empty, it indicates the local time zone. |
+| SetTime | Boolean | No | Whether to set the parsed time as the log time. true (default): yes. false: no. |
+| KeepSource | Boolean | No | Whether to keep the original field in the parsed log. true (default): keep. false: not keep. |
+| NoKeyError | Boolean | No | Whether to report an error if the specified original field is missing in the original log. true (default): report an error. false: not report an error. |
+| AlarmIfFail | Boolean | No | Whether to report an error if parsing the log time fails. true (default): report an error. false: not report an error. |
+
+## Example
+
+Collect the log information from the `simple.log` file in the current path according to the specified configuration options.
+
+```yaml
+enable: true
+inputs:
+  - Type: file_log
+    LogPath: .
+    FilePattern: simple.log
+processors:
+  - Type: processor_gotime
+    SourceKey: "content"
+    SourceFormat: "2006-01-02 15:04:05"
+    SourceLocation: 8
+    DestKey: "d_key"
+    DestFormat: "2006/01/02 15:04:05"
+    DestLocation: 9
+flushers:
+  - Type: flusher_stdout
+    OnlyStdout: true
+```
+
+* Input
+
+```bash
+echo "2006-01-02 15:04:05" >> simple.log
+```
+
+* Output
+
+```json
+{
+    "content":"2006-01-02 15:04:05",
+    "d_key":"2006/01/02 16:04:05"
+}
+```

--- a/plugins/processor/gotime/processor_gotime.go
+++ b/plugins/processor/gotime/processor_gotime.go
@@ -49,7 +49,10 @@ type ProcessorGotime struct {
 	timestampParseFunc func(timestamp int64) time.Time
 }
 
-const pluginName = "processor_gotime"
+const (
+	pluginName      = "processor_gotime"
+	machineTimeZone = -100
+)
 
 // Init called for init some system resources, like socket, mutex...
 func (p *ProcessorGotime) Init(context pipeline.Context) error {
@@ -66,11 +69,11 @@ func (p *ProcessorGotime) Init(context pipeline.Context) error {
 		return fmt.Errorf("must specify DestFormat for plugin %v", pluginName)
 	}
 	p.sourceLocation = time.Local
-	if p.SourceLocation != 0 {
+	if p.SourceLocation != machineTimeZone {
 		p.sourceLocation = time.FixedZone("SpecifiedTimezone", p.SourceLocation*60*60)
 	}
 	p.destLocation = time.Local
-	if p.DestLocation != 0 {
+	if p.DestLocation != machineTimeZone {
 		p.destLocation = time.FixedZone("SpecifiedTimezone", p.DestLocation*60*60)
 	}
 
@@ -157,10 +160,10 @@ func init() {
 		return &ProcessorGotime{
 			SourceKey:      "",
 			SourceFormat:   "",
-			SourceLocation: 0,
+			SourceLocation: machineTimeZone,
 			DestKey:        "",
 			DestFormat:     "",
-			DestLocation:   0,
+			DestLocation:   machineTimeZone,
 			SetTime:        true,
 			KeepSource:     true,
 			NoKeyError:     true,


### PR DESCRIPTION
Fix: https://github.com/alibaba/ilogtail/issues/829

## 改动
1. 将 `SourceLocation` 和 `DestLocation` 默认值更改为-100，表示未进行配置。
2. 补充单元测试样例：sourceLocation 为空
3. 根据[专业版文档](https://help.aliyun.com/document_detail/196161.html)编写中文文档，并翻译更新英文文档