### PR TITLE
fix: remove duplicated http flusher test case

### DIFF
--- a/plugins/flusher/http/flusher_http_test.go
+++ b/plugins/flusher/http/flusher_http_test.go
@@ -59,17 +59,6 @@ func TestHttpFlusherInit(t *testing.T) {
 		})
 	})
 
-	Convey("Given a http flusher with empty converter", t, func() {
-		flusher := &FlusherHTTP{
-			RemoteURL: "http://localhost:8086/write",
-			Convert:   helper.ConvertConfig{},
-		}
-		Convey("Then Init() should return error", func() {
-			err := flusher.Init(mockContext{})
-			So(err, ShouldNotBeNil)
-		})
-	})
-
 	Convey("Given a http flusher with Query contains variable ", t, func() {
 		flusher := &FlusherHTTP{
 			RemoteURL: "http://localhost:8086/write",


### PR DESCRIPTION
删除重复的测试案例："Given a http flusher with empty converter"