### PR TITLE
add_dockerClient_conn_test

### DIFF
--- a/pkg/helper/container_export.go
+++ b/pkg/helper/container_export.go
@@ -196,11 +196,11 @@ func CreateDockerClient(opt ...docker.Opt) (client *docker.Client, err error) {
 	// add dockerClient connectivity tests
 	pingCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	_, err = client.Ping(pingCtx)
+	ping, err := client.Ping(pingCtx)
 	if err != nil {
 		return nil, err
 	}
-	client.NegotiateAPIVersion(context.Background())
+	client.NegotiateAPIVersionPing(ping)
 	return
 }
 

--- a/pkg/helper/container_export.go
+++ b/pkg/helper/container_export.go
@@ -17,13 +17,15 @@ package helper
 import (
 	"context"
 	"fmt"
-	"github.com/alibaba/ilogtail/pkg/logger"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/events"
-	docker "github.com/docker/docker/client"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/events"
+	docker "github.com/docker/docker/client"
+
+	"github.com/alibaba/ilogtail/pkg/logger"
 )
 
 type ContainerMeta struct {

--- a/pkg/helper/container_export.go
+++ b/pkg/helper/container_export.go
@@ -189,9 +189,17 @@ func SplitRegexFromMap(input map[string]string) (staticResult map[string]string,
 func CreateDockerClient(opt ...docker.Opt) (client *docker.Client, err error) {
 	opt = append(opt, docker.FromEnv)
 	client, err = docker.NewClientWithOpts(opt...)
-	if err == nil {
-		client.NegotiateAPIVersion(context.Background())
+	if err != nil {
+		return nil, err
 	}
+	// add dockerClient connectivity tests
+	pingCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	_, err = client.Ping(pingCtx)
+	if err != nil {
+		return nil, err
+	}
+	client.NegotiateAPIVersion(context.Background())
 	return
 }
 

--- a/pkg/helper/container_export.go
+++ b/pkg/helper/container_export.go
@@ -17,14 +17,13 @@ package helper
 import (
 	"context"
 	"fmt"
-	"regexp"
-	"strings"
-	"time"
+	"github.com/alibaba/ilogtail/pkg/logger"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	docker "github.com/docker/docker/client"
-
-	"github.com/alibaba/ilogtail/pkg/logger"
+	"regexp"
+	"strings"
+	"time"
 )
 
 type ContainerMeta struct {

--- a/pkg/helper/container_export.go
+++ b/pkg/helper/container_export.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-
+	"time"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	docker "github.com/docker/docker/client"

--- a/pkg/helper/docker_center.go
+++ b/pkg/helper/docker_center.go
@@ -643,7 +643,13 @@ func getDockerCenterInstance() *DockerCenter {
 			logger.Warning(context.Background(), "check docker mount path error", err.Error())
 		}
 		var enableCriFinding = criRuntimeWrapper != nil
-		var enableDocker = dockerCenterInstance.initClient() == nil
+		var enableDocker = false
+		// if enableCriFinding is true,There is no need to initialize dockerClient.
+		if !enableCriFinding {
+			if dockerCenterInstance.initClient() == nil {
+				enableDocker = true
+			}
+		}
 		var enableStatic = isStaticContainerInfoEnabled()
 		containerFindingManager = NewContainerDiscoverManager(enableDocker, enableCriFinding, enableStatic)
 		containerFindingManager.Init(3)

--- a/pkg/helper/docker_center.go
+++ b/pkg/helper/docker_center.go
@@ -643,13 +643,7 @@ func getDockerCenterInstance() *DockerCenter {
 			logger.Warning(context.Background(), "check docker mount path error", err.Error())
 		}
 		var enableCriFinding = criRuntimeWrapper != nil
-		var enableDocker = false
-		// if enableCriFinding is true,There is no need to initialize dockerClient.
-		if !enableCriFinding {
-			if dockerCenterInstance.initClient() == nil {
-				enableDocker = true
-			}
-		}
+		var enableDocker = dockerCenterInstance.initClient() == nil
 		var enableStatic = isStaticContainerInfoEnabled()
 		containerFindingManager = NewContainerDiscoverManager(enableDocker, enableCriFinding, enableStatic)
 		containerFindingManager.Init(3)


### PR DESCRIPTION
目前基础环境为k8s+containerd的模式，查看logtail_plugin.LOG发现。即便不使用docker，也会初始化dockerClient,并且多次尝试连接，错误日志如下
```
2023-07-06 08:37:02 [INF] [plugin_manager.go:120] [Init] init plugin, local env tags:[_node_name_ ihuman _node_ip_ 10.2.112.25]
2023-07-06 08:37:02 [INF] [checkpoint_manager.go:96] [Init] init checkpoint:<nil>
2023-07-06 08:37:02 [INF] [logstore_config.go:666] [loadBuiltinConfig] load built-in config statistics, config name: shennong_log_profile, logstore: logtail_plugin_profile
2023-07-06 08:37:02 [INF] [logstore_config.go:666] [loadBuiltinConfig] load built-in config alarm, config name: logtail_alarm, logstore: logtail_alarm
2023-07-06 08:37:02 [INF] [logstore_config.go:666] [loadBuiltinConfig] load built-in config container, config name: logtail_containers, logstore: logtail_containers
2023-07-06 08:37:02 [INF] [plugin_manager.go:138] [Init] loadBuiltinConfig container:
2023-07-06 08:37:02 [INF] [logstore_config.go:655] [LoadLogstoreConfig] load config:config#/usr/local/ilogtail/./user_yaml_config.d/ilogtail-path.yaml      logstore:
2023-07-06 08:37:02 [ERR] [logger.go:363] [1] AlarmType:CATCH_STANDARD_OUTPUT_ALARM     err:read |0: file already closed
2023-07-06 08:37:02 [ERR] [logger.go:363] [1] AlarmType:CATCH_STANDARD_OUTPUT_ALARM     err:read |0: file already closed
2023-07-06 08:37:02 [INF] [docker_center.go:637] [func1] [CRIRuntime] create cri-runtime client successfully
2023-07-06 08:37:02 [INF] [container_discover_controller.go:167] [Init] input:param     docker discover:true    cri discover:true   static discover:false
2023-07-06 08:37:02 [INF] [container_discover_controller.go:193] [Init] init docker center, fetch all seconds:5m0s
2023-07-06 08:37:02 [INF] [container_discover_controller.go:203] [Init] init docker center, fecth all success timeout:1h40m0s
2023-07-06 08:37:02 [INF] [container_discover_controller.go:213] [Init] init docker center, client request timeout:30s
2023-07-06 08:37:02 [INF] [container_discover_controller.go:224] [Init] init docker center, max fetchOne count per second:200
2023-07-06 08:37:02 [WRN] [docker_center.go:701] [setLastError] AlarmType:DOCKER_CENTER_ALARM   message:list container errorerror found:Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
2023-07-06 08:37:02 [WRN] [docker_center.go:701] [setLastError] AlarmType:DOCKER_CENTER_ALARM   message:list container errorerror found:Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
2023-07-06 08:37:02 [WRN] [docker_center.go:701] [setLastError] AlarmType:DOCKER_CENTER_ALARM   message:list container errorerror found:Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
2023-07-06 08:37:02 [ERR] [container_discover_controller.go:236] [Init] AlarmType:DOCKER_CENTER_ALARM   fetch docker containers error in 3 times, close docker discover
```
查看代码，发现初始化dockerClient时并没有检查连接是否可用。并且我认为如果成功初始化了criRuntimeWrapper，就没必要初始化dockerClient了。做了些修改，麻烦查看一下