### PR TITLE
fix static container

### DIFF
--- a/pkg/helper/docker_center.go
+++ b/pkg/helper/docker_center.go
@@ -1052,6 +1052,9 @@ func (dc *DockerCenter) fetchOne(containerID string, tryFindSandbox bool) error 
 	if containerDetail.State.Status == ContainerStatusRunning && !ContainerProcessAlive(containerDetail.State.Pid) {
 		containerDetail.State.Status = ContainerStatusExited
 	}
+	// docker 场景下
+	// tryFindSandbox如果是false, 那么fetchOne的地方应该会调用两次，一次是sandbox的id，一次是业务容器的id
+	// tryFindSandbox如果是true, 调用的地方只会有一个业务容器的id，然后依赖fetchOne内部把sandbox信息补全
 	dc.updateContainer(containerID, dc.CreateInfoDetail(containerDetail, envConfigPrefix, false))
 	logger.Debug(context.Background(), "update container", containerID, "detail", containerDetail)
 	if tryFindSandbox && containerDetail.Config != nil {

--- a/pkg/helper/docker_center.go
+++ b/pkg/helper/docker_center.go
@@ -995,11 +995,9 @@ func (dc *DockerCenter) updateContainer(id string, container *DockerInfoDetail) 
 	dc.lock.Lock()
 	defer dc.lock.Unlock()
 	if container.K8SInfo != nil {
-		if _, ok := dc.containerMap[id]; !ok {
-			for _, oldContainer := range dc.containerMap {
-				if oldContainer.K8SInfo != nil && oldContainer.K8SInfo.IsSamePod(container.K8SInfo) {
-					oldContainer.K8SInfo.Merge(container.K8SInfo)
-				}
+		for _, oldContainer := range dc.containerMap {
+			if oldContainer.K8SInfo != nil && oldContainer.K8SInfo.IsSamePod(container.K8SInfo) {
+				oldContainer.K8SInfo.Merge(container.K8SInfo)
 			}
 		}
 	}

--- a/pkg/helper/docker_center.go
+++ b/pkg/helper/docker_center.go
@@ -669,6 +669,7 @@ func (dc *DockerCenter) readStaticConfig(forceFlush bool) {
 		forceFlush = true
 	}
 
+	// 静态文件读取容器信息的时候，只能全量读取，因此使用updateContainers全量更新
 	if forceFlush || changed {
 		containerMap := make(map[string]*DockerInfoDetail)
 		for _, info := range containerInfo {

--- a/pkg/helper/docker_center_file_discover_test.go
+++ b/pkg/helper/docker_center_file_discover_test.go
@@ -118,6 +118,583 @@ var staticDockerConfig2 = `[
 ]
 `
 
+var staticECIConfig = `[
+	{
+			"ID": "111",
+			"Name": "container1",
+			"Image": "image1",
+			"LogPath": "/var/log/pods/prod_podTest_podUidTest/container1/0.log",
+			"Labels": {
+					"io.kubernetes.container.name": "container1",
+					"io.kubernetes.pod.name": "podTest",
+					"io.kubernetes.pod.namespace": "prod",
+					"io.kubernetes.pod.uid": "podUidTest"
+			},
+			"LogType": "json-file",
+			"Env": {
+					"KUBERNETES_PORT": "tcp://192.168.0.1:443",
+					"KUBERNETES_PORT_443_TCP": "tcp://192.168.0.1:443",
+					"KUBERNETES_PORT_443_TCP_ADDR": "192.168.0.1",
+					"KUBERNETES_PORT_443_TCP_PORT": "443",
+					"KUBERNETES_PORT_443_TCP_PROTO": "tcp",
+					"KUBERNETES_SERVICE_HOST": "10.244.197.20",
+					"KUBERNETES_SERVICE_PORT": "6443",
+					"KUBERNETES_SERVICE_PORT_HTTPS": "443"
+			},
+			"Mounts": [
+				{
+					"Source": "/home/admin/logs",
+					"Destination" : "/home/admin/logs",
+					"Driver" : "host"
+				},
+				{
+					"Source": "/var/lib/docker",
+					"Destination" : "/docker",
+					"Driver" : "host"
+				}
+			],
+			"UpperDir": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/111/rootfs",
+			"Created": "2023-06-01T10:09:32.336427588+08:00",
+			"State": {
+					"Pid": 1001,
+					"Status": "running"
+			}
+	},
+	{
+			"ID": "222",
+			"Name": "container2",
+			"Image": "image2",
+			"LogPath": "/var/log/pods/prod_podTest_podUidTest/container2/0.log",
+			"Labels": {
+					"io.kubernetes.container.name": "container2",
+					"io.kubernetes.pod.name": "podTest",
+					"io.kubernetes.pod.namespace": "prod",
+					"io.kubernetes.pod.uid": "podUidTest"
+			},
+			"LogType": "json-file",
+			"Env": {
+					"KUBERNETES_PORT": "tcp://192.168.0.1:443",
+					"KUBERNETES_PORT_443_TCP": "tcp://192.168.0.1:443",
+					"KUBERNETES_PORT_443_TCP_ADDR": "192.168.0.1",
+					"KUBERNETES_PORT_443_TCP_PORT": "443",
+					"KUBERNETES_PORT_443_TCP_PROTO": "tcp",
+					"KUBERNETES_SERVICE_HOST": "10.244.197.20",
+					"KUBERNETES_SERVICE_PORT": "6443",
+					"KUBERNETES_SERVICE_PORT_HTTPS": "443"
+			},
+			"Mounts": [
+				{
+					"Source": "/home/admin/logs",
+					"Destination" : "/home/admin/logs",
+					"Driver" : "host"
+				},
+				{
+					"Source": "/var/lib/docker",
+					"Destination" : "/docker",
+					"Driver" : "host"
+				}
+			],
+			"UpperDir": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/222/rootfs",
+			"Created": "2023-06-01T10:09:33.221371944+08:00",
+			"State": {
+					"Pid": 1102,
+					"Status": "running"
+			}
+	},
+	{
+			"ID": "333",
+			"Name": "container3",
+			"Image": "image3",
+			"LogPath": "/var/log/pods/prod_podTest_podUidTest/container3/0.log",
+			"Labels": {
+					"io.kubernetes.container.name": "container3",
+					"io.kubernetes.pod.name": "podTest",
+					"io.kubernetes.pod.namespace": "prod",
+					"io.kubernetes.pod.uid": "podUidTest"
+			},
+			"LogType": "json-file",
+			"Env": {
+					"KUBERNETES_PORT": "tcp://192.168.0.1:443",
+					"KUBERNETES_PORT_443_TCP": "tcp://192.168.0.1:443",
+					"KUBERNETES_PORT_443_TCP_ADDR": "192.168.0.1",
+					"KUBERNETES_PORT_443_TCP_PORT": "443",
+					"KUBERNETES_PORT_443_TCP_PROTO": "tcp",
+					"KUBERNETES_SERVICE_HOST": "10.244.197.20",
+					"KUBERNETES_SERVICE_PORT": "6443",
+					"KUBERNETES_SERVICE_PORT_HTTPS": "443",
+					"POD_NAME": "",
+					"POD_NAMESPACE": "",
+					"aliyun_log_crd_user_defined_id": "k8s-group-xxx"
+			},
+			"Mounts": [
+				{
+					"Source": "/home/admin/logs",
+					"Destination" : "/home/admin/logs",
+					"Driver" : "host"
+				},
+				{
+					"Source": "/var/lib/docker",
+					"Destination" : "/docker",
+					"Driver" : "host"
+				}
+			],
+			"UpperDir": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/333/rootfs",
+			"Created": "2023-06-01T10:09:34.22551185+08:00",
+			"State": {
+					"Pid": 1181,
+					"Status": "running"
+			}
+	},
+	{
+			"ID": "444",
+			"Name": "container4",
+			"Image": "image4",
+			"LogPath": "/var/log/pods/prod_podTest_podUidTest/container4/0.log",
+			"Labels": {
+					"io.kubernetes.container.name": "container4",
+					"io.kubernetes.pod.name": "podTest",
+					"io.kubernetes.pod.namespace": "prod",
+					"io.kubernetes.pod.uid": "podUidTest"
+			},
+			"LogType": "json-file",
+			"Env": {
+					"POD_NAME": "",
+					"POD_NAMESPACE": ""
+			},
+			"Mounts": [
+				{
+					"Source": "/home/admin/logs",
+					"Destination" : "/home/admin/logs",
+					"Driver" : "host"
+				},
+				{
+					"Source": "/var/lib/docker",
+					"Destination" : "/docker",
+					"Driver" : "host"
+				}
+			],
+			"UpperDir": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/444/rootfs",
+			"Created": "2023-06-01T10:10:08.442675217+08:00",
+			"State": {
+					"Pid": 1965,
+					"Status": "running"
+			}
+	},
+	{
+			"ID": "555",
+			"Name": "container5",
+			"Image": "image5",
+			"LogPath": "/var/log/pods/prod_podTest_podUidTest/container5/0.log",
+			"Labels": {
+					"io.kubernetes.container.name": "container5",
+					"io.kubernetes.pod.name": "podTest",
+					"io.kubernetes.pod.namespace": "prod",
+					"io.kubernetes.pod.uid": "podUidTest"
+			},
+			"LogType": "json-file",
+			"Env": {
+					"POD_NAME": "",
+					"POD_NAMESPACE": ""
+			},
+			"Mounts": [
+				{
+					"Source": "/home/admin/logs",
+					"Destination" : "/home/admin/logs",
+					"Driver" : "host"
+				},
+				{
+					"Source": "/var/lib/docker",
+					"Destination" : "/docker",
+					"Driver" : "host"
+				}
+			],
+			"UpperDir": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/555/rootfs",
+			"Created": "2023-06-01T10:10:08.77858586+08:00",
+			"State": {
+					"Pid": 2007,
+					"Status": "running"
+			}
+	},
+	{
+			"ID": "podUidTest",
+			"Name": "POD",
+			"Image": "pause:latest",
+			"LogPath": "/var/log/pods/prod_podTest_podUidTest",
+			"Labels": {
+					"app": "appTest",
+					"attribute": "attTest",
+					"deployment": "deploymentTest",
+					"environment": "prod",
+					"io.kubernetes.pod.name": "podTest",
+					"io.kubernetes.pod.namespace": "prod",
+					"io.kubernetes.pod.uid": "podUidTest",
+					"log": "logTest",
+					"pod-template-hash": "xxx"
+			},
+			"LogType": "json-file",
+			"UpperDir": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/null/rootfs",
+			"Created": "0001-01-01T00:00:00Z",
+			"State": {
+					"Pid": 0,
+					"Status": ""
+			}
+	},
+	{
+			"ID": "666",
+			"Name": "container7",
+			"Image": "acr.baijia.com/uqun/container7:2022102001",
+			"LogPath": "/var/log/pods/prod_podTest_podUidTest/container7/0.log",
+			"Labels": {
+					"io.kubernetes.container.name": "container7",
+					"io.kubernetes.pod.name": "podTest",
+					"io.kubernetes.pod.namespace": "prod",
+					"io.kubernetes.pod.uid": "podUidTest"
+			},
+			"LogType": "json-file",
+			"Env": {
+				"POD_NAME": "",
+				"POD_NAMESPACE": ""
+			},
+			"Mounts": [
+				{
+					"Source": "/home/admin/logs",
+					"Destination" : "/home/admin/logs",
+					"Driver" : "host"
+				},
+				{
+					"Source": "/var/lib/docker",
+					"Destination" : "/docker",
+					"Driver" : "host"
+				}
+			],
+			"UpperDir": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/666/rootfs",
+			"Created": "2023-06-01T10:09:29.382815361+08:00",
+			"State": {
+					"Pid": 694,
+					"Status": "running"
+			}
+	},
+	{
+			"ID": "777",
+			"Name": "container8",
+			"Image": "acr.baijia.com/uqun/container8:1.7.0",
+			"LogPath": "/var/log/pods/prod_podTest_podUidTest/container8/0.log",
+			"Labels": {
+					"io.kubernetes.container.name": "container8",
+					"io.kubernetes.pod.name": "podTest",
+					"io.kubernetes.pod.namespace": "prod",
+					"io.kubernetes.pod.uid": "podUidTest"
+			},
+			"LogType": "json-file",
+			"Env": {
+				"POD_NAME": "",
+				"POD_NAMESPACE": ""
+			},
+			"Mounts": [
+					{
+							"Source": "/var/lib/kubelet/pods/podUidTest/volumes/kubernetes.io~empty-dir/container8-volume",
+							"Destination": "/ArmsAgent",
+							"Driver": ""
+					}
+			],
+			"UpperDir": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e916e0ba011ab5bf825ba24ffba7e3e5dedd2073e29222dd6238eb874cc27ddd/rootfs",
+			"Created": "2023-06-01T10:09:30.213522454+08:00",
+			"State": {
+					"Pid": 872,
+					"Status": "running"
+			}
+	}
+]`
+
+var staticECIConfig2 = `[
+	{
+			"ID": "111",
+			"Name": "container1",
+			"Image": "image1",
+			"LogPath": "/var/log/pods/prod_podTest_podUidTest/container1/0.log",
+			"Labels": {
+					"io.kubernetes.container.name": "container1",
+					"io.kubernetes.pod.name": "podTest",
+					"io.kubernetes.pod.namespace": "prod",
+					"io.kubernetes.pod.uid": "podUidTest"
+			},
+			"LogType": "json-file",
+			"Env": {
+					"KUBERNETES_PORT": "tcp://192.168.0.1:443",
+					"KUBERNETES_PORT_443_TCP": "tcp://192.168.0.1:443",
+					"KUBERNETES_PORT_443_TCP_ADDR": "192.168.0.1",
+					"KUBERNETES_PORT_443_TCP_PORT": "443",
+					"KUBERNETES_PORT_443_TCP_PROTO": "tcp",
+					"KUBERNETES_SERVICE_HOST": "10.244.197.20",
+					"KUBERNETES_SERVICE_PORT": "6443",
+					"KUBERNETES_SERVICE_PORT_HTTPS": "443"
+			},
+			"Mounts": [
+				{
+					"Source": "/home/admin/logs",
+					"Destination" : "/home/admin/logs",
+					"Driver" : "host"
+				},
+				{
+					"Source": "/var/lib/docker",
+					"Destination" : "/docker",
+					"Driver" : "host"
+				}
+			],
+			"UpperDir": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/111/rootfs",
+			"Created": "2023-06-01T10:09:32.336427588+08:00",
+			"State": {
+					"Pid": 1001,
+					"Status": "running"
+			}
+	},
+	{
+			"ID": "222",
+			"Name": "container2",
+			"Image": "image2",
+			"LogPath": "/var/log/pods/prod_podTest_podUidTest/container2/0.log",
+			"Labels": {
+					"io.kubernetes.container.name": "container2",
+					"io.kubernetes.pod.name": "podTest",
+					"io.kubernetes.pod.namespace": "prod",
+					"io.kubernetes.pod.uid": "podUidTest"
+			},
+			"LogType": "json-file",
+			"Env": {
+					"KUBERNETES_PORT": "tcp://192.168.0.1:443",
+					"KUBERNETES_PORT_443_TCP": "tcp://192.168.0.1:443",
+					"KUBERNETES_PORT_443_TCP_ADDR": "192.168.0.1",
+					"KUBERNETES_PORT_443_TCP_PORT": "443",
+					"KUBERNETES_PORT_443_TCP_PROTO": "tcp",
+					"KUBERNETES_SERVICE_HOST": "10.244.197.20",
+					"KUBERNETES_SERVICE_PORT": "6443",
+					"KUBERNETES_SERVICE_PORT_HTTPS": "443"
+			},
+			"Mounts": [
+				{
+					"Source": "/home/admin/logs",
+					"Destination" : "/home/admin/logs",
+					"Driver" : "host"
+				},
+				{
+					"Source": "/var/lib/docker",
+					"Destination" : "/docker",
+					"Driver" : "host"
+				}
+			],
+			"UpperDir": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/222/rootfs",
+			"Created": "2023-06-01T10:09:33.221371944+08:00",
+			"State": {
+					"Pid": 1102,
+					"Status": "running"
+			}
+	},
+	{
+			"ID": "333",
+			"Name": "container3",
+			"Image": "image3",
+			"LogPath": "/var/log/pods/prod_podTest_podUidTest/container3/0.log",
+			"Labels": {
+					"io.kubernetes.container.name": "container3",
+					"io.kubernetes.pod.name": "podTest",
+					"io.kubernetes.pod.namespace": "prod",
+					"io.kubernetes.pod.uid": "podUidTest"
+			},
+			"LogType": "json-file",
+			"Env": {
+					"KUBERNETES_PORT": "tcp://192.168.0.1:443",
+					"KUBERNETES_PORT_443_TCP": "tcp://192.168.0.1:443",
+					"KUBERNETES_PORT_443_TCP_ADDR": "192.168.0.1",
+					"KUBERNETES_PORT_443_TCP_PORT": "443",
+					"KUBERNETES_PORT_443_TCP_PROTO": "tcp",
+					"KUBERNETES_SERVICE_HOST": "10.244.197.20",
+					"KUBERNETES_SERVICE_PORT": "6443",
+					"KUBERNETES_SERVICE_PORT_HTTPS": "443",
+					"POD_NAME": "",
+					"POD_NAMESPACE": "",
+					"aliyun_log_crd_user_defined_id": "k8s-group-xxx"
+			},
+			"Mounts": [
+				{
+					"Source": "/home/admin/logs",
+					"Destination" : "/home/admin/logs",
+					"Driver" : "host"
+				},
+				{
+					"Source": "/var/lib/docker",
+					"Destination" : "/docker",
+					"Driver" : "host"
+				}
+			],
+			"UpperDir": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/333/rootfs",
+			"Created": "2023-06-01T10:09:34.22551185+08:00",
+			"State": {
+					"Pid": 1181,
+					"Status": "running"
+			}
+	},
+	{
+			"ID": "444",
+			"Name": "container4",
+			"Image": "image4",
+			"LogPath": "/var/log/pods/prod_podTest_podUidTest/container4/0.log",
+			"Labels": {
+					"io.kubernetes.container.name": "container4",
+					"io.kubernetes.pod.name": "podTest",
+					"io.kubernetes.pod.namespace": "prod",
+					"io.kubernetes.pod.uid": "podUidTest"
+			},
+			"LogType": "json-file",
+			"Env": {
+					"POD_NAME": "",
+					"POD_NAMESPACE": ""
+			},
+			"Mounts": [
+				{
+					"Source": "/home/admin/logs",
+					"Destination" : "/home/admin/logs",
+					"Driver" : "host"
+				},
+				{
+					"Source": "/var/lib/docker",
+					"Destination" : "/docker",
+					"Driver" : "host"
+				}
+			],
+			"UpperDir": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/444/rootfs",
+			"Created": "2023-06-01T10:10:08.442675217+08:00",
+			"State": {
+					"Pid": 1965,
+					"Status": "running"
+			}
+	},
+	{
+			"ID": "555",
+			"Name": "container5",
+			"Image": "image5",
+			"LogPath": "/var/log/pods/prod_podTest_podUidTest/container5/0.log",
+			"Labels": {
+					"io.kubernetes.container.name": "container5",
+					"io.kubernetes.pod.name": "podTest",
+					"io.kubernetes.pod.namespace": "prod",
+					"io.kubernetes.pod.uid": "podUidTest"
+			},
+			"LogType": "json-file",
+			"Env": {
+					"POD_NAME": "",
+					"POD_NAMESPACE": ""
+			},
+			"Mounts": [
+				{
+					"Source": "/home/admin/logs",
+					"Destination" : "/home/admin/logs",
+					"Driver" : "host"
+				},
+				{
+					"Source": "/var/lib/docker",
+					"Destination" : "/docker",
+					"Driver" : "host"
+				}
+			],
+			"UpperDir": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/555/rootfs",
+			"Created": "2023-06-01T10:10:08.77858586+08:00",
+			"State": {
+					"Pid": 2007,
+					"Status": "running"
+			}
+	},
+	{
+			"ID": "podUidTest",
+			"Name": "POD",
+			"Image": "pause:latest",
+			"LogPath": "/var/log/pods/prod_podTest_podUidTest",
+			"Labels": {
+					"app": "appTest",
+					"attribute": "attTest",
+					"deployment": "deploymentTest",
+					"environment": "prod",
+					"io.kubernetes.pod.name": "podTest",
+					"io.kubernetes.pod.namespace": "prod",
+					"io.kubernetes.pod.uid": "podUidTest",
+					"log": "logTest",
+					"pod-template-hash": "xxx",
+					"custom": "xxx"
+			},
+			"LogType": "json-file",
+			"UpperDir": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/null/rootfs",
+			"Created": "0001-01-01T00:00:00Z",
+			"State": {
+					"Pid": 0,
+					"Status": ""
+			}
+	},
+	{
+			"ID": "666",
+			"Name": "container7",
+			"Image": "acr.baijia.com/uqun/container7:2022102001",
+			"LogPath": "/var/log/pods/prod_podTest_podUidTest/container7/0.log",
+			"Labels": {
+					"io.kubernetes.container.name": "container7",
+					"io.kubernetes.pod.name": "podTest",
+					"io.kubernetes.pod.namespace": "prod",
+					"io.kubernetes.pod.uid": "podUidTest"
+			},
+			"LogType": "json-file",
+			"Env": {
+				"POD_NAME": "",
+				"POD_NAMESPACE": ""
+			},
+			"Mounts": [
+				{
+					"Source": "/home/admin/logs",
+					"Destination" : "/home/admin/logs",
+					"Driver" : "host"
+				},
+				{
+					"Source": "/var/lib/docker",
+					"Destination" : "/docker",
+					"Driver" : "host"
+				}
+			],
+			"UpperDir": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/666/rootfs",
+			"Created": "2023-06-01T10:09:29.382815361+08:00",
+			"State": {
+					"Pid": 694,
+					"Status": "running"
+			}
+	},
+	{
+			"ID": "777",
+			"Name": "container8",
+			"Image": "acr.baijia.com/uqun/container8:1.7.0",
+			"LogPath": "/var/log/pods/prod_podTest_podUidTest/container8/0.log",
+			"Labels": {
+					"io.kubernetes.container.name": "container8",
+					"io.kubernetes.pod.name": "podTest",
+					"io.kubernetes.pod.namespace": "prod",
+					"io.kubernetes.pod.uid": "podUidTest"
+			},
+			"LogType": "json-file",
+			"Env": {
+				"POD_NAME": "",
+				"POD_NAMESPACE": ""
+			},
+			"Mounts": [
+					{
+							"Source": "/var/lib/kubelet/pods/podUidTest/volumes/kubernetes.io~empty-dir/container8-volume",
+							"Destination": "/ArmsAgent",
+							"Driver": ""
+					}
+			],
+			"UpperDir": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e916e0ba011ab5bf825ba24ffba7e3e5dedd2073e29222dd6238eb874cc27ddd/rootfs",
+			"Created": "2023-06-01T10:09:30.213522454+08:00",
+			"State": {
+					"Pid": 872,
+					"Status": "running"
+			}
+	}
+]`
+
 func TestTryReadStaticContainerInfo(t *testing.T) {
 	defer os.Remove("./static_container.json")
 	defer os.Unsetenv(staticContainerInfoPathEnvKey)
@@ -182,6 +759,31 @@ func TestLoadStaticContainerConfig(t *testing.T) {
 	for id, info := range allInfo {
 		require.Equal(t, "123abc", id)
 		require.Equal(t, "192.168.1.1", info.ContainerIP)
+	}
+}
+
+func TestLoadStaticContainerConfigTwice(t *testing.T) {
+	resetDockerCenter()
+	defer os.Remove("./static_container.json")
+	defer os.Unsetenv(staticContainerInfoPathEnvKey)
+	ioutil.WriteFile("./static_container.json", []byte(staticECIConfig), os.ModePerm)
+	os.Setenv(staticContainerInfoPathEnvKey, "./static_container.json")
+	instance := getDockerCenterInstance()
+	allInfo := instance.containerMap
+	require.Equal(t, 8, len(allInfo))
+	for _, info := range allInfo {
+		require.Equal(t, 6, len(info.K8SInfo.Labels))
+	}
+
+	os.Remove("./static_container.json")
+	ioutil.WriteFile("./static_container.json", []byte(staticECIConfig2), os.ModePerm)
+
+	time.Sleep(time.Second * 10)
+
+	allInfo = instance.containerMap
+	require.Equal(t, 8, len(allInfo))
+	for _, info := range allInfo {
+		require.Equal(t, 7, len(info.K8SInfo.Labels))
 	}
 }
 

--- a/pkg/helper/docker_center_test.go
+++ b/pkg/helper/docker_center_test.go
@@ -73,7 +73,6 @@ func TestGetIpByHost_2(t *testing.T) {
 	os.Remove(hostFileName)
 }
 
-
 func TestGetAllAcceptedInfoV2(t *testing.T) {
 	resetDockerCenter()
 	dc := getDockerCenterInstance()

--- a/pkg/helper/docker_center_test.go
+++ b/pkg/helper/docker_center_test.go
@@ -73,52 +73,6 @@ func TestGetIpByHost_2(t *testing.T) {
 	os.Remove(hostFileName)
 }
 
-func TestUpdateK8sInfo(t *testing.T) {
-	resetDockerCenter()
-	dc := getDockerCenterInstance()
-
-	normalContainerLabels1 := map[string]string{
-		k8sPodNameLabel:      "testPodName",
-		k8sPodNameSpaceLabel: "testNamespace",
-	}
-	pauseContainerLabels := map[string]string{
-		k8sPodNameLabel:      "testPodName",
-		k8sPodNameSpaceLabel: "testNamespace",
-		"customLabel1":       "customLabel1",
-		"customLabel2":       "customLabel2",
-	}
-
-	normalContainerLabels2 := map[string]string{
-		k8sPodNameLabel:      "testPodName",
-		k8sPodNameSpaceLabel: "testNamespace",
-		"customNormalLabel1": "customNormalLabel1",
-		"customNormalLabel2": "customNormalLabel2",
-	}
-
-	newContainer := func(id, name string, labels map[string]string) *DockerInfoDetail {
-		return dc.CreateInfoDetail(types.ContainerJSON{
-			ContainerJSONBase: &types.ContainerJSONBase{
-				ID:    id,
-				Name:  name,
-				State: &types.ContainerState{},
-			},
-			Config: &container.Config{
-				Env:    make([]string, 0),
-				Labels: labels,
-			},
-		}, "", false)
-	}
-
-	{
-		dc.updateContainers(map[string]*DockerInfoDetail{
-			"c1": newContainer("c1", "normalContainer", normalContainerLabels1),
-			"c2": newContainer("c2", "POD", pauseContainerLabels),
-		})
-		require.Equal(t, len(dc.containerMap["c1"].K8SInfo.Labels), 2)
-		dc.updateContainer("c1", newContainer("c1", "normalContainer", normalContainerLabels2))
-		require.Equal(t, len(dc.containerMap["c1"].K8SInfo.Labels), 2)
-	}
-}
 
 func TestGetAllAcceptedInfoV2(t *testing.T) {
 	resetDockerCenter()

--- a/pkg/helper/docker_cri_adapter.go
+++ b/pkg/helper/docker_cri_adapter.go
@@ -30,13 +30,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alibaba/ilogtail/pkg/logger"
-
 	containerdcriserver "github.com/containerd/containerd/pkg/cri/server"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"google.golang.org/grpc"
 	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	"github.com/alibaba/ilogtail/pkg/logger"
 )
 
 const (
@@ -500,6 +500,7 @@ func (cw *CRIRuntimeWrapper) fetchOne(containerID string) error {
 	if err != nil {
 		return err
 	}
+
 	cw.wrapperK8sInfoByID(sandboxID, dockerContainer)
 
 	if logger.DebugFlag() {
@@ -509,6 +510,7 @@ func (cw *CRIRuntimeWrapper) fetchOne(containerID string) error {
 			dockerContainer.IDPrefix(), dockerContainer.ContainerInfo.Name, dockerContainer.ContainerInfo.Created, dockerContainer.Status(), dockerContainer.ContainerInfo)
 	}
 
+	// cri场景下会拼接好k8s信息，然后再单个updateContainer
 	cw.dockerCenter.updateContainer(containerID, dockerContainer)
 	cw.containerHistory[containerID] = true
 	cw.containers[containerID] = &innerContainerInfo{


### PR DESCRIPTION
updateContainer原设计上不支持覆盖更新，只支持增量更新。
静态文件读取容器信息场景下，如果静态文件有变更，重复读取静态文件，会导致sandbox信息丢失。