### PR TITLE
add containerd custom rootpath support

### DIFF
--- a/pkg/helper/docker_cri_adapter.go
+++ b/pkg/helper/docker_cri_adapter.go
@@ -616,7 +616,7 @@ func (cw *CRIRuntimeWrapper) lookupContainerRootfsAbsDir(info types.ContainerJSO
 			}
 		}
 	} else {
-		aDirs := []string{
+		aDirs = []string{
 			"/run/containerd",
 			"/var/run/containerd",
 		}

--- a/pkg/helper/docker_cri_adapter.go
+++ b/pkg/helper/docker_cri_adapter.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -606,10 +607,15 @@ func (cw *CRIRuntimeWrapper) lookupContainerRootfsAbsDir(info types.ContainerJSO
 	}
 
 	// TODO If the containerd interface provides the absolute path to the rootfs, optimize lookupContainerRootfsAbsDir method.
-	if len(os.Getenv("CONTAINERD_ROOT_PATH")) > 0 {
-		aDirs = append(aDirs, os.Getenv("CONTAINERD_ROOT_PATH"))
+	if len(os.Getenv("CONTAINERD_ROOT_DIR")) > 0 {
+		dir := os.Getenv("CONTAINERD_ROOT_DIR")
+		absPath, err := filepath.Abs(dir)
+		if err != nil {
+			logger.Errorf(context.Background(), "CHECK_CUSTOM_CONTAINERD_ROOT_DIR_FAILED", "failed to parse custom containerd root dir, please check it. dir: %s, error: %v", absPath, err)
+		} else {
+			aDirs = append(aDirs, absPath)
+		}
 	}
-
 	bDirs := []string{
 		"io.containerd.runtime.v2.task",
 		"io.containerd.runtime.v1.linux",

--- a/pkg/helper/docker_cri_adapter.go
+++ b/pkg/helper/docker_cri_adapter.go
@@ -605,6 +605,11 @@ func (cw *CRIRuntimeWrapper) lookupContainerRootfsAbsDir(info types.ContainerJSO
 		"/var/run/containerd",
 	}
 
+	// TODO If the containerd interface provides the absolute path to the rootfs, optimize lookupContainerRootfsAbsDir method.
+	if len(os.Getenv("CONTAINERD_ROOT_PATH")) > 0 {
+		aDirs = append(aDirs, os.Getenv("CONTAINERD_ROOT_PATH"))
+	}
+
 	bDirs := []string{
 		"io.containerd.runtime.v2.task",
 		"io.containerd.runtime.v1.linux",

--- a/pkg/helper/docker_cri_adapter.go
+++ b/pkg/helper/docker_cri_adapter.go
@@ -601,11 +601,7 @@ func (cw *CRIRuntimeWrapper) lookupContainerRootfsAbsDir(info types.ContainerJSO
 	}
 
 	// Example: /run/containerd/io.containerd.runtime.v1.linux/k8s.io/{ContainerID}/rootfs/
-	aDirs := []string{
-		"/run/containerd",
-		"/var/run/containerd",
-	}
-
+	aDirs := []string{}
 	// TODO If the containerd interface provides the absolute path to the rootfs, optimize lookupContainerRootfsAbsDir method.
 	if len(os.Getenv("CONTAINERD_ROOT_DIR")) > 0 {
 		dir := os.Getenv("CONTAINERD_ROOT_DIR")
@@ -613,7 +609,16 @@ func (cw *CRIRuntimeWrapper) lookupContainerRootfsAbsDir(info types.ContainerJSO
 		if err != nil {
 			logger.Errorf(context.Background(), "CHECK_CUSTOM_CONTAINERD_ROOT_DIR_FAILED", "failed to parse custom containerd root dir, please check it. dir: %s, error: %v", absPath, err)
 		} else {
-			aDirs = append(aDirs, absPath)
+			aDirs = []string{
+				absPath,
+				"/run/containerd",
+				"/var/run/containerd",
+			}
+		}
+	} else {
+		aDirs := []string{
+			"/run/containerd",
+			"/var/run/containerd",
 		}
 	}
 	bDirs := []string{


### PR DESCRIPTION
配置采集容器内文件采集异常，通过查看日志发现
```
2023-06-30 06:45:44 [WRN] [metric_docker_file.go:359] [Collect] [config#/usr/local/ilogtail/./user_yaml_config.d/test.yaml,]AlarmType:DOCKER_FILE_MATCH_ALARM       unknow error:can't find path from this container        path:/home/test-log     container:busybox   logstore:       config:config#/usr/local/ilogtail/./user_yaml_config.d/test.yaml
```

然后查看[源码](https://github.com/alibaba/ilogtail/blob/main/pkg/helper/docker_cri_adapter.go#L603)，发现containerd container rootfs查找方法是通过固定的路径查询。目前调用containerd接口也无法获取rootfs目录，所以建议添加环境变量支持用户配置自定义目录。