### PR TITLE
fix memory access error in evenv_handler

### DIFF
--- a/core/event_handler/EventHandler.cpp
+++ b/core/event_handler/EventHandler.cpp
@@ -860,11 +860,11 @@ void ModifyHandler::HandleTimeOut() {
         LogFileReaderPtrArray& readerArray = readerIter->second;
         // donot check file delete flag or close ptr when array size > 1
         if (readerArray.size() > 1) {
-            ++readerIter;
-            actioned = true;
             LOG_DEBUG(sLogger,
                       ("HandleTimeOut filename", readerIter->first)("dir", readerArray[0]->GetLogPath().c_str())(
                           "action", "continue")("reason", "reader array size > 1"));
+            ++readerIter;
+            actioned = true;
             continue;
         }
 


### PR DESCRIPTION
迭代器在 `++readerIter;` 继续使用，会造成内存访问错误。示例：
```
#include <iostream>
#include <vector>

int main() {
    std::vector<int> myVector {1, 2, 3, 4, 5};

    // 使用迭代器遍历 vector
    for (auto it = myVector.begin(); it != myVector.end(); ) {
            ++it;
        std::cout << *it << " ";
    }

    return 0;
}
```
实测：

![图片](https://github.com/alibaba/ilogtail/assets/7546325/10555a11-6d49-4d13-9cd5-c787d6c278b9)
