### PR TITLE
无法创建snapshot目录

### DIFF
--- a/core/logger/Logger.cpp
+++ b/core/logger/Logger.cpp
@@ -393,11 +393,6 @@ void Logger::LoadAllDefaultConfigs(std::map<std::string, LoggerConfig>& loggerCf
 void Logger::EnsureSnapshotDirExist(std::map<std::string, SinkConfig>& sinkCfgs) {
     std::string dirPath = GetProcessExecutionDir() + STRING_FLAG(logtail_snapshot_dir);
 
-    // determine if the file exists
-    if (CheckExistance(dirPath)) {
-        return;
-    }
-
     if (!Mkdir(dirPath)) {
         LogMsg(std::string("Create snapshot dir error ") + dirPath + ", error" + ErrnoToString(GetErrno()));
     }

--- a/core/logger/Logger.cpp
+++ b/core/logger/Logger.cpp
@@ -192,6 +192,7 @@ void Logger::LoadConfig(const std::string& filePath) {
         if (!in.good())
             break;
 
+        CheckSnapshotDir();
         in.seekg(0, std::ios::end);
         size_t len = in.tellg();
         in.seekg(0, std::ios::beg);
@@ -394,6 +395,19 @@ void Logger::LoadAllDefaultConfigs(std::map<std::string, LoggerConfig>& loggerCf
         {"AsyncFileSinkProfile", SinkConfig{"AsyncFile", 61, 1, 1, dirPath + PATH_SEPARATOR + "ilogtail_profile.LOG"}});
     sinkCfgs.insert(
         {"AsyncFileSinkStatus", SinkConfig{"AsyncFile", 61, 1, 1, dirPath + PATH_SEPARATOR + "ilogtail_status.LOG"}});
+}
+
+void Logger::CheckSnapshotDir() {
+    std::string dirPath = GetProcessExecutionDir() + STRING_FLAG(logtail_snapshot_dir);
+
+    // determine if the file exists
+    if (access(dirPath.c_str(), F_OK) == 0) {
+        return;
+    }
+
+    if (!Mkdir(dirPath)) {
+        LogMsg(std::string("Create snapshot dir error ") + dirPath + ", error" + ErrnoToString(GetErrno()));
+    }
 }
 
 } // namespace logtail

--- a/core/logger/Logger.h
+++ b/core/logger/Logger.h
@@ -80,8 +80,8 @@ private:
     void LoadAllDefaultConfigs(std::map<std::string, LoggerConfig>& loggerCfgs,
                                std::map<std::string, SinkConfig>& sinkCfgs);
 
-    // CheckSnapshotDir checks if the snapshot dir exists, if not, create it.
-    void CheckSnapshotDir();
+    // EnsureSnapshotDirExist ensures the snapshot dir exists.
+    void EnsureSnapshotDirExist(std::map<std::string, SinkConfig>& sinkCfgs);
 };
 
 } // namespace logtail

--- a/core/logger/Logger.h
+++ b/core/logger/Logger.h
@@ -79,6 +79,9 @@ private:
     // LoadAllDefaultConfigs loads all default configs into @loggerCfgs and @sinkCfgs.
     void LoadAllDefaultConfigs(std::map<std::string, LoggerConfig>& loggerCfgs,
                                std::map<std::string, SinkConfig>& sinkCfgs);
+
+    // CheckSnapshotDir checks if the snapshot dir exists, if not, create it.
+    void CheckSnapshotDir();
 };
 
 } // namespace logtail


### PR DESCRIPTION
#944 

如果在k8s中部署ilogtial并将`apsara_log_conf.json`文件挂载为`ConfigMap`，将导致无法创建snapshot目录。
这主要是因为原逻辑只要检测到 `apsara_log_conf.json`文件，并且配置文件中存在某些选项，就不会创建snapshot目录。现添加一个`CheckSnapshotDir()`函数，在读取`apsara_log_conf.json`文件成功后调用，主要判断snapshot目录是否存在，不存在就创建。