### PR TITLE
add timeout func when collect disk metrics

### DIFF
--- a/pkg/util/timeout_reader.go
+++ b/pkg/util/timeout_reader.go
@@ -17,6 +17,7 @@ package util
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"io"
 	"runtime"
 	"time"
@@ -70,4 +71,17 @@ func (r *TimeoutReader) Read(b []byte) (n int, err error) {
 		n, _ = r.b.Read(b)
 	}
 	return
+}
+
+func DoFuncWithTimeout(timeout time.Duration, workFunc func() error) error {
+	ch := make(chan error, 1)
+	go func() {
+		ch <- workFunc()
+	}()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(timeout):
+		return fmt.Errorf("operation timed out after %v", timeout)
+	}
 }

--- a/plugins/input/systemv2/input_system_v2.go
+++ b/plugins/input/systemv2/input_system_v2.go
@@ -394,7 +394,14 @@ func (r *InputSystem) Collect(collector pipeline.Collector) error {
 		r.CollectMem(collector)
 	}
 	if r.Disk {
-		r.CollectDisk(collector)
+		err := util.DoFuncWithTimeout(time.Second*3, func() error {
+			r.CollectDisk(collector)
+			return nil
+		})
+		if err != nil {
+			logger.Error(r.context.GetRuntimeContext(), "READ_DISK_ALARM", "read disk metrics timeout, would skip disk collection", err)
+			r.Disk = false
+		}
 	}
 	if r.Net {
 		r.CollectNet(collector)


### PR DESCRIPTION
收集磁盘指标时可能因磁盘挂载错误等问题导致block 情况，目前看可能和syscall api 相关，可能受内核版本等影响，目前环境无法复现，暂时增加timeout 函数，并且增加alarm 打印