### PR TITLE
fix: Improve accuracy of log record timestamps

### DIFF
--- a/pkg/protocol/converter/otlp.go
+++ b/pkg/protocol/converter/otlp.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
+	"github.com/alibaba/ilogtail/pkg/config"
 	"github.com/alibaba/ilogtail/pkg/models"
 	"github.com/alibaba/ilogtail/pkg/protocol"
 	"github.com/alibaba/ilogtail/pkg/protocol/otlp"
@@ -82,7 +83,11 @@ func (c *Converter) ConvertToOtlpResourseLogs(logGroup *protocol.LogGroup, targe
 		}
 
 		logRecord.SetObservedTimestamp(pcommon.Timestamp(time.Now().UnixNano()))
-		logRecord.SetTimestamp(pcommon.Timestamp(uint64(log.Time)*uint64(time.Second)) + pcommon.Timestamp(uint64(*log.TimeNs)*uint64(time.Nanosecond)))
+		if config.LogtailGlobalConfig.EnableTimestampNanosecond {
+			logRecord.SetTimestamp(pcommon.Timestamp(uint64(log.Time)*uint64(time.Second)) + pcommon.Timestamp(uint64(*log.TimeNs)*uint64(time.Nanosecond)))
+		} else {
+			logRecord.SetTimestamp(pcommon.Timestamp(uint64(log.Time) * uint64(time.Second)))
+		}
 
 		if body, has := contents[bodyKey]; has {
 			logRecord.Body().SetStr(body)

--- a/pkg/protocol/converter/otlp.go
+++ b/pkg/protocol/converter/otlp.go
@@ -82,7 +82,7 @@ func (c *Converter) ConvertToOtlpResourseLogs(logGroup *protocol.LogGroup, targe
 		}
 
 		logRecord.SetObservedTimestamp(pcommon.Timestamp(time.Now().UnixNano()))
-		logRecord.SetTimestamp(pcommon.Timestamp(uint64(log.Time) * uint64(time.Second)))
+		logRecord.SetTimestamp(pcommon.Timestamp(uint64(log.Time)*uint64(time.Second)) + pcommon.Timestamp(uint64(*log.TimeNs)*uint64(time.Nanosecond)))
 
 		if body, has := contents[bodyKey]; has {
 			logRecord.Body().SetStr(body)

--- a/pkg/protocol/converter/otlp_test.go
+++ b/pkg/protocol/converter/otlp_test.go
@@ -70,6 +70,10 @@ func TestNewConvertToOtlpLogs(t *testing.T) {
 						for j := 0; j < scope.LogRecords().Len(); j++ {
 							logRecord := scope.LogRecords().At(j)
 							convey.So(logs[i].Contents[4].Value, convey.ShouldEqual, logRecord.Body().AsString())
+
+							// Convert timestamp to unix seconds and compare with the original time
+							unixTimeSec := logRecord.Timestamp().AsTime().Unix()
+							convey.So(uint64(logs[j].Time), convey.ShouldEqual, unixTimeSec)
 						}
 					}
 				})
@@ -130,6 +134,10 @@ func TestNewConvertToOtlpLogs(t *testing.T) {
 						for j := 0; j < scope.LogRecords().Len(); j++ {
 							logRecord := scope.LogRecords().At(j)
 							convey.So(logs[i].Contents[4].Value, convey.ShouldEqual, logRecord.Body().AsString())
+
+							// Convert timestamp to unix nanoseconds and compare with the original timeNs
+							unixTimeNano := logRecord.Timestamp().AsTime().UnixNano()
+							convey.So(uint64(logs[j].Time)*uint64(systime.Second)+uint64(*logs[j].TimeNs), convey.ShouldEqual, unixTimeNano)
 						}
 					}
 				})


### PR DESCRIPTION
- Modify calculation of log record timestamp in "otlp.go" file to include nanoseconds

#1031 