### PR TITLE
fix profile file name in container

### DIFF
--- a/core/config/Config.cpp
+++ b/core/config/Config.cpp
@@ -570,7 +570,7 @@ LogFileReader* Config::CreateLogFileReader(const std::string& dir,
         reader->SetFuseMode(mIsFuseMode);
         reader->SetMarkOffsetFlag(mMarkOffsetFlag);
         if (mIsFuseMode) {
-            reader->SetFuseTrimedFilename(reader->GetLogPath().substr((STRING_FLAG(fuse_root_dir)).size() + 1));
+            reader->SetFuseTrimedFilename(reader->GetHostLogPath().substr((STRING_FLAG(fuse_root_dir)).size() + 1));
         }
         if (mLogDelayAlarmBytes > 0) {
             reader->SetDelayAlarmBytes(mLogDelayAlarmBytes);
@@ -616,10 +616,10 @@ LogFileReader* Config::CreateLogFileReader(const std::string& dir,
 
 #ifndef _MSC_VER // Unnecessary on platforms without symbolic.
         fsutil::PathStat buf;
-        if (!fsutil::PathStat::lstat(reader->GetLogPath(), buf)) {
+        if (!fsutil::PathStat::lstat(reader->GetHostLogPath(), buf)) {
             // should not happen
             reader->SetSymbolicLinkFlag(false);
-            LOG_ERROR(sLogger, ("failed to stat file", reader->GetLogPath())("set symbolic link flag to false", ""));
+            LOG_ERROR(sLogger, ("failed to stat file", reader->GetHostLogPath())("set symbolic link flag to false", ""));
         } else {
             reader->SetSymbolicLinkFlag(buf.IsLink());
         }

--- a/core/controller/EventDispatcherBase.cpp
+++ b/core/controller/EventDispatcherBase.cpp
@@ -1555,6 +1555,7 @@ bool EventDispatcherBase::ReadDSPacket(int eventFd) {
                                                                          config->mProjectName,
                                                                          config->mCategory,
                                                                          "",
+                                                                         "",
                                                                          empty,
                                                                          msgStr.size(),
                                                                          0,

--- a/core/event_handler/EventHandler.cpp
+++ b/core/event_handler/EventHandler.cpp
@@ -400,7 +400,7 @@ LogFileReaderPtr ModifyHandler::CreateLogFileReaderPtr(
 
     // new log
     bool backFlag = false;
-    if (readerPtr->GetRealLogPath().empty() || readerPtr->GetRealLogPath() == readerPtr->GetLogPath()) {
+    if (readerPtr->GetRealLogPath().empty() || readerPtr->GetRealLogPath() == readerPtr->GetHostLogPath()) {
         backFlag = true;
         // if reader is a new file(not from checkpoint), and file is rotate file, reset file pos
         if (readerArray.size() > 0 && !readerPtr->IsFromCheckPoint()) {
@@ -495,7 +495,7 @@ void ModifyHandler::Handle(const Event& event) {
                              "delete event has come, and only one reader exists in the corresponding log queue, and "
                              "the queue header file has been read or is forced to close")(
                                 "project", readerArray[0]->GetProjectName())("logstore", readerArray[0]->GetCategory())(
-                                "config", mConfigName)("log reader queue name", readerArray[0]->GetLogPath())(
+                                "config", mConfigName)("log reader queue name", readerArray[0]->GetHostLogPath())(
                                 "file device", readerArray[0]->GetDevInode().dev)(
                                 "file inode", readerArray[0]->GetDevInode().inode)("file size",
                                                                                    readerArray[0]->GetFileSize()));
@@ -518,7 +518,7 @@ void ModifyHandler::Handle(const Event& event) {
                              "the container has been stopped, and current file has been read or is forced to close")(
                                 "project", reader->GetProjectName())("logstore", reader->GetCategory())(
                                 "config", mConfigName)("log reader queue name",
-                                                       reader->GetLogPath())("file device", reader->GetDevInode().dev)(
+                                                       reader->GetHostLogPath())("file device", reader->GetDevInode().dev)(
                                 "file inode", reader->GetDevInode().inode)("file size", reader->GetFileSize()));
                         // release fd as quick as possible
                         reader->CloseFilePtr();
@@ -543,7 +543,7 @@ void ModifyHandler::Handle(const Event& event) {
                 LogFileReader::FileCompareResult cmpRst = rotatorReader->CompareToFile(logPath);
                 LOG_DEBUG(sLogger,
                           ("find rotator reader", logPath)("compare result", (int)cmpRst)(
-                              rotatorReader->GetLogPath(), rotatorReader->GetRealLogPath())(
+                              rotatorReader->GetHostLogPath(), rotatorReader->GetRealLogPath())(
                               ToString(rotatorReader->GetLastFilePos()), devInode.inode)("this", (uint64_t)this));
                 switch (cmpRst) {
                     case LogFileReader::FileCompareResult_DevInodeChange:
@@ -554,9 +554,9 @@ void ModifyHandler::Handle(const Event& event) {
                         break;
                     case LogFileReader::FileCompareResult_SigSameSizeChange: {
                         rotatorReader->UpdateLogPath(logPath);
-                        LogFileReaderPtrArray& readerArray = mNameReaderMap[rotatorReader->GetLogPathFile()];
+                        LogFileReaderPtrArray& readerArray = mNameReaderMap[rotatorReader->GetHostLogPathFile()];
                         // new log
-                        if (rotatorReader->GetRealLogPath() == rotatorReader->GetLogPath()) {
+                        if (rotatorReader->GetRealLogPath() == rotatorReader->GetHostLogPath()) {
                             readerArray.push_back(rotatorReader);
                         } else {
                             // rotate log, push front
@@ -635,7 +635,7 @@ void ModifyHandler::Handle(const Event& event) {
         while (!reader->UpdateFilePtr()) {
             if (errno == EMFILE) {
                 LOG_WARNING(sLogger,
-                            ("too many open files", "skip this read operation")("log path", reader->GetLogPath()));
+                            ("too many open files", "skip this read operation")("log path", reader->GetHostLogPath()));
                 return;
             }
             // eg: a.log rotate to a.log1, event sequece : a.log write 2min ago, file ptr closed -> a.log rotate a.log1
@@ -648,7 +648,7 @@ void ModifyHandler::Handle(const Event& event) {
                 sLogger,
                 ("open file failed", "move the corresponding reader to the rotator reader pool")(
                     "project", reader->GetProjectName())("logstore", reader->GetCategory())("config", mConfigName)(
-                    "log reader queue name", reader->GetLogPath())("log reader queue size", readerArrayPtr->size() - 1)(
+                    "log reader queue name", reader->GetHostLogPath())("log reader queue size", readerArrayPtr->size() - 1)(
                     "file device", reader->GetDevInode().dev)("file inode", reader->GetDevInode().inode)(
                     "file size", reader->GetFileSize())("rotator reader pool size", mRotatorReaderMap.size() + 1));
             readerArrayPtr->pop_front();
@@ -667,21 +667,21 @@ void ModifyHandler::Handle(const Event& event) {
         // if dev inode changed, delete this reader and create reader
         if (!reader->CheckDevInode()) {
             LOG_INFO(sLogger,
-                     ("file dev inode changed, create new reader. new path", logPath)("old path", reader->GetLogPath())(
+                     ("file dev inode changed, create new reader. new path", logPath)("old path", reader->GetHostLogPath())(
                          ToString(readerArrayPtr->size()), mRotatorReaderMap.size())(
                          ToString(reader->GetDevInode().inode), reader->GetLastFilePos())("DevInode map size",
                                                                                           mDevInodeReaderMap.size()));
             recreateReaderFlag = true;
             LogtailAlarm::GetInstance()->SendAlarm(INNER_PROFILE_ALARM,
                                                    string("file dev inode changed, create new reader. new path:")
-                                                       + reader->GetLogPath() + " ,project:" + reader->GetProjectName()
+                                                       + reader->GetHostLogPath() + " ,project:" + reader->GetProjectName()
                                                        + " ,logstore:" + reader->GetCategory());
         }
         // if signature is different and logpath is different, delete this reader and create reader
-        else if (!reader->CheckFileSignatureAndOffset(fileSize) && logPath != reader->GetLogPath()) {
+        else if (!reader->CheckFileSignatureAndOffset(fileSize) && logPath != reader->GetHostLogPath()) {
             LOG_INFO(sLogger,
                      ("file sig and name both changed, create new reader. new path", logPath)(
-                         "old path", reader->GetLogPath())(ToString(readerArrayPtr->size()), mRotatorReaderMap.size())(
+                         "old path", reader->GetHostLogPath())(ToString(readerArrayPtr->size()), mRotatorReaderMap.size())(
                          ToString(reader->GetDevInode().inode), reader->GetLastFilePos())("DevInode map size",
                                                                                           mDevInodeReaderMap.size()));
             recreateReaderFlag = true;
@@ -690,7 +690,7 @@ void ModifyHandler::Handle(const Event& event) {
             LOG_INFO(sLogger,
                      ("need to recreate reader", "remove the corresponding reader from the log reader queue")(
                          "project", reader->GetProjectName())("logstore", reader->GetCategory())("config", mConfigName)(
-                         "log reader queue name", reader->GetLogPath())(
+                         "log reader queue name", reader->GetHostLogPath())(
                          "log reader queue size", readerArrayPtr->size() - 1)("file device", reader->GetDevInode().dev)(
                          "file inode", reader->GetDevInode().inode)("file size", reader->GetFileSize()));
             readerArrayPtr->pop_front();
@@ -705,7 +705,7 @@ void ModifyHandler::Handle(const Event& event) {
         if (reader->ShouldForceReleaseDeletedFileFd()) {
             LOG_INFO(sLogger,
                      ("force closing the file, project", reader->GetProjectName())("logstore", reader->GetCategory())(
-                         "config", mConfigName)("log reader queue name", reader->GetLogPath())(
+                         "config", mConfigName)("log reader queue name", reader->GetHostLogPath())(
                          "file device", reader->GetDevInode().dev)("file inode", reader->GetDevInode().inode)(
                          "file size", reader->GetFileSize())("last file position", reader->GetLastFilePos()));
             reader->CloseFilePtr();
@@ -719,12 +719,12 @@ void ModifyHandler::Handle(const Event& event) {
                     s_lastOutPutTime = curTime;
                     LOG_WARNING(sLogger,
                                 ("logprocess queue is full, put modify event to event queue again",
-                                 reader->GetLogPath())(reader->GetProjectName(), reader->GetCategory()));
+                                 reader->GetHostLogPath())(reader->GetProjectName(), reader->GetCategory()));
 
                     LogtailAlarm::GetInstance()->SendAlarm(
                         PROCESS_QUEUE_BUSY_ALARM,
                         string("logprocess queue is full, put modify event to event queue again, file:")
-                            + reader->GetLogPath() + " ,project:" + reader->GetProjectName()
+                            + reader->GetHostLogPath() + " ,project:" + reader->GetProjectName()
                             + " ,logstore:" + reader->GetCategory());
                 }
 
@@ -741,7 +741,7 @@ void ModifyHandler::Handle(const Event& event) {
                                                                       reader->GetProjectName(),
                                                                       reader->GetCategory(),
                                                                       reader->GetConvertedPath(),
-                                                                      reader->GetLogPath(),
+                                                                      reader->GetHostLogPath(),
                                                                       reader->GetExtraTags(),
                                                                       reader->GetDevInode().dev,
                                                                       reader->GetDevInode().inode,
@@ -765,7 +765,7 @@ void ModifyHandler::Handle(const Event& event) {
                               "current file has been read, and is marked deleted or the relative container has been "
                               "stopped")("project", reader->GetProjectName())("logstore", reader->GetCategory())(
                                  "config", mConfigName)("log reader queue name",
-                                                        reader->GetLogPath())("file device", reader->GetDevInode().dev)(
+                                                        reader->GetHostLogPath())("file device", reader->GetDevInode().dev)(
                                  "file inode", reader->GetDevInode().inode)("file size", reader->GetFileSize()));
                     reader->CloseFilePtr();
                 }
@@ -815,7 +815,7 @@ void ModifyHandler::Handle(const Event& event) {
                 ("close the file and move the corresponding reader to the rotator reader pool",
                  "current file has been read and more files are waiting in the log reader queue")(
                     "project", reader->GetProjectName())("logstore", reader->GetCategory())("config", mConfigName)(
-                    "log reader queue name", reader->GetLogPath())("log reader queue size", readerArrayPtr->size() - 1)(
+                    "log reader queue name", reader->GetHostLogPath())("log reader queue size", readerArrayPtr->size() - 1)(
                     "file device", reader->GetDevInode().dev)("file inode", reader->GetDevInode().inode)(
                     "file size", reader->GetFileSize())("rotator reader pool size", mRotatorReaderMap.size() + 1));
             reader->CloseFilePtr();
@@ -868,7 +868,7 @@ void ModifyHandler::HandleTimeOut() {
         // donot check file delete flag or close ptr when array size > 1
         if (readerArray.size() > 1) {
             LOG_DEBUG(sLogger,
-                      ("HandleTimeOut filename", readerIter->first)("dir", readerArray[0]->GetLogPath().c_str())(
+                      ("HandleTimeOut filename", readerIter->first)("dir", readerArray[0]->GetHostLogPath().c_str())(
                           "action", "continue")("reason", "reader array size > 1"));
             ++readerIter;
             actioned = true;
@@ -887,7 +887,7 @@ void ModifyHandler::HandleTimeOut() {
                     ("current file is marked deleted with no more readers in the log reader queue for some time",
                      "remove the corresponding reader from the log reader queue")("project", (*iter)->GetProjectName())(
                         "logstore", (*iter)->GetCategory())("config", mConfigName)(
-                        "log reader queue name", (*iter)->GetLogPath())("log reader queue size", 0)(
+                        "log reader queue name", (*iter)->GetHostLogPath())("log reader queue size", 0)(
                         "file device", (*iter)->GetDevInode().dev)("file inode", (*iter)->GetDevInode().inode)(
                         "file size", (*iter)->GetFileSize())("last file position", (*iter)->GetLastFilePos()));
                 mDevInodeReaderMap.erase((*iter)->GetDevInode());
@@ -901,13 +901,13 @@ void ModifyHandler::HandleTimeOut() {
                 ++closeFilePtrCount;
                 actioned = true;
                 LOG_DEBUG(sLogger,
-                          ("HandleTimeOut filename", readerIter->first)("dir", readerArray[0]->GetLogPath().c_str())(
+                          ("HandleTimeOut filename", readerIter->first)("dir", readerArray[0]->GetHostLogPath().c_str())(
                               "action", "close")("reason", "file no new data timeout"));
             }
         }
         if (!actioned && readerArray.size() > 0) {
             LOG_DEBUG(sLogger,
-                      ("HandleTimeOut filename", readerIter->first)("dir", readerArray[0]->GetLogPath().c_str())(
+                      ("HandleTimeOut filename", readerIter->first)("dir", readerArray[0]->GetHostLogPath().c_str())(
                           "action", "continue")("reason", "nothing to do"));
         }
         if (readerArray.empty()) {
@@ -962,7 +962,7 @@ void ModifyHandler::DeleteTimeoutReader(int32_t timeoutInterval) {
                          ("remove the corresponding reader from the log reader queue",
                           "current file has not been updated for a long time")("project", (*iter)->GetProjectName())(
                              "logstore", (*iter)->GetCategory())("config", mConfigName)(
-                             "log reader queue name", (*iter)->GetLogPath())("log reader queue size",
+                             "log reader queue name", (*iter)->GetHostLogPath())("log reader queue size",
                                                                              readerArray.size() - 1)(
                              "file device", (*iter)->GetDevInode().dev)("file inode", (*iter)->GetDevInode().inode)(
                              "file size", (*iter)->GetFileSize())("last file position", (*iter)->GetLastFilePos()));

--- a/core/event_handler/EventHandler.cpp
+++ b/core/event_handler/EventHandler.cpp
@@ -741,6 +741,7 @@ void ModifyHandler::Handle(const Event& event) {
                                                                       reader->GetProjectName(),
                                                                       reader->GetCategory(),
                                                                       reader->GetConvertedPath(),
+                                                                      reader->GetLogPath(),
                                                                       reader->GetExtraTags(),
                                                                       reader->GetDevInode().dev,
                                                                       reader->GetDevInode().inode,

--- a/core/processor/LogProcess.cpp
+++ b/core/processor/LogProcess.cpp
@@ -606,7 +606,7 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
                                                              sendFailures,
                                                              errorLine);
             LOG_DEBUG(sLogger,
-                      ("project", projectName)("logstore", category)("filename", logPath)("realFilename", hostLogPath)("read_bytes", readBytes)(
+                      ("project", projectName)("logstore", category)("filename", logPath)("hostFilename", hostLogPath)("read_bytes", readBytes)(
                           "line_feed", lineFeed)("split_lines", splitLines)("parse_failures", parseFailures)(
                           "parse_time_failures", parseTimeFailures)("regex_match_failures", regexMatchFailures)(
                           "history_failures", historyFailures));

--- a/core/processor/LogProcess.cpp
+++ b/core/processor/LogProcess.cpp
@@ -282,9 +282,11 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
             s_processBytes += (logBuffer->bufferSize);
             LogFileReaderPtr logFileReader = logBuffer->logFileReader;
             auto logPath = logFileReader->GetConvertedPath();
+            auto realLogPath = logFileReader->GetLogPath();
 #if defined(_MSC_VER)
             if (BOOL_FLAG(enable_chinese_tag_path)) {
                 logPath = EncodingConverter::GetInstance()->FromACPToUTF8(logPath);
+                realLogPath = EncodingConverter::GetInstance()->FromACPToUTF8(realLogPath);
             }
 #endif
 
@@ -592,6 +594,7 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
                                                              projectName,
                                                              category,
                                                              logPath,
+                                                             realLogPath,
                                                              logFileReader->GetExtraTags(),
                                                              readBytes,
                                                              skipBytes,
@@ -603,7 +606,7 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
                                                              sendFailures,
                                                              errorLine);
             LOG_DEBUG(sLogger,
-                      ("project", projectName)("logstore", category)("filename", logPath)("read_bytes", readBytes)(
+                      ("project", projectName)("logstore", category)("filename", logPath)("realFilename", realLogPath)("read_bytes", readBytes)(
                           "line_feed", lineFeed)("split_lines", splitLines)("parse_failures", parseFailures)(
                           "parse_time_failures", parseTimeFailures)("regex_match_failures", regexMatchFailures)(
                           "history_failures", historyFailures));

--- a/core/processor/LogProcess.cpp
+++ b/core/processor/LogProcess.cpp
@@ -281,11 +281,11 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
             s_processCount++;
             s_processBytes += (logBuffer->bufferSize);
             LogFileReaderPtr logFileReader = logBuffer->logFileReader;
-            auto logPath = logFileReader->GetConvertedPath();
+            auto convertedPath = logFileReader->GetConvertedPath();
             auto hostLogPath = logFileReader->GetHostLogPath();
 #if defined(_MSC_VER)
             if (BOOL_FLAG(enable_chinese_tag_path)) {
-                logPath = EncodingConverter::GetInstance()->FromACPToUTF8(logPath);
+                convertedPath = EncodingConverter::GetInstance()->FromACPToUTF8(convertedPath);
                 hostLogPath = EncodingConverter::GetInstance()->FromACPToUTF8(hostLogPath);
             }
 #endif
@@ -321,7 +321,7 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
                     passingTags.append(TAG_PREFIX)
                         .append(LOG_RESERVED_KEY_PATH)
                         .append(TAG_SEPARATOR)
-                        .append(logPath.substr(0, 511));
+                        .append(convertedPath.substr(0, 511));
 
                     std::string userDefinedId = ConfigManager::GetInstance()->GetUserDefinedIdSet();
                     if (!userDefinedId.empty()) {
@@ -388,14 +388,14 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
                     if (LogtailAlarm::GetInstance()->IsLowLevelAlarmValid()) {
                         LogtailAlarm::GetInstance()->SendAlarm(
                             SPLIT_LOG_FAIL_ALARM,
-                            "split log lines fail, please check log_begin_regex, file:" + logPath
+                            "split log lines fail, please check log_begin_regex, file:" + convertedPath
                                 + ", logs:" + string(buffer, 0, 1024),
                             projectName,
                             category,
                             config->mRegion);
                     }
                     LOG_ERROR(sLogger,
-                              ("split log lines fail", "please check log_begin_regex")("file_name", logPath)(
+                              ("split log lines fail", "please check log_begin_regex")("file_name", convertedPath)(
                                   "read bytes", readBytes)("first 1KB log", string(buffer, 0, 1024)));
                 }
                 // if not discard unmatch data, we add whole data block when data splitted fail
@@ -496,7 +496,7 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
                     logTagPtr->set_value(LogFileProfiler::mHostname.substr(0, 99));
                     logTagPtr = logGroup.add_logtags();
                     logTagPtr->set_key(LOG_RESERVED_KEY_PATH);
-                    logTagPtr->set_value(logPath.substr(0, 511));
+                    logTagPtr->set_value(convertedPath.substr(0, 511));
 
                     // zone info for ant
                     const std::string& alipayZone = AppConfig::GetInstance()->GetAlipayZone();
@@ -575,7 +575,7 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
                                                   config->mMergeType,
                                                   (uint32_t)(logGroupSize * DOUBLE_FLAG(loggroup_bytes_inflation)),
                                                   "",
-                                                  logPath,
+                                                  convertedPath,
                                                   context)) {
                         LogtailAlarm::GetInstance()->SendAlarm(DISCARD_DATA_ALARM,
                                                                "push file data into batch map fail",
@@ -584,7 +584,7 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
                                                                config->mRegion);
                         LOG_ERROR(sLogger,
                                   ("push file data into batch map fail, discard logs", logGroup.logs_size())(
-                                      "project", projectName)("logstore", category)("filename", logPath));
+                                      "project", projectName)("logstore", category)("filename", convertedPath));
                     }
                 }
             }
@@ -593,7 +593,7 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
                                                              config->mRegion,
                                                              projectName,
                                                              category,
-                                                             logPath,
+                                                             convertedPath,
                                                              hostLogPath,
                                                              logFileReader->GetExtraTags(),
                                                              readBytes,
@@ -606,7 +606,7 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
                                                              sendFailures,
                                                              errorLine);
             LOG_DEBUG(sLogger,
-                      ("project", projectName)("logstore", category)("filename", logPath)("hostFilename", hostLogPath)("read_bytes", readBytes)(
+                      ("project", projectName)("logstore", category)("filename", convertedPath)("hostFilename", hostLogPath)("read_bytes", readBytes)(
                           "line_feed", lineFeed)("split_lines", splitLines)("parse_failures", parseFailures)(
                           "parse_time_failures", parseTimeFailures)("regex_match_failures", regexMatchFailures)(
                           "history_failures", historyFailures));

--- a/core/processor/LogProcess.cpp
+++ b/core/processor/LogProcess.cpp
@@ -282,11 +282,11 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
             s_processBytes += (logBuffer->bufferSize);
             LogFileReaderPtr logFileReader = logBuffer->logFileReader;
             auto logPath = logFileReader->GetConvertedPath();
-            auto realLogPath = logFileReader->GetLogPath();
+            auto hostLogPath = logFileReader->GetLogPath();
 #if defined(_MSC_VER)
             if (BOOL_FLAG(enable_chinese_tag_path)) {
                 logPath = EncodingConverter::GetInstance()->FromACPToUTF8(logPath);
-                realLogPath = EncodingConverter::GetInstance()->FromACPToUTF8(realLogPath);
+                hostLogPath = EncodingConverter::GetInstance()->FromACPToUTF8(hostLogPath);
             }
 #endif
 
@@ -594,7 +594,7 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
                                                              projectName,
                                                              category,
                                                              logPath,
-                                                             realLogPath,
+                                                             hostLogPath,
                                                              logFileReader->GetExtraTags(),
                                                              readBytes,
                                                              skipBytes,
@@ -606,7 +606,7 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
                                                              sendFailures,
                                                              errorLine);
             LOG_DEBUG(sLogger,
-                      ("project", projectName)("logstore", category)("filename", logPath)("realFilename", realLogPath)("read_bytes", readBytes)(
+                      ("project", projectName)("logstore", category)("filename", logPath)("realFilename", hostLogPath)("read_bytes", readBytes)(
                           "line_feed", lineFeed)("split_lines", splitLines)("parse_failures", parseFailures)(
                           "parse_time_failures", parseTimeFailures)("regex_match_failures", regexMatchFailures)(
                           "history_failures", historyFailures));

--- a/core/processor/LogProcess.cpp
+++ b/core/processor/LogProcess.cpp
@@ -282,7 +282,7 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
             s_processBytes += (logBuffer->bufferSize);
             LogFileReaderPtr logFileReader = logBuffer->logFileReader;
             auto logPath = logFileReader->GetConvertedPath();
-            auto hostLogPath = logFileReader->GetLogPath();
+            auto hostLogPath = logFileReader->GetHostLogPath();
 #if defined(_MSC_VER)
             if (BOOL_FLAG(enable_chinese_tag_path)) {
                 logPath = EncodingConverter::GetInstance()->FromACPToUTF8(logPath);

--- a/core/profiler/LogFileProfiler.cpp
+++ b/core/profiler/LogFileProfiler.cpp
@@ -81,9 +81,11 @@ bool LogFileProfiler::GetProfileData(LogGroup& logGroup, LogStoreStatistic* stat
     contentPtr = logPtr->add_contents();
     contentPtr->set_key("file_name");
     contentPtr->set_value(statistic->mFilename.empty() ? "logstore_statistics" : statistic->mFilename);
-    contentPtr = logPtr->add_contents();
-    contentPtr->set_key("host_file_name");
-    contentPtr->set_value(statistic->mHostFilename.empty() ? "logstore_statistics" : statistic->mHostFilename);
+    if (!statistic->mHostFilename.empty()) {
+        contentPtr = logPtr->add_contents();
+        contentPtr->set_key("host_file_name");
+        contentPtr->set_value(statistic->mHostFilename);
+    }
     contentPtr = logPtr->add_contents();
     contentPtr->set_key("logtail_version");
     contentPtr->set_value(ILOGTAIL_VERSION);
@@ -278,7 +280,7 @@ void LogFileProfiler::AddProfilingData(const std::string& configName,
                                        uint64_t historyFailures,
                                        uint64_t sendFailures,
                                        const std::string& errorLine) {
-    if (!filename.empty()) {
+    if (!hostFilename.empty()) {
         // logstore statistics
         AddProfilingData(configName,
                          region,
@@ -315,7 +317,7 @@ void LogFileProfiler::AddProfilingData(const std::string& configName,
         (iter->second)->mLastUpdateTime = time(NULL);
     } else {
         LogStoreStatistic* statistic = NULL;
-        if (filename.empty()) {
+        if (hostFilename.empty()) {
             std::vector<sls_logs::LogTag> empty;
             statistic = new LogStoreStatistic(configName,
                                                 projectName,
@@ -361,7 +363,7 @@ void LogFileProfiler::AddProfilingSkipBytes(const std::string& configName,
                                             const std::string& hostFilename,
                                             const std::vector<sls_logs::LogTag>& tags,
                                             uint64_t skipBytes) {
-    if (!filename.empty()) {
+    if (!hostFilename.empty()) {
         // logstore statistics
         AddProfilingSkipBytes(configName, region, projectName, category, "", "", tags, skipBytes);
     }
@@ -374,7 +376,7 @@ void LogFileProfiler::AddProfilingSkipBytes(const std::string& configName,
         (iter->second)->mLastUpdateTime = time(NULL);
     } else {
         LogStoreStatistic* statistic = NULL;
-        if (filename.empty()) {
+        if (hostFilename.empty()) {
             std::vector<sls_logs::LogTag> empty;
             statistic = new LogStoreStatistic(configName, projectName, category, filename, hostFilename, empty);
         } else {
@@ -397,7 +399,7 @@ void LogFileProfiler::AddProfilingReadBytes(const std::string& configName,
                                             uint64_t fileSize,
                                             uint64_t readOffset,
                                             int32_t lastReadTime) {
-    if (!filename.empty()) {
+    if (!hostFilename.empty()) {
         // logstore statistics
         AddProfilingReadBytes(
             configName, region, projectName, category, "", "", tags, dev, inode, fileSize, readOffset, lastReadTime);
@@ -410,7 +412,7 @@ void LogFileProfiler::AddProfilingReadBytes(const std::string& configName,
         (iter->second)->UpdateReadInfo(dev, inode, fileSize, readOffset, lastReadTime);
     } else {
         LogStoreStatistic* statistic = NULL;
-        if (filename.empty()) {
+        if (hostFilename.empty()) {
             std::vector<sls_logs::LogTag> empty;
             statistic = new LogStoreStatistic(configName, projectName, category, filename, hostFilename, empty);
         } else {

--- a/core/profiler/LogFileProfiler.cpp
+++ b/core/profiler/LogFileProfiler.cpp
@@ -80,11 +80,11 @@ bool LogFileProfiler::GetProfileData(LogGroup& logGroup, LogStoreStatistic* stat
     contentPtr->set_value(statistic->mConfigName);
     contentPtr = logPtr->add_contents();
     contentPtr->set_key("file_name");
-    contentPtr->set_value(statistic->mFilename.empty() ? "logstore_statistics" : statistic->mFilename);
-    if (!statistic->mHostFilename.empty()) {
+    contentPtr->set_value(statistic->mConvertedPath.empty() ? "logstore_statistics" : statistic->mConvertedPath);
+    if (!statistic->mHostLogPath.empty()) {
         contentPtr = logPtr->add_contents();
-        contentPtr->set_key("host_file_name");
-        contentPtr->set_value(statistic->mHostFilename);
+        contentPtr->set_key("host_log_path");
+        contentPtr->set_value(statistic->mHostLogPath);
     }
     contentPtr = logPtr->add_contents();
     contentPtr->set_key("logtail_version");
@@ -157,7 +157,7 @@ bool LogFileProfiler::GetProfileData(LogGroup& logGroup, LogStoreStatistic* stat
     }
 
     // get logstore send info
-    if (statistic->mFilename.empty()) {
+    if (statistic->mHostLogPath.empty()) {
         LogstoreFeedBackKey fbKey = GenerateLogstoreFeedBackKey(statistic->mProjectName, statistic->mCategory);
         LogstoreSenderStatistics senderStatistics = Sender::Instance()->GetSenderStatistics(fbKey);
 
@@ -260,16 +260,16 @@ void LogFileProfiler::SendProfileData(bool forceSend) {
 }
 
 
-// 1. when in container, filename is the file path in container, hostFilename is the file path on host.
-//    eg. /home/admin/access.log in container, filename = "/home/admin/access.log", hostFilename="/logtail_host/xxx/home/admin/access.log".
-//    so hostFilename is unique.
-// 2. On host, filename = hostFilename.
+// 1. when in container, convertedPath is the file path in container, hostLogPath is the file path on host.
+//    eg. /home/admin/access.log in container, convertedPath = "/home/admin/access.log", hostLogPath="/logtail_host/xxx/home/admin/access.log".
+//    so hostLogPath is unique.
+// 2. On host, convertedPath = hostLogPath.
 void LogFileProfiler::AddProfilingData(const std::string& configName,
                                        const std::string& region,
                                        const std::string& projectName,
                                        const std::string& category,
-                                       const std::string& filename,
-                                       const std::string& hostFilename,
+                                       const std::string& convertedPath,
+                                       const std::string& hostLogPath,
                                        const std::vector<sls_logs::LogTag>& tags,
                                        uint64_t readBytes,
                                        uint64_t skipBytes,
@@ -280,7 +280,7 @@ void LogFileProfiler::AddProfilingData(const std::string& configName,
                                        uint64_t historyFailures,
                                        uint64_t sendFailures,
                                        const std::string& errorLine) {
-    if (!hostFilename.empty()) {
+    if (!hostLogPath.empty()) {
         // logstore statistics
         AddProfilingData(configName,
                          region,
@@ -299,7 +299,7 @@ void LogFileProfiler::AddProfilingData(const std::string& configName,
                          sendFailures,
                          "");
     }
-    string key = projectName + "_" + category + "_" + configName + "_" + hostFilename;
+    string key = projectName + "_" + category + "_" + configName + "_" + hostLogPath;
     std::lock_guard<std::mutex> lock(mStatisticLock);
     LogstoreSenderStatisticsMap& statisticsMap = *MakesureRegionStatisticsMapUnlocked(region);
     std::unordered_map<string, LogStoreStatistic*>::iterator iter = statisticsMap.find(key);
@@ -317,13 +317,13 @@ void LogFileProfiler::AddProfilingData(const std::string& configName,
         (iter->second)->mLastUpdateTime = time(NULL);
     } else {
         LogStoreStatistic* statistic = NULL;
-        if (hostFilename.empty()) {
+        if (hostLogPath.empty()) {
             std::vector<sls_logs::LogTag> empty;
             statistic = new LogStoreStatistic(configName,
                                                 projectName,
                                                 category,
-                                                filename,
-                                                hostFilename,
+                                                convertedPath,
+                                                hostLogPath,
                                                 empty,
                                                 readBytes,
                                                 skipBytes,
@@ -338,8 +338,8 @@ void LogFileProfiler::AddProfilingData(const std::string& configName,
             statistic = new LogStoreStatistic(configName,
                                                 projectName,
                                                 category,
-                                                filename,
-                                                hostFilename,
+                                                convertedPath,
+                                                hostLogPath,
                                                 tags,
                                                 readBytes,
                                                 skipBytes,
@@ -359,15 +359,15 @@ void LogFileProfiler::AddProfilingSkipBytes(const std::string& configName,
                                             const std::string& region,
                                             const std::string& projectName,
                                             const std::string& category,
-                                            const std::string& filename,
-                                            const std::string& hostFilename,
+                                            const std::string& convertedPath,
+                                            const std::string& hostLogPath,
                                             const std::vector<sls_logs::LogTag>& tags,
                                             uint64_t skipBytes) {
-    if (!hostFilename.empty()) {
+    if (!hostLogPath.empty()) {
         // logstore statistics
         AddProfilingSkipBytes(configName, region, projectName, category, "", "", tags, skipBytes);
     }
-    string key = projectName + "_" + category + "_" + configName + "_" + hostFilename;
+    string key = projectName + "_" + category + "_" + configName + "_" + hostLogPath;
     std::lock_guard<std::mutex> lock(mStatisticLock);
     LogstoreSenderStatisticsMap& statisticsMap = *MakesureRegionStatisticsMapUnlocked(region);
     std::unordered_map<string, LogStoreStatistic*>::iterator iter = statisticsMap.find(key);
@@ -376,11 +376,11 @@ void LogFileProfiler::AddProfilingSkipBytes(const std::string& configName,
         (iter->second)->mLastUpdateTime = time(NULL);
     } else {
         LogStoreStatistic* statistic = NULL;
-        if (hostFilename.empty()) {
+        if (hostLogPath.empty()) {
             std::vector<sls_logs::LogTag> empty;
-            statistic = new LogStoreStatistic(configName, projectName, category, filename, hostFilename, empty);
+            statistic = new LogStoreStatistic(configName, projectName, category, convertedPath, hostLogPath, empty);
         } else {
-            statistic = new LogStoreStatistic(configName, projectName, category, filename, hostFilename, tags);
+            statistic = new LogStoreStatistic(configName, projectName, category, convertedPath, hostLogPath, tags);
         }
         statistic->mSkipBytes += skipBytes;
         statisticsMap.insert(std::pair<string, LogStoreStatistic*>(key, statistic));
@@ -391,20 +391,20 @@ void LogFileProfiler::AddProfilingReadBytes(const std::string& configName,
                                             const std::string& region,
                                             const std::string& projectName,
                                             const std::string& category,
-                                            const std::string& filename,
-                                            const std::string& hostFilename,
+                                            const std::string& convertedPath,
+                                            const std::string& hostLogPath,
                                             const std::vector<sls_logs::LogTag>& tags,
                                             uint64_t dev,
                                             uint64_t inode,
                                             uint64_t fileSize,
                                             uint64_t readOffset,
                                             int32_t lastReadTime) {
-    if (!hostFilename.empty()) {
+    if (!hostLogPath.empty()) {
         // logstore statistics
         AddProfilingReadBytes(
             configName, region, projectName, category, "", "", tags, dev, inode, fileSize, readOffset, lastReadTime);
     }
-    string key = projectName + "_" + category + "_" + configName + "_" + hostFilename;
+    string key = projectName + "_" + category + "_" + configName + "_" + hostLogPath;
     std::lock_guard<std::mutex> lock(mStatisticLock);
     LogstoreSenderStatisticsMap& statisticsMap = *MakesureRegionStatisticsMapUnlocked(region);
     std::unordered_map<string, LogStoreStatistic*>::iterator iter = statisticsMap.find(key);
@@ -412,11 +412,11 @@ void LogFileProfiler::AddProfilingReadBytes(const std::string& configName,
         (iter->second)->UpdateReadInfo(dev, inode, fileSize, readOffset, lastReadTime);
     } else {
         LogStoreStatistic* statistic = NULL;
-        if (hostFilename.empty()) {
+        if (hostLogPath.empty()) {
             std::vector<sls_logs::LogTag> empty;
-            statistic = new LogStoreStatistic(configName, projectName, category, filename, hostFilename, empty);
+            statistic = new LogStoreStatistic(configName, projectName, category, convertedPath, hostLogPath, empty);
         } else {
-            statistic = new LogStoreStatistic(configName, projectName, category, filename, hostFilename, tags);
+            statistic = new LogStoreStatistic(configName, projectName, category, convertedPath, hostLogPath, tags);
         }
         statistic->UpdateReadInfo(dev, inode, fileSize, readOffset, lastReadTime);
         statisticsMap.insert(std::pair<string, LogStoreStatistic*>(key, statistic));
@@ -530,8 +530,8 @@ void LogFileProfiler::UpdateDumpData(const sls_logs::LogGroup& logGroup, Json::V
 #ifdef APSARA_UNIT_TEST_MAIN
 uint64_t LogFileProfiler::GetProfilingLines(const std::string& projectName,
                                             const std::string& category,
-                                            const std::string& filename) {
-    std::string key = projectName + "_" + category + "_" + filename;
+                                            const std::string& convertedPath) {
+    std::string key = projectName + "_" + category + "_" + convertedPath;
     std::lock_guard<std::mutex> lock(mStatisticLock);
     if (mAllStatisticsMap.size() != (size_t)1) {
         return 0;

--- a/core/profiler/LogFileProfiler.cpp
+++ b/core/profiler/LogFileProfiler.cpp
@@ -82,8 +82,8 @@ bool LogFileProfiler::GetProfileData(LogGroup& logGroup, LogStoreStatistic* stat
     contentPtr->set_key("file_name");
     contentPtr->set_value(statistic->mFilename.empty() ? "logstore_statistics" : statistic->mFilename);
     contentPtr = logPtr->add_contents();
-    contentPtr->set_key("real_file_name");
-    contentPtr->set_value(statistic->mRealFilename.empty() ? "logstore_statistics" : statistic->mRealFilename);
+    contentPtr->set_key("host_file_name");
+    contentPtr->set_value(statistic->mHostFilename.empty() ? "logstore_statistics" : statistic->mHostFilename);
     contentPtr = logPtr->add_contents();
     contentPtr->set_key("logtail_version");
     contentPtr->set_value(ILOGTAIL_VERSION);
@@ -262,7 +262,7 @@ void LogFileProfiler::AddProfilingData(const std::string& configName,
                                        const std::string& projectName,
                                        const std::string& category,
                                        const std::string& filename,
-                                       const std::string& realFilename,
+                                       const std::string& hostFilename,
                                        const std::vector<sls_logs::LogTag>& tags,
                                        uint64_t readBytes,
                                        uint64_t skipBytes,
@@ -292,7 +292,7 @@ void LogFileProfiler::AddProfilingData(const std::string& configName,
                          sendFailures,
                          "");
     }
-    string key = projectName + "_" + category + "_" + configName + "_" + realFilename;
+    string key = projectName + "_" + category + "_" + configName + "_" + hostFilename;
     std::lock_guard<std::mutex> lock(mStatisticLock);
     LogstoreSenderStatisticsMap& statisticsMap = *MakesureRegionStatisticsMapUnlocked(region);
     std::unordered_map<string, LogStoreStatistic*>::iterator iter = statisticsMap.find(key);
@@ -316,7 +316,7 @@ void LogFileProfiler::AddProfilingData(const std::string& configName,
                                                 projectName,
                                                 category,
                                                 filename,
-                                                realFilename,
+                                                hostFilename,
                                                 empty,
                                                 readBytes,
                                                 skipBytes,
@@ -332,7 +332,7 @@ void LogFileProfiler::AddProfilingData(const std::string& configName,
                                                 projectName,
                                                 category,
                                                 filename,
-                                                realFilename,
+                                                hostFilename,
                                                 tags,
                                                 readBytes,
                                                 skipBytes,
@@ -353,14 +353,14 @@ void LogFileProfiler::AddProfilingSkipBytes(const std::string& configName,
                                             const std::string& projectName,
                                             const std::string& category,
                                             const std::string& filename,
-                                            const std::string& realFilename,
+                                            const std::string& hostFilename,
                                             const std::vector<sls_logs::LogTag>& tags,
                                             uint64_t skipBytes) {
     if (!filename.empty()) {
         // logstore statistics
         AddProfilingSkipBytes(configName, region, projectName, category, "", "", tags, skipBytes);
     }
-    string key = projectName + "_" + category + "_" + configName + "_" + realFilename;
+    string key = projectName + "_" + category + "_" + configName + "_" + hostFilename;
     std::lock_guard<std::mutex> lock(mStatisticLock);
     LogstoreSenderStatisticsMap& statisticsMap = *MakesureRegionStatisticsMapUnlocked(region);
     std::unordered_map<string, LogStoreStatistic*>::iterator iter = statisticsMap.find(key);
@@ -371,9 +371,9 @@ void LogFileProfiler::AddProfilingSkipBytes(const std::string& configName,
         LogStoreStatistic* statistic = NULL;
         if (filename.empty()) {
             std::vector<sls_logs::LogTag> empty;
-            statistic = new LogStoreStatistic(configName, projectName, category, filename, realFilename, empty);
+            statistic = new LogStoreStatistic(configName, projectName, category, filename, hostFilename, empty);
         } else {
-            statistic = new LogStoreStatistic(configName, projectName, category, filename, realFilename, tags);
+            statistic = new LogStoreStatistic(configName, projectName, category, filename, hostFilename, tags);
         }
         statistic->mSkipBytes += skipBytes;
         statisticsMap.insert(std::pair<string, LogStoreStatistic*>(key, statistic));
@@ -385,7 +385,7 @@ void LogFileProfiler::AddProfilingReadBytes(const std::string& configName,
                                             const std::string& projectName,
                                             const std::string& category,
                                             const std::string& filename,
-                                            const std::string& realFilename,
+                                            const std::string& hostFilename,
                                             const std::vector<sls_logs::LogTag>& tags,
                                             uint64_t dev,
                                             uint64_t inode,
@@ -397,7 +397,7 @@ void LogFileProfiler::AddProfilingReadBytes(const std::string& configName,
         AddProfilingReadBytes(
             configName, region, projectName, category, "", "", tags, dev, inode, fileSize, readOffset, lastReadTime);
     }
-    string key = projectName + "_" + category + "_" + configName + "_" + realFilename;
+    string key = projectName + "_" + category + "_" + configName + "_" + hostFilename;
     std::lock_guard<std::mutex> lock(mStatisticLock);
     LogstoreSenderStatisticsMap& statisticsMap = *MakesureRegionStatisticsMapUnlocked(region);
     std::unordered_map<string, LogStoreStatistic*>::iterator iter = statisticsMap.find(key);
@@ -407,9 +407,9 @@ void LogFileProfiler::AddProfilingReadBytes(const std::string& configName,
         LogStoreStatistic* statistic = NULL;
         if (filename.empty()) {
             std::vector<sls_logs::LogTag> empty;
-            statistic = new LogStoreStatistic(configName, projectName, category, filename, realFilename, empty);
+            statistic = new LogStoreStatistic(configName, projectName, category, filename, hostFilename, empty);
         } else {
-            statistic = new LogStoreStatistic(configName, projectName, category, filename, realFilename, tags);
+            statistic = new LogStoreStatistic(configName, projectName, category, filename, hostFilename, tags);
         }
         statistic->UpdateReadInfo(dev, inode, fileSize, readOffset, lastReadTime);
         statisticsMap.insert(std::pair<string, LogStoreStatistic*>(key, statistic));

--- a/core/profiler/LogFileProfiler.cpp
+++ b/core/profiler/LogFileProfiler.cpp
@@ -257,6 +257,11 @@ void LogFileProfiler::SendProfileData(bool forceSend) {
     mLastSendTime = curTime;
 }
 
+
+// 1. when in container, filename is the file path in container, hostFilename is the file path on host.
+//    eg. /home/admin/access.log in container, filename = "/home/admin/access.log", hostFilename="/logtail_host/xxx/home/admin/access.log".
+//    so hostFilename is unique.
+// 2. On host, filename = hostFilename.
 void LogFileProfiler::AddProfilingData(const std::string& configName,
                                        const std::string& region,
                                        const std::string& projectName,

--- a/core/profiler/LogFileProfiler.h
+++ b/core/profiler/LogFileProfiler.h
@@ -46,6 +46,7 @@ public:
                           const std::string& projectName,
                           const std::string& category,
                           const std::string& filename,
+                          const std::string& realFilename,
                           const std::vector<sls_logs::LogTag>& tags,
                           uint64_t readBytes,
                           uint64_t skipBytes,
@@ -61,6 +62,7 @@ public:
                                const std::string& projectName,
                                const std::string& category,
                                const std::string& filename,
+                               const std::string& realFilename,
                                const std::vector<sls_logs::LogTag>& tags,
                                uint64_t skipBytes);
 
@@ -69,6 +71,7 @@ public:
                                const std::string& projectName,
                                const std::string& category,
                                const std::string& filename,
+                               const std::string& realFilename,
                                const std::vector<sls_logs::LogTag>& tags,
                                uint64_t dev,
                                uint64_t inode,
@@ -98,6 +101,7 @@ private:
                           const std::string& projectName,
                           const std::string& category,
                           const std::string& filename,
+                          const std::string& realFilename,
                           const std::vector<sls_logs::LogTag>& tags,
                           uint64_t readBytes = 0,
                           uint64_t skipBytes = 0,
@@ -112,6 +116,7 @@ private:
               mProjectName(projectName),
               mCategory(category),
               mFilename(filename),
+              mRealFilename(realFilename),
               mTags(tags),
               mReadBytes(readBytes),
               mSkipBytes(skipBytes),
@@ -166,6 +171,7 @@ private:
         std::string mProjectName;
         std::string mCategory;
         std::string mFilename;
+        std::string mRealFilename;
         std::vector<sls_logs::LogTag> mTags;
         // how many bytes processed
         uint64_t mReadBytes;

--- a/core/profiler/LogFileProfiler.h
+++ b/core/profiler/LogFileProfiler.h
@@ -46,7 +46,7 @@ public:
                           const std::string& projectName,
                           const std::string& category,
                           const std::string& filename,
-                          const std::string& realFilename,
+                          const std::string& hostFilename,
                           const std::vector<sls_logs::LogTag>& tags,
                           uint64_t readBytes,
                           uint64_t skipBytes,
@@ -62,7 +62,7 @@ public:
                                const std::string& projectName,
                                const std::string& category,
                                const std::string& filename,
-                               const std::string& realFilename,
+                               const std::string& hostFilename,
                                const std::vector<sls_logs::LogTag>& tags,
                                uint64_t skipBytes);
 
@@ -71,7 +71,7 @@ public:
                                const std::string& projectName,
                                const std::string& category,
                                const std::string& filename,
-                               const std::string& realFilename,
+                               const std::string& host,
                                const std::vector<sls_logs::LogTag>& tags,
                                uint64_t dev,
                                uint64_t inode,
@@ -101,7 +101,7 @@ private:
                           const std::string& projectName,
                           const std::string& category,
                           const std::string& filename,
-                          const std::string& realFilename,
+                          const std::string& hostFilename,
                           const std::vector<sls_logs::LogTag>& tags,
                           uint64_t readBytes = 0,
                           uint64_t skipBytes = 0,
@@ -116,7 +116,7 @@ private:
               mProjectName(projectName),
               mCategory(category),
               mFilename(filename),
-              mRealFilename(realFilename),
+              mHostFilename(hostFilename),
               mTags(tags),
               mReadBytes(readBytes),
               mSkipBytes(skipBytes),
@@ -171,7 +171,7 @@ private:
         std::string mProjectName;
         std::string mCategory;
         std::string mFilename;
-        std::string mRealFilename;
+        std::string mHostFilename;
         std::vector<sls_logs::LogTag> mTags;
         // how many bytes processed
         uint64_t mReadBytes;

--- a/core/profiler/LogFileProfiler.h
+++ b/core/profiler/LogFileProfiler.h
@@ -45,8 +45,8 @@ public:
                           const std::string& region,
                           const std::string& projectName,
                           const std::string& category,
-                          const std::string& filename,
-                          const std::string& hostFilename,
+                          const std::string& convertedPath,
+                          const std::string& hostLogPath,
                           const std::vector<sls_logs::LogTag>& tags,
                           uint64_t readBytes,
                           uint64_t skipBytes,
@@ -61,8 +61,8 @@ public:
                                const std::string& region,
                                const std::string& projectName,
                                const std::string& category,
-                               const std::string& filename,
-                               const std::string& hostFilename,
+                               const std::string& convertedPath,
+                               const std::string& hostLogPath,
                                const std::vector<sls_logs::LogTag>& tags,
                                uint64_t skipBytes);
 
@@ -70,7 +70,7 @@ public:
                                const std::string& region,
                                const std::string& projectName,
                                const std::string& category,
-                               const std::string& filename,
+                               const std::string& convertedPath,
                                const std::string& host,
                                const std::vector<sls_logs::LogTag>& tags,
                                uint64_t dev,
@@ -100,8 +100,8 @@ private:
         LogStoreStatistic(const std::string& configName,
                           const std::string& projectName,
                           const std::string& category,
-                          const std::string& filename,
-                          const std::string& hostFilename,
+                          const std::string& convertedPath,
+                          const std::string& hostLogPath,
                           const std::vector<sls_logs::LogTag>& tags,
                           uint64_t readBytes = 0,
                           uint64_t skipBytes = 0,
@@ -115,8 +115,8 @@ private:
             : mConfigName(configName),
               mProjectName(projectName),
               mCategory(category),
-              mFilename(filename),
-              mHostFilename(hostFilename),
+              mConvertedPath(convertedPath),
+              mHostLogPath(hostLogPath),
               mTags(tags),
               mReadBytes(readBytes),
               mSkipBytes(skipBytes),
@@ -170,8 +170,8 @@ private:
         std::string mConfigName;
         std::string mProjectName;
         std::string mCategory;
-        std::string mFilename;
-        std::string mHostFilename;
+        std::string mConvertedPath;
+        std::string mHostLogPath;
         std::vector<sls_logs::LogTag> mTags;
         // how many bytes processed
         uint64_t mReadBytes;

--- a/core/reader/DelimiterLogFileReader.cpp
+++ b/core/reader/DelimiterLogFileReader.cpp
@@ -30,8 +30,8 @@ const std::string DelimiterLogFileReader::s_mDiscardedFieldKey = "_";
 
 DelimiterLogFileReader::DelimiterLogFileReader(const std::string& projectName,
                                                const std::string& category,
-                                               const std::string& logPathDir,
-                                               const std::string& logPathFile,
+                                               const std::string& hostLogPathDir,
+                                               const std::string& hostLogPathFile,
                                                int32_t tailLimit,
                                                const std::string& timeFormat,
                                                const std::string& topicFormat,
@@ -46,8 +46,8 @@ DelimiterLogFileReader::DelimiterLogFileReader(const std::string& projectName,
                                                bool extractPartialFields)
     : LogFileReader(projectName,
                     category,
-                    logPathDir,
-                    logPathFile,
+                    hostLogPathDir,
+                    hostLogPathFile,
                     tailLimit,
                     topicFormat,
                     groupTopic,
@@ -159,7 +159,7 @@ bool DelimiterLogFileReader::ParseLogLine(const char* buffer,
                             ("parse delimiter log fail, keys count unmatch "
                              "columns count, parsed",
                              parsedColCount)("required", mColumnKeys.size())("log", buffer)("project", mProjectName)(
-                                "logstore", mCategory)("file", mLogPath));
+                                "logstore", mCategory)("file", mHostLogPath));
                 LogtailAlarm::GetInstance()->SendAlarm(PARSE_LOG_FAIL_ALARM,
                                                        string("keys count unmatch columns count :")
                                                            + ToString(parsedColCount) + ", required:"
@@ -182,7 +182,7 @@ bool DelimiterLogFileReader::ParseLogLine(const char* buffer,
                                              mProjectName,
                                              mCategory,
                                              mRegion,
-                                             mLogPath,
+                                             mHostLogPath,
                                              error,
                                              mTzOffsetSecond)) {
                     parseSuccess = false;
@@ -204,7 +204,7 @@ bool DelimiterLogFileReader::ParseLogLine(const char* buffer,
             PARSE_LOG_FAIL_ALARM, "no column keys defined", mProjectName, mCategory, mRegion);
         LOG_WARNING(sLogger,
                     ("parse delimiter log fail",
-                     "no column keys defined")("project", mProjectName)("logstore", mCategory)("file", mLogPath));
+                     "no column keys defined")("project", mProjectName)("logstore", mCategory)("file", mHostLogPath));
         error = PARSE_LOG_FORMAT_ERROR;
         parseSuccess = false;
     }

--- a/core/reader/DelimiterLogFileReader.h
+++ b/core/reader/DelimiterLogFileReader.h
@@ -27,8 +27,8 @@ class DelimiterLogFileReader : public LogFileReader {
 public:
     DelimiterLogFileReader(const std::string& projectName,
                            const std::string& category,
-                           const std::string& logPathDir,
-                           const std::string& logPathFile,
+                           const std::string& hostLogPathDir,
+                           const std::string& hostLogPathFile,
                            int32_t tailLimit,
                            const std::string& timeFormat,
                            const std::string& topicFormat,

--- a/core/reader/JsonLogFileReader.cpp
+++ b/core/reader/JsonLogFileReader.cpp
@@ -28,8 +28,8 @@ using namespace std;
 
 JsonLogFileReader::JsonLogFileReader(const std::string& projectName,
                                      const std::string& category,
-                                     const std::string& logPathDir,
-                                     const std::string& logPathFile,
+                                     const std::string& hostLogPathDir,
+                                     const std::string& hostLogPathFile,
                                      int32_t tailLimit,
                                      const std::string& timeFormat,
                                      const std::string& topicFormat,
@@ -39,8 +39,8 @@ JsonLogFileReader::JsonLogFileReader(const std::string& projectName,
                                      bool dockerFileFlag)
     : LogFileReader(projectName,
                     category,
-                    logPathDir,
-                    logPathFile,
+                    hostLogPathDir,
+                    hostLogPathFile,
                     tailLimit,
                     topicFormat,
                     groupTopic,
@@ -83,7 +83,7 @@ bool JsonLogFileReader::ParseLogLine(const char* buffer,
             LOG_WARNING(sLogger,
                         ("parse json log fail, log",
                          buffer)("rapidjson offset", doc.GetErrorOffset())("rapidjson error", doc.GetParseError())(
-                            "project", mProjectName)("logstore", mCategory)("file", mLogPath));
+                            "project", mProjectName)("logstore", mCategory)("file", mHostLogPath));
             LogtailAlarm::GetInstance()->SendAlarm(
                 PARSE_LOG_FAIL_ALARM, string("parse json fail:") + string(buffer), mProjectName, mCategory, mRegion);
         }
@@ -93,7 +93,7 @@ bool JsonLogFileReader::ParseLogLine(const char* buffer,
         if (LogtailAlarm::GetInstance()->IsLowLevelAlarmValid()) {
             LOG_WARNING(
                 sLogger,
-                ("invalid json object, log", buffer)("project", mProjectName)("logstore", mCategory)("file", mLogPath));
+                ("invalid json object, log", buffer)("project", mProjectName)("logstore", mCategory)("file", mHostLogPath));
             LogtailAlarm::GetInstance()->SendAlarm(PARSE_LOG_FAIL_ALARM,
                                                    string("invalid json object:") + string(buffer),
                                                    mProjectName,
@@ -117,7 +117,7 @@ bool JsonLogFileReader::ParseLogLine(const char* buffer,
                                          mProjectName,
                                          mCategory,
                                          mRegion,
-                                         mLogPath,
+                                         mHostLogPath,
                                          error,
                                          mTzOffsetSecond)) {
                 parseSuccess = false;
@@ -128,7 +128,7 @@ bool JsonLogFileReader::ParseLogLine(const char* buffer,
             if (LogtailAlarm::GetInstance()->IsLowLevelAlarmValid()) {
                 LOG_WARNING(sLogger,
                             ("parse json log fail, log", buffer)("invalid time key", mTimeKey)("project", mProjectName)(
-                                "logstore", mCategory)("file", mLogPath));
+                                "logstore", mCategory)("file", mHostLogPath));
                 LogtailAlarm::GetInstance()->SendAlarm(PARSE_LOG_FAIL_ALARM,
                                                        string("found no time_key: ") + mTimeKey
                                                            + ", log:" + string(buffer),
@@ -261,7 +261,7 @@ bool JsonLogFileReader::FindJsonMatch(
     if (idx == size || buffer[idx] != '{') {
         LOG_DEBUG(sLogger,
                   ("invalid json begining", buffer + beginIdx)("project", mProjectName)("logstore",
-                                                                                        mCategory)("file", mLogPath));
+                                                                                        mCategory)("file", mHostLogPath));
         startWithBlock = false;
         return false;
     }
@@ -282,7 +282,7 @@ bool JsonLogFileReader::FindJsonMatch(
                     LOG_WARNING(
                         sLogger,
                         ("brace count", braceCount)("brace not match, invalid json begining", buffer + beginIdx)(
-                            "project", mProjectName)("logstore", mCategory)("file", mLogPath));
+                            "project", mProjectName)("logstore", mCategory)("file", mHostLogPath));
                     return false;
                 }
                 break;
@@ -304,6 +304,6 @@ bool JsonLogFileReader::FindJsonMatch(
     }
     LOG_DEBUG(sLogger,
               ("find no match, beginIdx", beginIdx)("idx", idx)("project", mProjectName)("logstore",
-                                                                                         mCategory)("file", mLogPath));
+                                                                                         mCategory)("file", mHostLogPath));
     return false;
 }

--- a/core/reader/JsonLogFileReader.h
+++ b/core/reader/JsonLogFileReader.h
@@ -27,8 +27,8 @@ class JsonLogFileReader : public LogFileReader {
 public:
     JsonLogFileReader(const std::string& projectName,
                       const std::string& category,
-                      const std::string& logPathDir,
-                      const std::string& logPathFile,
+                      const std::string& hostLogPathDir,
+                      const std::string& hostLogPathFile,
                       int32_t tailLimit,
                       const std::string& timeFormat,
                       const std::string& topicFormat,

--- a/core/reader/LogFileReader.cpp
+++ b/core/reader/LogFileReader.cpp
@@ -66,28 +66,28 @@ DEFINE_FLAG_INT32(force_release_deleted_file_fd_timeout,
 namespace logtail {
 
 #define COMMON_READER_INFO \
-    ("project", mProjectName)("logstore", mCategory)("config", mConfigName)("log reader queue name", mLogPath)( \
+    ("project", mProjectName)("logstore", mCategory)("config", mConfigName)("log reader queue name", mHostLogPath)( \
         "file device", mDevInode.dev)("file inode", mDevInode.inode)("file signature", mLastFileSignatureHash)
 
 size_t LogFileReader::BUFFER_SIZE = 1024 * 512; // 512KB
 
 void LogFileReader::DumpMetaToMem(bool checkConfigFlag) {
     if (checkConfigFlag) {
-        size_t index = mLogPath.rfind(PATH_SEPARATOR);
-        if (index == string::npos || index == mLogPath.size() - 1) {
+        size_t index = mHostLogPath.rfind(PATH_SEPARATOR);
+        if (index == string::npos || index == mHostLogPath.size() - 1) {
             LOG_INFO(sLogger,
                      ("skip dump reader meta", "invalid log reader queue name")("project", mProjectName)(
-                         "logstore", mCategory)("config", mConfigName)("log reader queue name", mLogPath)(
+                         "logstore", mCategory)("config", mConfigName)("log reader queue name", mHostLogPath)(
                          "file device", ToString(mDevInode.dev))("file inode", ToString(mDevInode.inode))("file signature",
                                                                                       mLastFileSignatureHash));
             return;
         }
-        string dirPath = mLogPath.substr(0, index);
-        string fileName = mLogPath.substr(index + 1, mLogPath.size() - index - 1);
+        string dirPath = mHostLogPath.substr(0, index);
+        string fileName = mHostLogPath.substr(index + 1, mHostLogPath.size() - index - 1);
         if (ConfigManager::GetInstance()->FindBestMatch(dirPath, fileName) == NULL) {
             LOG_INFO(sLogger,
                      ("skip dump reader meta", "no config matches the file path")("project", mProjectName)(
-                         "logstore", mCategory)("config", mConfigName)("log reader queue name", mLogPath)(
+                         "logstore", mCategory)("config", mConfigName)("log reader queue name", mHostLogPath)(
                          "file device", ToString(mDevInode.dev))("file inode", ToString(mDevInode.inode))("file signature",
                                                                                       mLastFileSignatureHash));
             return;
@@ -95,11 +95,11 @@ void LogFileReader::DumpMetaToMem(bool checkConfigFlag) {
         LOG_INFO(
             sLogger,
             ("dump log reader meta, project", mProjectName)("logstore", mCategory)("config", mConfigName)(
-                "log reader queue name", mLogPath)("file device", ToString(mDevInode.dev))("file inode", ToString(mDevInode.inode))(
+                "log reader queue name", mHostLogPath)("file device", ToString(mDevInode.dev))("file inode", ToString(mDevInode.inode))(
                 "file signature", mLastFileSignatureHash)("real file path", mRealLogPath)("file size", mLastFileSize)(
                 "last file position", mLastFilePos)("is file opened", ToString(mLogFileOp.IsOpen())));
     }
-    CheckPoint* checkPointPtr = new CheckPoint(mLogPath,
+    CheckPoint* checkPointPtr = new CheckPoint(mHostLogPath,
                                                mLastFilePos,
                                                mLastFileSignatureSize,
                                                mLastFileSignatureHash,
@@ -135,7 +135,7 @@ bool LogFileReader::ShouldForceReleaseDeletedFileFd() {
 }
 
 void LogFileReader::InitReader(bool tailExisted, FileReadPolicy policy, uint32_t eoConcurrency) {
-    string buffer = LogFileProfiler::mIpAddr + "_" + mLogPath + "_" + CalculateRandomUUID();
+    string buffer = LogFileProfiler::mIpAddr + "_" + mHostLogPath + "_" + CalculateRandomUUID();
     uint64_t cityHash = CityHash64(buffer.c_str(), buffer.size());
     mSourceId = ToHexString(cityHash);
 
@@ -154,7 +154,7 @@ void LogFileReader::InitReader(bool tailExisted, FileReadPolicy policy, uint32_t
             LOG_INFO(
                 sLogger,
                 ("recover log reader status from checkpoint, project", mProjectName)("logstore", mCategory)(
-                    "config", mConfigName)("log reader queue name", mLogPath)("file device", ToString(mDevInode.dev))(
+                    "config", mConfigName)("log reader queue name", mHostLogPath)("file device", ToString(mDevInode.dev))(
                     "file inode", ToString(mDevInode.inode))("file signature", mLastFileSignatureHash)(
                     "real file path", mRealLogPath)("file size", mLastFileSize)("last file position", mLastFilePos));
             // check if we should skip first modify
@@ -233,8 +233,8 @@ void LogFileReader::initExactlyOnce(uint32_t concurrency) {
         primaryCpt.set_sig_hash(mLastFileSignatureHash);
         primaryCpt.set_sig_size(mLastFileSignatureSize);
         primaryCpt.set_config_name(mConfigName);
-        primaryCpt.set_log_path(mLogPath);
-        primaryCpt.set_real_path(mRealLogPath.empty() ? mLogPath : mRealLogPath);
+        primaryCpt.set_log_path(mHostLogPath);
+        primaryCpt.set_real_path(mRealLogPath.empty() ? mHostLogPath : mRealLogPath);
         primaryCpt.set_dev(mDevInode.dev);
         primaryCpt.set_inode(mDevInode.inode);
         detail::updatePrimaryCheckpoint(mEOOption->primaryCheckpointKey, primaryCpt, "all (new)");
@@ -411,8 +411,8 @@ void LogFileReader::updatePrimaryCheckpointRealPath() {
 
 LogFileReader::LogFileReader(const string& projectName,
                              const string& category,
-                             const string& logPathDir,
-                             const std::string& logPathFile,
+                             const string& hostLogPathDir,
+                             const std::string& hostLogPathFile,
                              int32_t tailLimit,
                              bool discardUnmatch,
                              bool dockerFileFlag) {
@@ -420,8 +420,8 @@ LogFileReader::LogFileReader(const string& projectName,
     mProjectName = projectName;
     mCategory = category;
     mTopicName = "";
-    mLogPathFile = logPathFile;
-    mLogPath = PathJoin(logPathDir, logPathFile);
+    mHostLogPathFile = hostLogPathFile;
+    mHostLogPath = PathJoin(hostLogPathDir, hostLogPathFile);
     mTailLimit = tailLimit;
     mLastFilePos = 0;
     mLastFileSize = 0;
@@ -449,8 +449,8 @@ LogFileReader::LogFileReader(const string& projectName,
 
 LogFileReader::LogFileReader(const std::string& projectName,
                              const std::string& category,
-                             const std::string& logPathDir,
-                             const std::string& logPathFile,
+                             const std::string& hostLogPathDir,
+                             const std::string& hostLogPathFile,
                              int32_t tailLimit,
                              const std::string& topicFormat,
                              const std::string& groupTopic,
@@ -460,8 +460,8 @@ LogFileReader::LogFileReader(const std::string& projectName,
     mFirstWatched = true;
     mProjectName = projectName;
     mCategory = category;
-    mLogPathFile = logPathFile;
-    mLogPath = PathJoin(logPathDir, logPathFile);
+    mHostLogPathFile = hostLogPathFile;
+    mHostLogPath = PathJoin(hostLogPathDir, hostLogPathFile);
     mTailLimit = tailLimit;
     mLastFilePos = 0;
     mLastFileSize = 0;
@@ -475,7 +475,7 @@ LogFileReader::LogFileReader(const std::string& projectName,
     } else if (lowerConfig == "group_topic")
         mTopicName = groupTopic;
     else if (!dockerFileFlag) // if docker file, wait for reset topic format
-        mTopicName = GetTopicName(topicFormat, mLogPath);
+        mTopicName = GetTopicName(topicFormat, mHostLogPath);
     mFileEncoding = fileEncoding;
     mLogBeginRegPtr = NULL;
     mDiscardUnmatch = discardUnmatch;
@@ -500,14 +500,14 @@ LogFileReader::LogFileReader(const std::string& projectName,
 }
 
 void LogFileReader::SetDockerPath(const std::string& dockerBasePath, size_t dockerReplaceSize) {
-    if (dockerReplaceSize > (size_t)0 && mLogPath.size() > dockerReplaceSize && !dockerBasePath.empty()) {
+    if (dockerReplaceSize > (size_t)0 && mHostLogPath.size() > dockerReplaceSize && !dockerBasePath.empty()) {
         if (dockerBasePath.size() == (size_t)1) {
-            mDockerPath = mLogPath.substr(dockerReplaceSize);
+            mDockerPath = mHostLogPath.substr(dockerReplaceSize);
         } else {
-            mDockerPath = dockerBasePath + mLogPath.substr(dockerReplaceSize);
+            mDockerPath = dockerBasePath + mHostLogPath.substr(dockerReplaceSize);
         }
 
-        LOG_DEBUG(sLogger, ("convert docker file path", "")("host path", mLogPath)("docker path", mDockerPath));
+        LOG_DEBUG(sLogger, ("convert docker file path", "")("host path", mHostLogPath)("docker path", mDockerPath));
     }
 }
 
@@ -516,7 +516,7 @@ void LogFileReader::SetReadFromBeginning() {
     mLastReadPos = 0;
     LOG_INFO(sLogger,
              ("force reading file from the beginning, project", mProjectName)("logstore", mCategory)(
-                 "config", mConfigName)("log reader queue name", mLogPath)("file device", ToString(mDevInode.dev))(
+                 "config", mConfigName)("log reader queue name", mHostLogPath)("file device", ToString(mDevInode.dev))(
                  "file inode", ToString(mDevInode.inode))("file signature", mLastFileSignatureHash)("file size",
                                                                                                     mLastFileSize));
     mFirstWatched = false;
@@ -709,23 +709,23 @@ bool LogFileReader::CheckForFirstOpen(FileReadPolicy policy) {
     // we just want to set file pos, then a TEMPORARY object for LogFileOperator is needed here, not a class member
     // LogFileOperator we should open file via UpdateFilePtr, then start reading
     LogFileOperator op;
-    op.Open(mLogPath.c_str(), mIsFuseMode);
+    op.Open(mHostLogPath.c_str(), mIsFuseMode);
     if (op.IsOpen() == false) {
         mLastFilePos = 0;
         mLastReadPos = 0;
         LOG_INFO(sLogger,
                  ("force reading file from the beginning",
                   "open file failed when trying to find the start position for reading")("project", mProjectName)(
-                     "logstore", mCategory)("config", mConfigName)("log reader queue name", mLogPath)(
+                     "logstore", mCategory)("config", mConfigName)("log reader queue name", mHostLogPath)(
                      "file device", ToString(mDevInode.dev))("file inode", ToString(mDevInode.inode))(
                      "file signature", mLastFileSignatureHash)("file size", mLastFileSize));
         auto error = GetErrno();
         if (fsutil::Dir::IsENOENT(error))
             return true;
         else {
-            LOG_ERROR(sLogger, ("open log file fail", mLogPath)("errno", ErrnoToString(error)));
+            LOG_ERROR(sLogger, ("open log file fail", mHostLogPath)("errno", ErrnoToString(error)));
             LogtailAlarm::GetInstance()->SendAlarm(OPEN_LOGFILE_FAIL_ALARM,
-                                                   string("Failed to open log file: ") + mLogPath
+                                                   string("Failed to open log file: ") + mHostLogPath
                                                        + "; errono:" + ErrnoToString(error),
                                                    mProjectName,
                                                    mCategory,
@@ -746,12 +746,12 @@ bool LogFileReader::CheckForFirstOpen(FileReadPolicy policy) {
         mLastFilePos = 0;
         mLastReadPos = 0;
     } else {
-        LOG_ERROR(sLogger, ("invalid file read policy for file", mLogPath));
+        LOG_ERROR(sLogger, ("invalid file read policy for file", mHostLogPath));
         return false;
     }
     LOG_INFO(sLogger,
              ("set the starting position for reading, project", mProjectName)("logstore", mCategory)(
-                 "config", mConfigName)("log reader queue name", mLogPath)("file device", ToString(mDevInode.dev))(
+                 "config", mConfigName)("log reader queue name", mHostLogPath)("file device", ToString(mDevInode.dev))(
                  "file inode", ToString(mDevInode.inode))("file signature", mLastFileSignatureHash)("start position",
                                                                                                     mLastFilePos));
     return true;
@@ -804,7 +804,7 @@ void LogFileReader::FixLastFilePos(LogFileOperator& op, int64_t endOffset) {
     LOG_WARNING(sLogger,
                 ("no begin line found", "most likely to have parse error when reading begins")("project", mProjectName)(
                     "logstore", mCategory)("config", mConfigName)("log reader queue name",
-                                                                  mLogPath)("file device", ToString(mDevInode.dev))(
+                                                                  mHostLogPath)("file device", ToString(mDevInode.dev))(
                     "file inode", ToString(mDevInode.inode))("file signature", mLastFileSignatureHash)(
                     "search start position", mLastFilePos)("search end position", mLastFilePos + readSizeReal));
 
@@ -967,7 +967,7 @@ bool LogFileReader::ReadLog(LogBuffer*& logBuffer) {
     if (mLogFileOp.IsOpen() == false) {
         if (!ShouldForceReleaseDeletedFileFd()) {
             // should never happen
-            LOG_ERROR(sLogger, ("unknow error, log file not open", mLogPath));
+            LOG_ERROR(sLogger, ("unknow error, log file not open", mHostLogPath));
         }
         return false;
     }
@@ -1029,29 +1029,29 @@ bool LogFileReader::ReadLog(LogBuffer*& logBuffer) {
 void LogFileReader::OnOpenFileError() {
     switch (errno) {
         case ENOENT:
-            LOG_DEBUG(sLogger, ("log file not exist, probably caused by rollback", mLogPath));
+            LOG_DEBUG(sLogger, ("log file not exist, probably caused by rollback", mHostLogPath));
             break;
         case EACCES:
-            LOG_ERROR(sLogger, ("open log file fail because of permission", mLogPath));
+            LOG_ERROR(sLogger, ("open log file fail because of permission", mHostLogPath));
             LogtailAlarm::GetInstance()->SendAlarm(LOGFILE_PERMINSSION_ALARM,
-                                                   string("Failed to open log file because of permission: ") + mLogPath,
+                                                   string("Failed to open log file because of permission: ") + mHostLogPath,
                                                    mProjectName,
                                                    mCategory,
                                                    mRegion);
             break;
         case EMFILE:
-            LOG_ERROR(sLogger, ("too many open file", mLogPath));
+            LOG_ERROR(sLogger, ("too many open file", mHostLogPath));
             LogtailAlarm::GetInstance()->SendAlarm(OPEN_LOGFILE_FAIL_ALARM,
                                                    string("Failed to open log file because of : Too many open files")
-                                                       + mLogPath,
+                                                       + mHostLogPath,
                                                    mProjectName,
                                                    mCategory,
                                                    mRegion);
             break;
         default:
-            LOG_ERROR(sLogger, ("open log file fail", mLogPath)("errno", ErrnoToString(GetErrno())));
+            LOG_ERROR(sLogger, ("open log file fail", mHostLogPath)("errno", ErrnoToString(GetErrno())));
             LogtailAlarm::GetInstance()->SendAlarm(OPEN_LOGFILE_FAIL_ALARM,
-                                                   string("Failed to open log file: ") + mLogPath
+                                                   string("Failed to open log file: ") + mHostLogPath
                                                        + "; errono:" + ErrnoToString(GetErrno()),
                                                    mProjectName,
                                                    mCategory,
@@ -1076,9 +1076,9 @@ bool LogFileReader::UpdateFilePtr() {
         if (GloablFileDescriptorManager::GetInstance()->GetOpenedFilePtrSize() > INT32_FLAG(max_reader_open_files)) {
             LOG_ERROR(sLogger,
                       ("log file reader fd limit, too many open files",
-                       mLogPath)(mProjectName, mCategory)("limit", INT32_FLAG(max_reader_open_files)));
+                       mHostLogPath)(mProjectName, mCategory)("limit", INT32_FLAG(max_reader_open_files)));
             LogtailAlarm::GetInstance()->SendAlarm(OPEN_FILE_LIMIT_ALARM,
-                                                   string("Failed to open log file: ") + mLogPath
+                                                   string("Failed to open log file: ") + mHostLogPath
                                                        + " limit:" + ToString(INT32_FLAG(max_reader_open_files)),
                                                    mProjectName,
                                                    mCategory,
@@ -1088,7 +1088,7 @@ bool LogFileReader::UpdateFilePtr() {
             return false;
         }
         int32_t tryTime = 0;
-        LOG_DEBUG(sLogger, ("UpdateFilePtr open log file ", mLogPath));
+        LOG_DEBUG(sLogger, ("UpdateFilePtr open log file ", mHostLogPath));
         if (mRealLogPath.size() > 0) {
             while (tryTime++ < 5) {
                 mLogFileOp.Open(mRealLogPath.c_str(), mIsFuseMode);
@@ -1105,7 +1105,7 @@ bool LogFileReader::UpdateFilePtr() {
                 GloablFileDescriptorManager::GetInstance()->OnFileOpen(this);
                 LOG_INFO(sLogger,
                          ("open file succeeded, project", mProjectName)("logstore", mCategory)("config", mConfigName)(
-                             "log reader queue name", mLogPath)("file device", ToString(mDevInode.dev))(
+                             "log reader queue name", mHostLogPath)("file device", ToString(mDevInode.dev))(
                              "file inode", ToString(mDevInode.inode))("file signature", mLastFileSignatureHash)(
                              "real file path", mRealLogPath)("file size", mLastFileSize)("last file position",
                                                                                          mLastFilePos));
@@ -1114,7 +1114,7 @@ bool LogFileReader::UpdateFilePtr() {
                 mLogFileOp.Close();
             }
         }
-        if (mRealLogPath == mLogPath) {
+        if (mRealLogPath == mHostLogPath) {
             LOG_INFO(sLogger,
                      ("log file dev inode changed or file deleted ",
                       "prepare to delete reader or put reader into rotated map")("log path", mRealLogPath));
@@ -1122,7 +1122,7 @@ bool LogFileReader::UpdateFilePtr() {
         }
         tryTime = 0;
         while (tryTime++ < 5) {
-            mLogFileOp.Open(mLogPath.c_str(), mIsFuseMode);
+            mLogFileOp.Open(mHostLogPath.c_str(), mIsFuseMode);
             if (mLogFileOp.IsOpen() == false) {
                 usleep(100);
             } else {
@@ -1131,15 +1131,15 @@ bool LogFileReader::UpdateFilePtr() {
         }
         if (mLogFileOp.IsOpen() == false) {
             OnOpenFileError();
-            LOG_WARNING(sLogger, ("LogFileReader open log file failed", mLogPath));
+            LOG_WARNING(sLogger, ("LogFileReader open log file failed", mHostLogPath));
             return false;
         } else if (CheckDevInode()) {
-            // the mLogPath's dev inode equal to mDevInode, so real log path is mLogPath
-            mRealLogPath = mLogPath;
+            // the mHostLogPath's dev inode equal to mDevInode, so real log path is mHostLogPath
+            mRealLogPath = mHostLogPath;
             GloablFileDescriptorManager::GetInstance()->OnFileOpen(this);
             LOG_INFO(sLogger,
                      ("open file succeeded, project", mProjectName)("logstore", mCategory)("config", mConfigName)(
-                         "log reader queue name", mLogPath)("file device", ToString(mDevInode.dev))(
+                         "log reader queue name", mHostLogPath)("file device", ToString(mDevInode.dev))(
                          "file inode", ToString(mDevInode.inode))("file signature", mLastFileSignatureHash)(
                          "file size", mLastFileSize)("last file position", mLastFilePos));
             return true;
@@ -1147,7 +1147,7 @@ bool LogFileReader::UpdateFilePtr() {
             mLogFileOp.Close();
         }
         LOG_INFO(sLogger,
-                 ("log file dev inode changed or file deleted ", "prepare to delete reader")(mLogPath, mRealLogPath));
+                 ("log file dev inode changed or file deleted ", "prepare to delete reader")(mHostLogPath, mRealLogPath));
         return false;
     }
     return true;
@@ -1164,12 +1164,12 @@ bool LogFileReader::CloseTimeoutFilePtr(int32_t curTime) {
             LOG_INFO(sLogger,
                      ("close the file", "current log file has not been updated for some time and has been read")(
                          "project", mProjectName)("logstore", mCategory)("config", mConfigName)(
-                         "log reader queue name", mLogPath)("file device", ToString(mDevInode.dev))(
+                         "log reader queue name", mHostLogPath)("file device", ToString(mDevInode.dev))(
                          "file inode", ToString(mDevInode.inode))("file signature", mLastFileSignatureHash)(
                          "file size", mLastFileSize)("last file position", mLastFilePos));
             CloseFilePtr();
             // delete item in LogFileCollectOffsetIndicator map
-            LogFileCollectOffsetIndicator::GetInstance()->DeleteItem(mLogPath, mDevInode);
+            LogFileCollectOffsetIndicator::GetInstance()->DeleteItem(mHostLogPath, mDevInode);
             return true;
         }
     }
@@ -1178,9 +1178,9 @@ bool LogFileReader::CloseTimeoutFilePtr(int32_t curTime) {
 
 void LogFileReader::CloseFilePtr() {
     if (mLogFileOp.IsOpen()) {
-        LOG_DEBUG(sLogger, ("start close LogFileReader", mLogPath));
+        LOG_DEBUG(sLogger, ("start close LogFileReader", mHostLogPath));
 
-        // if mLogPath is symbolic link, then we should not update it accrding to /dev/fd/xx
+        // if mHostLogPath is symbolic link, then we should not update it accrding to /dev/fd/xx
         if (!mSymbolicLinkFlag) {
             // retrieve file path from file descriptor in order to open it later
             // this is important when file is moved when rotating
@@ -1188,7 +1188,7 @@ void LogFileReader::CloseFilePtr() {
             if (!curRealLogPath.empty()) {
                 LOG_INFO(sLogger,
                          ("update the real file path of the log reader during closing, project", mProjectName)(
-                             "logstore", mCategory)("config", mConfigName)("log reader queue name", mLogPath)(
+                             "logstore", mCategory)("config", mConfigName)("log reader queue name", mHostLogPath)(
                              "file device", ToString(mDevInode.dev))("file inode", ToString(mDevInode.inode))(
                              "file signature", mLastFileSignatureHash)("original file path",
                                                                        mRealLogPath)("new file path", curRealLogPath));
@@ -1197,7 +1197,7 @@ void LogFileReader::CloseFilePtr() {
                     updatePrimaryCheckpointRealPath();
                 }
             } else {
-                LOG_WARNING(sLogger, ("failed to get real log path", mLogPath));
+                LOG_WARNING(sLogger, ("failed to get real log path", mHostLogPath));
             }
         }
 
@@ -1205,10 +1205,10 @@ void LogFileReader::CloseFilePtr() {
             int fd = mLogFileOp.GetFd();
             LOG_WARNING(
                 sLogger,
-                ("close file ptr error:", mLogPath)("error", strerror(errno))("fd", fd)("inode", mDevInode.inode));
+                ("close file ptr error:", mHostLogPath)("error", strerror(errno))("fd", fd)("inode", mDevInode.inode));
             LogtailAlarm::GetInstance()->SendAlarm(OPEN_LOGFILE_FAIL_ALARM,
                                                    string("close file ptr error because of ") + strerror(errno)
-                                                       + ", file path: " + mLogPath + ", inode: "
+                                                       + ", file path: " + mHostLogPath + ", inode: "
                                                        + ToString(mDevInode.inode) + ", inode: " + ToString(fd),
                                                    mProjectName,
                                                    mCategory,
@@ -1227,10 +1227,10 @@ bool LogFileReader::CheckDevInode() {
     fsutil::PathStat statBuf;
     if (mLogFileOp.Stat(statBuf) != 0) {
         if (errno == ENOENT) {
-            LOG_WARNING(sLogger, ("file deleted ", "unknow error")("path", mLogPath)("fd", mLogFileOp.GetFd()));
+            LOG_WARNING(sLogger, ("file deleted ", "unknow error")("path", mHostLogPath)("fd", mLogFileOp.GetFd()));
         } else {
             LOG_WARNING(sLogger,
-                        ("get file info error, ", strerror(errno))("path", mLogPath)("fd", mLogFileOp.GetFd()));
+                        ("get file info error, ", strerror(errno))("path", mHostLogPath)("fd", mLogFileOp.GetFd()));
         }
         return false;
     } else {
@@ -1244,7 +1244,7 @@ bool LogFileReader::CheckFileSignatureAndOffset(int64_t& fileSize) {
     char firstLine[1025];
     int nbytes = mLogFileOp.Pread(firstLine, 1, 1024, 0);
     if (nbytes < 0) {
-        LOG_ERROR(sLogger, ("fail to read file", mLogPath)("nbytes", nbytes));
+        LOG_ERROR(sLogger, ("fail to read file", mHostLogPath)("nbytes", nbytes));
         return false;
     }
     firstLine[nbytes] = '\0';
@@ -1257,10 +1257,10 @@ bool LogFileReader::CheckFileSignatureAndOffset(int64_t& fileSize) {
         endSize = mLogFileOp.GetFileSize();
         LOG_WARNING(
             sLogger,
-            ("tell error", mLogPath)("inode", mDevInode.inode)("error", strerror(lastErrNo))("reopen", reopenFlag));
+            ("tell error", mHostLogPath)("inode", mDevInode.inode)("error", strerror(lastErrNo))("reopen", reopenFlag));
         LogtailAlarm::GetInstance()->SendAlarm(OPEN_LOGFILE_FAIL_ALARM,
                                                string("tell error because of ") + strerror(lastErrNo) + " file path: "
-                                                   + mLogPath + ", inode : " + ToString(mDevInode.inode),
+                                                   + mHostLogPath + ", inode : " + ToString(mDevInode.inode),
                                                mProjectName,
                                                mCategory,
                                                mRegion);
@@ -1273,7 +1273,7 @@ bool LogFileReader::CheckFileSignatureAndOffset(int64_t& fileSize) {
     mLastFileSize = endSize;
     bool sigCheckRst = CheckAndUpdateSignature(string(firstLine), mLastFileSignatureHash, mLastFileSignatureSize);
     if (!sigCheckRst) {
-        LOG_INFO(sLogger, ("Check file truncate by signature, read from begin", mLogPath));
+        LOG_INFO(sLogger, ("Check file truncate by signature, read from begin", mHostLogPath));
         mLastFilePos = 0;
         if (mEOOption) {
             updatePrimaryCheckpointSignature();
@@ -1286,10 +1286,10 @@ bool LogFileReader::CheckFileSignatureAndOffset(int64_t& fileSize) {
     if (endSize < mLastFilePos) {
         LOG_INFO(sLogger,
                  ("File signature is same but size decrease, read from now fileSize",
-                  mLogPath)(ToString(endSize), ToString(mLastFilePos))(GetProjectName(), GetCategory()));
+                  mHostLogPath)(ToString(endSize), ToString(mLastFilePos))(GetProjectName(), GetCategory()));
 
         LogtailAlarm::GetInstance()->SendAlarm(LOG_TRUNCATE_ALARM,
-                                               mLogPath
+                                               mHostLogPath
                                                    + " signature is same but size decrease, read from now fileSize "
                                                    + ToString(endSize) + " last read pos " + ToString(mLastFilePos),
                                                mProjectName,
@@ -1324,7 +1324,7 @@ void LogFileReader::ResetTopic(const std::string& topicFormat) {
         return;
     } else {
         // only reset file's topic
-        mTopicName = GetTopicName(topicFormat, mLogPath);
+        mTopicName = GetTopicName(topicFormat, mHostLogPath);
     }
 }
 
@@ -1359,7 +1359,7 @@ vector<int32_t> LogFileReader::LogSplit(char* buffer, int32_t size, int32_t& lin
                         if (LogtailAlarm::GetInstance()->IsLowLevelAlarmValid()) {
                             LOG_ERROR(sLogger,
                                     ("regex_match in LogSplit fail, exception",
-                                    exception)("project", mProjectName)("logstore", mCategory)("file", mLogPath));
+                                    exception)("project", mProjectName)("logstore", mCategory)("file", mHostLogPath));
                         }
                         LogtailAlarm::GetInstance()->SendAlarm(REGEX_MATCH_ALARM,
                                                             "regex_match in LogSplit fail:" + exception,
@@ -1391,7 +1391,7 @@ vector<int32_t> LogFileReader::LogSplit(char* buffer, int32_t size, int32_t& lin
             if (LogtailAlarm::GetInstance()->IsLowLevelAlarmValid()) {
                 LOG_ERROR(sLogger,
                           ("regex_match in LogSplit fail, exception",
-                           exception)("project", mProjectName)("logstore", mCategory)("file", mLogPath));
+                           exception)("project", mProjectName)("logstore", mCategory)("file", mHostLogPath));
             }
             LogtailAlarm::GetInstance()->SendAlarm(
                 REGEX_MATCH_ALARM, "regex_match in LogSplit fail:" + exception, mProjectName, mCategory, mRegion);
@@ -1520,12 +1520,12 @@ bool LogFileReader::GetRawData(
         else if (curTime - mReadDelayTime >= INT32_FLAG(read_delay_alarm_duration)) {
             mReadDelayTime = curTime;
             LOG_WARNING(sLogger,
-                        ("read log delay", mLogPath)("fall behind bytes", delta)("file size", fileSize)("read pos",
+                        ("read log delay", mHostLogPath)("fall behind bytes", delta)("file size", fileSize)("read pos",
                                                                                                         mLastFilePos));
             LogtailAlarm::GetInstance()->SendAlarm(
                 READ_LOG_DELAY_ALARM,
                 string("fall behind ") + ToString(delta) + " bytes, file size:" + ToString(fileSize)
-                    + ", now position:" + ToString(mLastFilePos) + ", path:" + mLogPath
+                    + ", now position:" + ToString(mLastFilePos) + ", path:" + mHostLogPath
                     + ", now read log content:" + std::string(bufferptr, *size < 256 ? *size : 256),
                 mProjectName,
                 mCategory,
@@ -1537,13 +1537,13 @@ bool LogFileReader::GetRawData(
     // if delta size > mReadDelaySkipBytes, force set file pos and send alarm
     if (mReadDelaySkipBytes > 0 && delta > mReadDelaySkipBytes) {
         LOG_WARNING(sLogger,
-                    ("read log delay and force set file pos to file size", mLogPath)("fall behind bytes", delta)(
+                    ("read log delay and force set file pos to file size", mHostLogPath)("fall behind bytes", delta)(
                         "skip bytes config", mReadDelaySkipBytes)("file size", fileSize)("read pos", mLastFilePos));
         LogtailAlarm::GetInstance()->SendAlarm(
             READ_LOG_DELAY_ALARM,
             string("force set file pos to file size, fall behind ") + ToString(delta)
                 + " bytes, file size:" + ToString(fileSize) + ", now position:" + ToString(mLastFilePos)
-                + ", path:" + mLogPath + ", now read log content:" + std::string(bufferptr, *size < 256 ? *size : 256),
+                + ", path:" + mHostLogPath + ", now read log content:" + std::string(bufferptr, *size < 256 ? *size : 256),
             mProjectName,
             mCategory,
             mRegion);
@@ -1553,7 +1553,7 @@ bool LogFileReader::GetRawData(
 
     if (mMarkOffsetFlag && *size > 0) {
         fileInfo = new FileInfo(mLogFileOp.GetFd(), mDevInode);
-        fileInfo->filename = mIsFuseMode ? mFuseTrimedFilename : mLogPath;
+        fileInfo->filename = mIsFuseMode ? mFuseTrimedFilename : mHostLogPath;
         fileInfo->offset = mLastFilePos - (int64_t)(*size);
         fileInfo->len = (int64_t)(*size);
         fileInfo->filePos = mLastFilePos;
@@ -1570,11 +1570,11 @@ bool LogFileReader::GetRawData(
             && curTime - mReadStoppedContainerAlarmTime >= INT32_FLAG(logtail_alarm_interval)) {
             mReadStoppedContainerAlarmTime = curTime;
             LOG_WARNING(sLogger,
-                        ("read stopped container file", mLogPath)("stopped time", mContainerStoppedTime)(
+                        ("read stopped container file", mHostLogPath)("stopped time", mContainerStoppedTime)(
                             "file size", fileSize)("read pos", mLastFilePos));
             LogtailAlarm::GetInstance()->SendAlarm(
                 READ_STOPPED_CONTAINER_ALARM,
-                string("path: ") + mLogPath + ", stopped time:" + ToString(mContainerStoppedTime)
+                string("path: ") + mHostLogPath + ", stopped time:" + ToString(mContainerStoppedTime)
                     + ", file size:" + ToString(fileSize) + ", now position:" + ToString(mLastFilePos),
                 mProjectName,
                 mCategory,
@@ -1633,9 +1633,9 @@ void LogFileReader::ReadUTF8(char*& bufferptr, size_t* size, int64_t end, bool& 
 
     if (moreData && nbytes == 0) {
         nbytes = READ_BYTE;
-        LOG_WARNING(sLogger, ("Log is too long and forced to be split at offset: ", mLastFilePos + nbytes)("file: ", mLogPath)("inode: ", mDevInode.inode)("first 1024B log: ", std::string(bufferptr, 1024)));
+        LOG_WARNING(sLogger, ("Log is too long and forced to be split at offset: ", mLastFilePos + nbytes)("file: ", mHostLogPath)("inode: ", mDevInode.inode)("first 1024B log: ", std::string(bufferptr, 1024)));
         std::ostringstream oss;
-        oss << "Log is too long and forced to be split at offset: " << ToString(mLastFilePos + nbytes) << " file: " << mLogPath << " inode: " << ToString(mDevInode.inode) << " first 1024B log: " << std::string(bufferptr, 1024) << std::endl;
+        oss << "Log is too long and forced to be split at offset: " << ToString(mLastFilePos + nbytes) << " file: " << mHostLogPath << " inode: " << ToString(mDevInode.inode) << " first 1024B log: " << std::string(bufferptr, 1024) << std::endl;
         LogtailAlarm::GetInstance()->SendAlarm(
             SPLIT_LOG_FAIL_ALARM,
             oss.str(),
@@ -1730,9 +1730,9 @@ void LogFileReader::ReadGBK(char*& bufferptr, size_t* size, int64_t end, bool& m
     setExactlyOnceCheckpointAfterRead(*size);
     mLastFilePos += readCharCount;
     if (logTooLongSplitFlag) {
-        LOG_WARNING(sLogger, ("Log is too long and forced to be split at offset: ", mLastFilePos)("file: ", mLogPath)("inode: ", mDevInode.inode)("first 1024B log: ", std::string(bufferptr, 1024)));
+        LOG_WARNING(sLogger, ("Log is too long and forced to be split at offset: ", mLastFilePos)("file: ", mHostLogPath)("inode: ", mDevInode.inode)("first 1024B log: ", std::string(bufferptr, 1024)));
         std::ostringstream oss;
-        oss << "Log is too long and forced to be split at offset: " << ToString(mLastFilePos) << " file: " << mLogPath << " inode: " << ToString(mDevInode.inode) << " first 1024B log: " << std::string(bufferptr, 1024) << std::endl;
+        oss << "Log is too long and forced to be split at offset: " << ToString(mLastFilePos) << " file: " << mHostLogPath << " inode: " << ToString(mDevInode.inode) << " first 1024B log: " << std::string(bufferptr, 1024) << std::endl;
         LogtailAlarm::GetInstance()->SendAlarm(
             SPLIT_LOG_FAIL_ALARM,
             oss.str(),
@@ -1757,7 +1757,7 @@ LogFileReader::ReadFile(LogFileOperator& op, void* buf, size_t size, int64_t& of
         nbytes = op.SkipHoleRead(buf, 1, size, &offset);
         if (nbytes < 0) {
             LOG_ERROR(sLogger,
-                      ("SkipHoleRead fail to read log file", mLogPath)("mLastFilePos",
+                      ("SkipHoleRead fail to read log file", mHostLogPath)("mLastFilePos",
                                                                        mLastFilePos)("size", size)("offset", offset));
             return 0;
         }
@@ -1765,10 +1765,10 @@ LogFileReader::ReadFile(LogFileOperator& op, void* buf, size_t size, int64_t& of
             *truncateInfo = new TruncateInfo(oriOffset, offset);
             LOG_INFO(sLogger,
                      ("read fuse file with a hole, size",
-                      offset - oriOffset)("filename", mLogPath)("dev", mDevInode.dev)("inode", mDevInode.inode));
+                      offset - oriOffset)("filename", mHostLogPath)("dev", mDevInode.dev)("inode", mDevInode.inode));
             LogtailAlarm::GetInstance()->SendAlarm(
                 FUSE_FILE_TRUNCATE_ALARM,
-                string("read fuse file with a hole, size: ") + ToString(offset - oriOffset) + " filename: " + mLogPath
+                string("read fuse file with a hole, size: ") + ToString(offset - oriOffset) + " filename: " + mHostLogPath
                     + " dev: " + ToString(mDevInode.dev) + " inode: " + ToString(mDevInode.inode),
                 mProjectName,
                 mCategory,
@@ -1778,7 +1778,7 @@ LogFileReader::ReadFile(LogFileOperator& op, void* buf, size_t size, int64_t& of
         nbytes = op.Pread(buf, 1, size, offset);
         if (nbytes < 0) {
             LOG_ERROR(sLogger,
-                      ("Pread fail to read log file", mLogPath)("mLastFilePos", mLastFilePos)("size", size)("offset",
+                      ("Pread fail to read log file", mHostLogPath)("mLastFilePos", mLastFilePos)("size", size)("offset",
                                                                                                             offset));
             return 0;
         }
@@ -1855,7 +1855,7 @@ LogFileReader::~LogFileReader() {
     }
     LOG_INFO(sLogger,
              ("try to close the file and destruct the corresponding log reader, project",
-              mProjectName)("logstore", mCategory)("config", mConfigName)("log reader queue name", mLogPath)(
+              mProjectName)("logstore", mCategory)("config", mConfigName)("log reader queue name", mHostLogPath)(
                  "file device", ToString(mDevInode.dev))("file inode", ToString(mDevInode.inode))(
                  "file size", mLastFileSize)("file signature", mLastFileSignatureHash)("file size", mLastFileSize)(
                  "last file position", mLastFilePos));
@@ -1879,15 +1879,15 @@ void LogFileReader::UpdateReaderManual() {
     if (mLogFileOp.IsOpen()) {
         mLogFileOp.Close();
     }
-    mLogFileOp.Open(mLogPath.c_str(), mIsFuseMode);
-    mDevInode = GetFileDevInode(mLogPath);
+    mLogFileOp.Open(mHostLogPath.c_str(), mIsFuseMode);
+    mDevInode = GetFileDevInode(mHostLogPath);
 }
 #endif
 
 CommonRegLogFileReader::CommonRegLogFileReader(const std::string& projectName,
                                                const std::string& category,
-                                               const std::string& logPathDir,
-                                               const std::string& logPathFile,
+                                               const std::string& hostLogPathDir,
+                                               const std::string& hostLogPathFile,
                                                int32_t tailLimit,
                                                const std::string& timeFormat,
                                                const std::string& topicFormat,
@@ -1897,8 +1897,8 @@ CommonRegLogFileReader::CommonRegLogFileReader(const std::string& projectName,
                                                bool dockerFileFlag /* = true */)
     : LogFileReader(projectName,
                     category,
-                    logPathDir,
-                    logPathFile,
+                    hostLogPathDir,
+                    hostLogPathFile,
                     tailLimit,
                     topicFormat,
                     groupTopic,
@@ -1961,7 +1961,7 @@ bool CommonRegLogFileReader::ParseLogLine(const char* buffer,
                                                 mSpecifiedYear,
                                                 mProjectName,
                                                 mRegion,
-                                                mLogPath,
+                                                mHostLogPath,
                                                 error,
                                                 logGroupSize,
                                                 mTzOffsetSecond);
@@ -1987,7 +1987,7 @@ bool CommonRegLogFileReader::ParseLogLine(const char* buffer,
                                                     ts.tv_nsec,
                                                     mProjectName,
                                                     mRegion,
-                                                    mLogPath,
+                                                    mHostLogPath,
                                                     error,
                                                     logGroupSize);
             }
@@ -2002,30 +2002,30 @@ bool CommonRegLogFileReader::ParseLogLine(const char* buffer,
 
 ApsaraLogFileReader::ApsaraLogFileReader(const std::string& projectName,
                                          const std::string& category,
-                                         const std::string& logPathDir,
-                                         const std::string& logPathFile,
+                                         const std::string& hostLogPathDir,
+                                         const std::string& hostLogPathFile,
                                          int32_t tailLimit,
                                          const std::string topicFormat,
                                          const std::string& groupTopic,
                                          FileEncoding fileEncoding,
                                          bool discardUnmatch,
                                          bool dockerFileFlag)
-    : LogFileReader(projectName, category, logPathDir, logPathFile, tailLimit, discardUnmatch, dockerFileFlag) {
+    : LogFileReader(projectName, category, hostLogPathDir, hostLogPathFile, tailLimit, discardUnmatch, dockerFileFlag) {
     mLogType = APSARA_LOG;
     const std::string lowerConfig = ToLowerCaseString(topicFormat);
     if (lowerConfig == "none" || lowerConfig == "customized") {
         mTopicName = "";
     } else if (lowerConfig == "default") {
-        size_t pos_dot = mLogPath.rfind("."); // the "." must be founded
-        size_t pos = mLogPath.find("@");
+        size_t pos_dot = mHostLogPath.rfind("."); // the "." must be founded
+        size_t pos = mHostLogPath.find("@");
         if (pos != std::string::npos) {
-            size_t pos_slash = mLogPath.find(PATH_SEPARATOR, pos);
+            size_t pos_slash = mHostLogPath.find(PATH_SEPARATOR, pos);
             if (pos_slash != std::string::npos) {
-                mTopicName = mLogPath.substr(0, pos) + mLogPath.substr(pos_slash, pos_dot - pos_slash);
+                mTopicName = mHostLogPath.substr(0, pos) + mHostLogPath.substr(pos_slash, pos_dot - pos_slash);
             }
         }
         if (mTopicName.empty()) {
-            mTopicName = mLogPath.substr(0, pos_dot);
+            mTopicName = mHostLogPath.substr(0, pos_dot);
         }
         std::string lowTopic = ToLowerCaseString(mTopicName);
         std::string logSuffix = ".log";
@@ -2040,7 +2040,7 @@ ApsaraLogFileReader::ApsaraLogFileReader(const std::string& projectName,
     } else if (lowerConfig == "group_topic")
         mTopicName = groupTopic;
     else
-        mTopicName = GetTopicName(topicFormat, mLogPath);
+        mTopicName = GetTopicName(topicFormat, mHostLogPath);
     mFileEncoding = fileEncoding;
 }
 
@@ -2063,7 +2063,7 @@ bool ApsaraLogFileReader::ParseLogLine(const char* buffer,
                                                   mProjectName,
                                                   mCategory,
                                                   mRegion,
-                                                  mLogPath,
+                                                  mHostLogPath,
                                                   error,
                                                   logGroupSize,
                                                   mTzOffsetSecond,

--- a/core/reader/LogFileReader.h
+++ b/core/reader/LogFileReader.h
@@ -61,8 +61,8 @@ public:
     // for ApsaraLogFileReader
     LogFileReader(const std::string& projectName,
                   const std::string& category,
-                  const std::string& logPathDir,
-                  const std::string& logPathFile,
+                  const std::string& hostLogPathDir,
+                  const std::string& hostLogPathFile,
                   int32_t tailLimit,
                   bool discardUnmatch,
                   bool dockerFileFlag);
@@ -70,8 +70,8 @@ public:
     // for CommonRegLogFileReader, JsonLogFileReader, DelimiterLogFileReader
     LogFileReader(const std::string& projectName,
                   const std::string& category,
-                  const std::string& logPathDir,
-                  const std::string& logPathFile,
+                  const std::string& hostLogPathDir,
+                  const std::string& hostLogPathFile,
                   int32_t tailLimit,
                   const std::string& topicFormat,
                   const std::string& groupTopic,
@@ -119,13 +119,13 @@ public:
 
     std::string GetCategory() const { return mCategory; }
 
-    std::string GetLogPath() const { return mLogPath; }
+    std::string GetHostLogPath() const { return mHostLogPath; }
 
     bool GetSymbolicLinkFlag() const { return mSymbolicLinkFlag; }
 
-    std::string GetConvertedPath() const { return mDockerPath.empty() ? mLogPath : mDockerPath; }
+    std::string GetConvertedPath() const { return mDockerPath.empty() ? mHostLogPath : mDockerPath; }
 
-    std::string GetLogPathFile() const { return mLogPathFile; }
+    std::string GetHostLogPathFile() const { return mHostLogPathFile; }
 
     int64_t GetFileSize() const { return mLastFileSize; }
 
@@ -185,7 +185,7 @@ public:
     bool CheckFileSignatureAndOffset(int64_t& fileSize);
 
     void UpdateLogPath(const std::string& filePath) {
-        if (mLogPath == filePath) {
+        if (mHostLogPath == filePath) {
             return;
         }
         mRealLogPath = filePath;
@@ -334,8 +334,8 @@ protected:
     std::string mRegion;
     std::string mCategory;
     std::string mConfigName;
-    std::string mLogPath;
-    std::string mLogPathFile;
+    std::string mHostLogPath;
+    std::string mHostLogPathFile;
     std::string mRealLogPath; // real log path
     bool mSymbolicLinkFlag = false;
     std::string mSourceId;
@@ -445,7 +445,7 @@ private:
         std::string key;
         key.append(mConfigName)
             .append("-")
-            .append(mLogPath)
+            .append(mHostLogPath)
             .append("-")
             .append(std::to_string(mDevInode.dev))
             .append("-")
@@ -537,8 +537,8 @@ class CommonRegLogFileReader : public LogFileReader {
 public:
     CommonRegLogFileReader(const std::string& projectName,
                            const std::string& category,
-                           const std::string& logPathDir,
-                           const std::string& logPathFile,
+                           const std::string& hostLogPathDir,
+                           const std::string& hostLogPathFile,
                            int32_t tailLimit,
                            const std::string& timeFormat,
                            const std::string& topicFormat,
@@ -573,8 +573,8 @@ class ApsaraLogFileReader : public LogFileReader {
 public:
     ApsaraLogFileReader(const std::string& projectName,
                         const std::string& category,
-                        const std::string& logPathDir,
-                        const std::string& logPathFile,
+                        const std::string& hostLogPathDir,
+                        const std::string& hostLogPathFile,
                         int32_t tailLimit,
                         const std::string topicFormat,
                         const std::string& groupTopic = "",

--- a/core/unittest/reader/DeletedFileUnittest.cpp
+++ b/core/unittest/reader/DeletedFileUnittest.cpp
@@ -25,17 +25,17 @@ namespace logtail {
 class DeletedFileUnittest : public ::testing::Test {
 public:
     void SetUp() override {
-        logPathDir = ".";
-        logPathFile = "DeletedFileUnittest.txt";
+        hostLogPathDir = ".";
+        hostLogPathFile = "DeletedFileUnittest.txt";
         reader.reset(new CommonRegLogFileReader(
-            "testProject", "testLogstore", logPathDir, logPathFile, 0, "%Y-%m-%d %H:%M:%S", ""));
+            "testProject", "testLogstore", hostLogPathDir, hostLogPathFile, 0, "%Y-%m-%d %H:%M:%S", ""));
     }
     void TearDown() override { INT32_FLAG(force_release_deleted_file_fd_timeout) = -1; }
     void TestShouldForceReleaseDeletedFileFdDeleted();
     void TestShouldForceReleaseDeletedFileFdStopped();
     LogFileReaderPtr reader;
-    std::string logPathDir;
-    std::string logPathFile;
+    std::string hostLogPathDir;
+    std::string hostLogPathFile;
 };
 
 void DeletedFileUnittest::TestShouldForceReleaseDeletedFileFdDeleted() {


### PR DESCRIPTION
AddProfilingData使用的key是projectName + "_" + category + "_" + configName + "_" + filename

之前filename使用的是：std::string GetConvertedPath() const { return mDockerPath.empty() ? mLogPath : mDockerPath; }
容器场景下，比如用户配置的是容器内的，/home/log/123.log，GetConvertedPath返回的是/home/log/123.log，这样在容器重启之后，filename是不变的，导致统计的时候，上一个容器的统计仍在累加。

修改之后，filename使用的是mLogPath，为采集的真实路径，容器重启之后，AddProfilingData的key会变化，会重新统计