### PR TITLE
Optimizing reader release strategy

### DIFF
--- a/core/event_handler/EventHandler.cpp
+++ b/core/event_handler/EventHandler.cpp
@@ -38,7 +38,7 @@ using namespace sls_logs;
 DEFINE_FLAG_INT64(read_file_time_slice, "microseconds", 50 * 1000);
 DEFINE_FLAG_INT32(logreader_timeout_interval,
                   "reader hasn't updated for a long time will be removed, seconds",
-                  86400 * 30);
+                  86400 * 30000); // roughly equivalent to not releasing logReader when timed out
 DEFINE_FLAG_INT32(cookie_timeout_interval,
                   "rotate cookie hasn't updated for a long time will be removed, seconds",
                   1800);


### PR DESCRIPTION
目前，超过30天没有变化的文件，Reader会被删除，导致其下次有更新时会被认为是新文件。
因此存在一些更新间隔很长的日志文件，每次更新日志都会出现重复采集的问题。
本pr间接解除了超时删除Reader的逻辑来解决此问题