### PR TITLE
fix: multi-bytes character cut off

### DIFF
--- a/core/reader/LogFileReader.cpp
+++ b/core/reader/LogFileReader.cpp
@@ -1874,8 +1874,8 @@ size_t LogFileReader::AlignLastCharacter(char* buffer, size_t size) {
         // GB 18030 encoding rules:
         // 1. The number of byte for one character can be 1, 2, 4.
         // 2. 1 byte character: the top bit is 0.
-        // 3. 2 bytes character: the top bit of the first byte is 1; the second bit of the second byte is 1.
-        // 4. 4 bytes character: the top bit of the first byte is 1; the first and second bit of the 2nd and 4th byte are 00.
+        // 3. 2 bytes character: the top bit of the first byte is 1; the second byte is between 0x40 and 0xFE.
+        // 4. 4 bytes character: the top bit of the first byte is 1; the 2nd and 4th byte are between 0x30 and 0x39.
 
         // First byte of the multi-bytes character, must be rollback
         if ((buffer[endPs] & 0x80) == 0x80) {
@@ -1885,7 +1885,7 @@ size_t LogFileReader::AlignLastCharacter(char* buffer, size_t size) {
         if ((buffer[endPs] & 0xC0) == 0) { // 4 bytes character, 0xC0 -> 11000000
             int pair = 0;
             // search backward whether 2nd byte is paired with 4th
-            while (endPs >= 0 and (buffer[endPs] & 0xC0) == 0) {
+            while (endPs >= 1 && ((buffer[endPs - 1] & 0x80) == 0x80 && (buffer[endPs] & 0xC0) == 0)) {
                 pair += 1;
                 endPs -= 2;
             }

--- a/core/reader/LogFileReader.cpp
+++ b/core/reader/LogFileReader.cpp
@@ -1866,41 +1866,60 @@ int32_t LogFileReader::LastMatchedLine(char* buffer, int32_t size, int32_t& roll
 
 size_t LogFileReader::AlignLastCharacter(char* buffer, size_t size) {
     int n = 0;
-    if (buffer[size - 1] == '\n') {
+    int endPs = size - 1;
+    if (buffer[endPs] == '\n') {
         return size;
     }
     if (mFileEncoding == ENCODING_GBK) {
-        // GBK encoding rules:
-        // 1. The top bit of the first byte is 1.
-        // 2. The top bit of the second byte or single byte character is 0.
-        if (buffer[size - 1] & 0x80) {
-            return size - 1;
+        // GB 18030 encoding rules:
+        // 1. The number of byte for one character can be 1, 2, 4.
+        // 2. 1 byte character: the top bit is 0.
+        // 3. 2 bytes character: the top bit of the first byte is 1; the second bit of the second byte is 1.
+        // 4. 4 bytes character: the top bit of the first byte is 1; the first and second bit of the 2nd and 4th byte are 00.
+
+        // First byte of the multi-bytes character, must be rollback
+        if ((buffer[endPs] & 0x80) == 0x80) {
+            size--;
+            endPs--;
+        }
+        if ((buffer[endPs] & 0xC0) == 0) { // 4 bytes character, 0xC0 -> 11000000
+            int pair = 0;
+            // search backward whether 2nd byte is paired with 4th
+            while (endPs >= 0 and (buffer[endPs] & 0xC0) == 0) {
+                pair += 1;
+                endPs -= 2;
+            }
+            if (pair % 2 == 0) {
+                return size;
+            } else {
+                buffer[size - 2] = '\0';
+                return size - 2;
+            }
         } else {
             return size;
         }
     } else {
         // UTF8 encoding rules:
         // 1. For single byte character, the top bit is 0.
-        // 2. For N (N > 1) bytes character, the top N bit of the first byte is 1. The top 2 bits of the following bytes are 10.
-        int endPs = size - 1;
+        // 2. For N (N > 1) bytes character, the top N bit of the first byte is 1. The first and second bits of the following bytes are 10.
         while (endPs >= 0) {
             char ch = buffer[endPs];
-            if ((ch & 0x80) == 0) { // 1 bytes character
+            if ((ch & 0x80) == 0) { // 1 bytes character, 0x80 -> 10000000
                 n = 1;
                 break;
-            } else if ((ch & 0xE0) == 0xC0) { // 2 bytes character
+            } else if ((ch & 0xE0) == 0xC0) { // 2 bytes character, 0xE0 -> 11100000, 0xC0 -> 11000000
                 n = 2;
                 break;
-            } else if ((ch & 0xF0) == 0xE0) { // 3 bytes character
+            } else if ((ch & 0xF0) == 0xE0) { // 3 bytes character, 0xF0 -> 11110000, 0xE0 -> 11100000
                 n = 3;
                 break;
-            } else if ((ch & 0xF8) == 0xF0) { // 4 bytes character
+            } else if ((ch & 0xF8) == 0xF0) { // 4 bytes character, 0xF8 -> 11111000, 0xF0 -> 11110000
                 n = 4;
                 break;
-            } else if ((ch & 0xFC) == 0xF8) { // 5 bytes character
+            } else if ((ch & 0xFC) == 0xF8) { // 5 bytes character, 0xFC -> 11111100, 0xF8 -> 11111000
                 n = 5;
                 break;
-            } else if ((ch & 0xFE) == 0xFC) { // 6 bytes character
+            } else if ((ch & 0xFE) == 0xFC) { // 6 bytes character, 0xFE -> 11111110, 0xFC -> 11111100
                 n = 6;
                 break;
             }

--- a/core/reader/LogFileReader.h
+++ b/core/reader/LogFileReader.h
@@ -104,6 +104,8 @@ public:
 
     virtual int32_t LastMatchedLine(char* buffer, int32_t size, int32_t& rollbackLineFeedCount);
 
+    size_t AlignLastCharacter(char* buffer, size_t size);
+
     virtual ~LogFileReader();
 
     std::string GetRegion() const { return mRegion; }
@@ -510,6 +512,7 @@ private:
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class EventDispatcherTest;
     friend class LogFileReaderUnittest;
+    friend class LogMultiBytesUnittest;
     friend class ExactlyOnceReaderUnittest;
     friend class SenderUnittest;
     friend class AppConfigUnittest;

--- a/core/unittest/reader/LogFileReaderUnittest.cpp
+++ b/core/unittest/reader/LogFileReaderUnittest.cpp
@@ -654,10 +654,25 @@ void LogMultiBytesUnittest::TestAlignLastCharacterGBK() {
                                          FileEncoding::ENCODING_GBK,
                                          false,
                                          false);
-    std::string expectedLog = "\xce\xaa\xbf\xc9\xb9\xdb\xb2\xe2\xb3\xa1\xbe\xb0\xb6\xf8"; // equal to "为可观测场景而"
-    std::string testLog = expectedLog + "\xc9";
-    size_t result = logFileReader.AlignLastCharacter(const_cast<char*>(testLog.data()), expectedLog.size() + 1);
-    APSARA_TEST_EQUAL_FATAL(expectedLog.size(), result);
+    { // case: GBK
+        std::string expectedLog = "\xce\xaa\xbf\xc9\xb9\xdb\xb2\xe2\xb3\xa1\xbe\xb0\xb6\xf8"; // equal to "为可观测场景而"
+        std::string testLog = expectedLog + "\xc9";
+        size_t result = logFileReader.AlignLastCharacter(const_cast<char*>(testLog.data()), expectedLog.size() + 1);
+        APSARA_TEST_EQUAL_FATAL(expectedLog.size(), result);
+    }
+    { // case: GB 18030
+        std::string expectedLog = "ilogtail\xce\xaa"; // equal to "ilogtail为"
+        std::string testLog = expectedLog + "\x81\x30\x89\x39"; // equal to "â"
+        size_t result = logFileReader.AlignLastCharacter(const_cast<char*>(testLog.data()), expectedLog.size() + 2);
+        APSARA_TEST_EQUAL_FATAL(expectedLog.size(), result);
+    }
+    { // case: All ASCII
+        std::string expectedLog = "ilogtail";
+        std::string testLog = expectedLog + "\x81\x30\x89\x39"; // equal to "â"
+        size_t result = logFileReader.AlignLastCharacter(const_cast<char*>(testLog.data()), expectedLog.size() + 3);
+        APSARA_TEST_EQUAL_FATAL(expectedLog.size(), result);
+    }
+
 }
 
 void LogMultiBytesUnittest::TestReadUTF8() {

--- a/core/unittest/reader/LogFileReaderUnittest.cpp
+++ b/core/unittest/reader/LogFileReaderUnittest.cpp
@@ -655,7 +655,7 @@ void LogMultiBytesUnittest::TestAlignLastCharacterGBK() {
                                          false,
                                          false);
     std::string expectedLog = "\xce\xaa\xbf\xc9\xb9\xdb\xb2\xe2\xb3\xa1\xbe\xb0\xb6\xf8"; // equal to "为可观测场景而"
-    std::string testLog = expectedLog + "\xc9\xfa";
+    std::string testLog = expectedLog + "\xc9";
     size_t result = logFileReader.AlignLastCharacter(const_cast<char*>(testLog.data()), expectedLog.size() + 1);
     APSARA_TEST_EQUAL_FATAL(expectedLog.size(), result);
 }

--- a/core/unittest/reader/LogFileReaderUnittest.cpp
+++ b/core/unittest/reader/LogFileReaderUnittest.cpp
@@ -121,7 +121,7 @@ void LogFileReaderUnittest::TestReadGBK() {
                                       FileEncoding::ENCODING_GBK,
                                       false,
                                       false);
-        LogFileReader::BUFFER_SIZE = 13;
+        LogFileReader::BUFFER_SIZE = 14;
         size_t BUFFER_SIZE_UTF8 = 15; // "ilogtail 为可"
         reader.SetLogBeginRegex("no matching pattern");
         reader.UpdateReaderManual();
@@ -263,7 +263,7 @@ void LogFileReaderUnittest::TestReadUTF8() {
         reader.InitReader(true, LogFileReader::BACKWARD_TO_BEGINNING);
         int64_t fileSize = 0;
         reader.CheckFileSignatureAndOffset(fileSize);
-        LogFileReader::BUFFER_SIZE = fileSize - 11;
+        LogFileReader::BUFFER_SIZE = fileSize - 13;
         LogBuffer logBuffer;
         bool moreData = false;
         reader.ReadUTF8(logBuffer, fileSize, moreData);
@@ -291,7 +291,7 @@ void LogFileReaderUnittest::TestReadUTF8() {
         reader.InitReader(true, LogFileReader::BACKWARD_TO_BEGINNING);
         int64_t fileSize = 0;
         reader.CheckFileSignatureAndOffset(fileSize);
-        LogFileReader::BUFFER_SIZE = fileSize - 11;
+        LogFileReader::BUFFER_SIZE = fileSize - 13;
         LogBuffer logBuffer;
         bool moreData = false;
         // first read
@@ -299,14 +299,14 @@ void LogFileReaderUnittest::TestReadUTF8() {
         APSARA_TEST_TRUE_FATAL(moreData);
         std::string expectedPart(expectedContent.get());
         // TODO: expect: expectedPart.resize(expectedPart.rfind("iLogtail") - 1);
-        expectedPart.resize(fileSize - 11);
+        expectedPart.resize(LogFileReader::BUFFER_SIZE);
         APSARA_TEST_STREQ_FATAL(expectedPart.c_str(), logBuffer.rawBuffer.data());
         // second read
         reader.ReadUTF8(logBuffer, fileSize, moreData);
         APSARA_TEST_FALSE_FATAL(moreData);
         expectedPart = expectedContent.get();
         // TODO: expect: expectedPart = expectedPart.substr(expectedPart.rfind("iLogtail"));
-        expectedPart = expectedPart.substr(fileSize - 11);
+        expectedPart = expectedPart.substr(LogFileReader::BUFFER_SIZE);
         APSARA_TEST_STREQ_FATAL(expectedPart.c_str(), logBuffer.rawBuffer.data());
     }
 }
@@ -559,6 +559,157 @@ void LogSplitUnittest::TestLogSplitMultiLineAllNotmatchNoDiscard() {
     APSARA_TEST_FALSE_FATAL(splitSuccess);
     APSARA_TEST_EQUAL_FATAL(1UL, index.size());
     APSARA_TEST_EQUAL_FATAL(testLog, index[0].to_string());
+}
+
+class LogMultiBytesUnittest : public ::testing::Test {
+public:
+    static void SetUpTestCase() {
+        logPathDir = GetProcessExecutionDir();
+        if (PATH_SEPARATOR[0] == logPathDir.back()) {
+            logPathDir.resize(logPathDir.size() - 1);
+        }
+        logPathDir += PATH_SEPARATOR + "testDataSet" + PATH_SEPARATOR + "LogFileReaderUnittest";
+        gbkFile = "gbk.txt";
+        utf8File = "utf8.txt"; // content of utf8.txt is equivalent to gbk.txt
+    }
+
+    static void TearDownTestCase() {
+        remove(gbkFile.c_str());
+        remove(utf8File.c_str());
+    }
+
+    void SetUp() override {
+        std::string filepath = logPathDir + PATH_SEPARATOR + utf8File;
+        std::unique_ptr<FILE, decltype(&std::fclose)> fp(std::fopen(filepath.c_str(), "r"), &std::fclose);
+        if (!fp.get()) {
+            return;
+        }
+        std::fseek(fp.get(), 0, SEEK_END);
+        long filesize = std::ftell(fp.get());
+        std::fseek(fp.get(), 0, SEEK_SET);
+        expectedContent.reset(new char[filesize + 1]);
+        fread(expectedContent.get(), filesize, 1, fp.get());
+        expectedContent[filesize] = '\0';
+        for (long i = filesize - 1; i >= 0; --i) {
+            if (expectedContent[i] == '\n') {
+                expectedContent[i] = 0;
+                break;
+            };
+        }
+    }
+
+    void TearDown() override { LogFileReader::BUFFER_SIZE = 1024 * 512; }
+    void TestAlignLastCharacterUTF8();
+    void TestAlignLastCharacterGBK();
+    void TestReadUTF8();
+    void TestReadGBK();
+
+    std::string projectName = "projectName";
+    std::string category = "logstoreName";
+    std::string timeFormat = "";
+    std::string topicFormat = "";
+    std::string groupTopic = "";
+    std::unique_ptr<char[]> expectedContent;
+    static std::string logPathDir;
+    static std::string gbkFile;
+    static std::string utf8File;
+};
+
+UNIT_TEST_CASE(LogMultiBytesUnittest, TestAlignLastCharacterUTF8);
+UNIT_TEST_CASE(LogMultiBytesUnittest, TestAlignLastCharacterGBK);
+UNIT_TEST_CASE(LogMultiBytesUnittest, TestReadUTF8);
+UNIT_TEST_CASE(LogMultiBytesUnittest, TestReadGBK);
+
+std::string LogMultiBytesUnittest::logPathDir;
+std::string LogMultiBytesUnittest::gbkFile;
+std::string LogMultiBytesUnittest::utf8File;
+
+void LogMultiBytesUnittest::TestAlignLastCharacterUTF8() {
+    CommonRegLogFileReader logFileReader(projectName,
+                                         category,
+                                         "",
+                                         "",
+                                         INT32_FLAG(default_tail_limit_kb),
+                                         timeFormat,
+                                         topicFormat,
+                                         groupTopic,
+                                         FileEncoding::ENCODING_UTF8,
+                                         false,
+                                         false);
+    std::string expectedLog = "为可观测场景而";
+    std::string testLog = expectedLog + "生";
+    size_t result = logFileReader.AlignLastCharacter(const_cast<char*>(testLog.data()), expectedLog.size() + 1);
+    APSARA_TEST_EQUAL_FATAL(expectedLog.size(), result);
+}
+
+void LogMultiBytesUnittest::TestAlignLastCharacterGBK() {
+    CommonRegLogFileReader logFileReader(projectName,
+                                         category,
+                                         "",
+                                         "",
+                                         INT32_FLAG(default_tail_limit_kb),
+                                         timeFormat,
+                                         topicFormat,
+                                         groupTopic,
+                                         FileEncoding::ENCODING_GBK,
+                                         false,
+                                         false);
+    std::string expectedLog = "\xce\xaa\xbf\xc9\xb9\xdb\xb2\xe2\xb3\xa1\xbe\xb0\xb6\xf8"; // equal to "为可观测场景而"
+    std::string testLog = expectedLog + "\xc9\xfa";
+    size_t result = logFileReader.AlignLastCharacter(const_cast<char*>(testLog.data()), expectedLog.size() + 1);
+    APSARA_TEST_EQUAL_FATAL(expectedLog.size(), result);
+}
+
+void LogMultiBytesUnittest::TestReadUTF8() {
+    CommonRegLogFileReader reader(projectName,
+                                      category,
+                                      logPathDir,
+                                      utf8File,
+                                      INT32_FLAG(default_tail_limit_kb),
+                                      timeFormat,
+                                      topicFormat,
+                                      groupTopic,
+                                      FileEncoding::ENCODING_UTF8,
+                                      false,
+                                      false);
+    LogFileReader::BUFFER_SIZE = 13; // equal to "iLogtail 为" plus one illegal byte
+    reader.UpdateReaderManual();
+    reader.InitReader(true, LogFileReader::BACKWARD_TO_BEGINNING);
+    int64_t fileSize = 0;
+    reader.CheckFileSignatureAndOffset(fileSize);
+    LogBuffer logBuffer;
+    bool moreData = false;
+    reader.ReadUTF8(logBuffer, fileSize, moreData);
+    std::string expectedPart(expectedContent.get());
+    expectedPart = expectedPart.substr(0, LogFileReader::BUFFER_SIZE - 1);
+    APSARA_TEST_STREQ_FATAL(expectedPart.c_str(), logBuffer.rawBuffer.data());
+}
+
+void LogMultiBytesUnittest::TestReadGBK() {
+    CommonRegLogFileReader reader(projectName,
+                                  category,
+                                  logPathDir,
+                                  gbkFile,
+                                  INT32_FLAG(default_tail_limit_kb),
+                                  timeFormat,
+                                  topicFormat,
+                                  groupTopic,
+                                  FileEncoding::ENCODING_GBK,
+                                  false,
+                                  false);
+    LogFileReader::BUFFER_SIZE = 12; // equal to "iLogtail 为" plus one illegal byte
+    size_t BUFFER_SIZE_UTF8 = 12; // "ilogtail 为可"
+    reader.UpdateReaderManual();
+    reader.InitReader(true, LogFileReader::BACKWARD_TO_BEGINNING);
+    int64_t fileSize = 0;
+    reader.CheckFileSignatureAndOffset(fileSize);
+    LogBuffer logBuffer;
+    bool moreData = false;
+    reader.ReadGBK(logBuffer, fileSize, moreData);
+    APSARA_TEST_TRUE_FATAL(moreData);
+    std::string expectedPart(expectedContent.get());
+    expectedPart = expectedPart.substr(0, BUFFER_SIZE_UTF8);
+    APSARA_TEST_STREQ_FATAL(expectedPart.c_str(), logBuffer.rawBuffer.data());
 }
 
 } // namespace logtail


### PR DESCRIPTION
## 问题
UTF8 和 GBK 编码中都存在多字节字符。当读取的日志超出 buffer size 的时候，日志就会被截断读取。这种情况下，就有可能导致多字节字符被 split 在两次读取，导致乱码。

## 解决方案
在每次读取日志时，都会对读取的日志进行回退。所以，利用逆向回退，将读取的字符进行回退对齐。