### PR TITLE
refine container info code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,4 @@ your changes, such as:
 - [public] [both] [added] add new plugin: processor_log_to_sls_metric
 - [public] [both] [fixed] fix service_go_profile nil panic
 - [public] [both] [fixed] service_prometheus support scale in kubernetes
+- [public] [both] [fixed] logtail containers monitor refine code

--- a/core/config_manager/ConfigManagerBase.cpp
+++ b/core/config_manager/ConfigManagerBase.cpp
@@ -313,7 +313,6 @@ void ConfigManagerBase::UpdatePluginStats(const Json::Value& config) {
                             && config["plugin"][*it][i]["detail"]["CollectContainersFlag"].isBool()
                             && config["plugin"][*it][i]["detail"]["CollectContainersFlag"].asBool()) {
                                 stats["inner_function"].insert("collect_containers_meta");
-                            }
                         }
                     }
                 }

--- a/core/config_manager/ConfigManagerBase.cpp
+++ b/core/config_manager/ConfigManagerBase.cpp
@@ -308,9 +308,10 @@ void ConfigManagerBase::UpdatePluginStats(const Json::Value& config) {
                     std::string type = config["plugin"][*it][i]["type"].asString();
                     stats[*it].insert(type);
                     if (type == "service_docker_stdout") {
-                        if (config["plugin"][*it][i].isMember("detail") && config["plugin"][*it][i]["detail"].isObject()) {
-                            if (config["plugin"][*it][i]["detail"].isMember("CollectContainersFlag") 
-                                && config["plugin"][*it][i]["detail"]["CollectContainersFlag"].asBool()) {
+                        if (config["plugin"][*it][i].isMember("detail") && config["plugin"][*it][i]["detail"].isObject() 
+                            && config["plugin"][*it][i]["detail"].isMember("CollectContainersFlag") 
+                            && config["plugin"][*it][i]["detail"]["CollectContainersFlag"].isBool()
+                            && config["plugin"][*it][i]["detail"]["CollectContainersFlag"].asBool()) {
                                 stats["inner_function"].insert("collect_containers_meta");
                             }
                         }
@@ -341,10 +342,9 @@ void ConfigManagerBase::UpdatePluginStats(const Json::Value& config) {
         stats["processors"].insert(processor);
         stats["flushers"].insert("flusher_sls");
 
-        if (config.isMember("advanced") && config["advanced"].isObject()) {
-            if (config["advanced"].isMember("collect_containers_flag") && config["advanced"]["collect_containers_flag"].asBool()) {
-                stats["inner_function"].insert("collect_containers_meta");
-            }
+        if (config.isMember("advanced") && config["advanced"].isObject() && config["advanced"].isMember("collect_containers_flag") 
+            && config["advanced"]["collect_containers_flag"].isBool() && config["advanced"]["collect_containers_flag"].asBool()) {
+            stats["inner_function"].insert("collect_containers_meta");
         }
     }
 

--- a/core/config_manager/ConfigManagerBase.cpp
+++ b/core/config_manager/ConfigManagerBase.cpp
@@ -305,7 +305,16 @@ void ConfigManagerBase::UpdatePluginStats(const Json::Value& config) {
         for (auto it = mem.begin(); it != mem.end(); ++it) {
             if (*it == "inputs" || *it == "processors" || *it == "flushers") {
                 for (int i = 0; i < config["plugin"][*it].size(); ++i) {
-                    stats[*it].insert(config["plugin"][*it][i]["type"].asString());
+                    std::string type = config["plugin"][*it][i]["type"].asString();
+                    stats[*it].insert(type);
+                    if (type == "service_docker_stdout") {
+                        if (config["plugin"][*it][i].isMember("detail") && config["plugin"][*it][i]["detail"].isObject()) {
+                            if (config["plugin"][*it][i]["detail"].isMember("CollectContainersFlag") 
+                                && config["plugin"][*it][i]["detail"]["CollectContainersFlag"].asBool()) {
+                                stats["inner_function"].insert("collect_containers_meta");
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -331,6 +340,12 @@ void ConfigManagerBase::UpdatePluginStats(const Json::Value& config) {
         stats["inputs"].insert("file_log");
         stats["processors"].insert(processor);
         stats["flushers"].insert("flusher_sls");
+
+        if (config.isMember("advanced") && config["advanced"].isObject()) {
+            if (config["advanced"].isMember("collect_containers_flag") && config["advanced"]["collect_containers_flag"].asBool()) {
+                stats["inner_function"].insert("collect_containers_meta");
+            }
+        }
     }
 
     ScopedSpinLock lock(mPluginStatsLock);

--- a/pkg/helper/container_config.go
+++ b/pkg/helper/container_config.go
@@ -134,10 +134,12 @@ func RecordContainerConfigResultIncrement(message *ContainerConfigResult) {
 }
 
 // 记录新增容器ID
-func RecordAddedContainerIDs(containerID string) {
+func RecordAddedContainerIDs(containerIDs []string) {
 	addedContainerMapMutex.Lock()
 	defer addedContainerMapMutex.Unlock()
-	AddedContainerMap[containerID] = struct{}{}
+	for _, containerID := range containerIDs {
+		AddedContainerMap[containerID] = struct{}{}
+	}
 }
 
 // 获取新增容器ID列表
@@ -265,4 +267,27 @@ func GetShortID(fullID string) string {
 
 func GetStringFromList(list []string) string {
 	return strings.Join(list, ";")
+}
+
+func SameStringSlice(x, y []string) bool {
+	if len(x) != len(y) {
+		return false
+	}
+	// create a map of string -> int
+	diff := make(map[string]int, len(x))
+	for _, _x := range x {
+		// 0 value for int is 0, so just increment a counter for the string
+		diff[_x]++
+	}
+	for _, _y := range y {
+		// If the string _y is not in diff bail out early
+		if _, ok := diff[_y]; !ok {
+			return false
+		}
+		diff[_y] -= 1
+		if diff[_y] == 0 {
+			delete(diff, _y)
+		}
+	}
+	return len(diff) == 0
 }

--- a/pkg/helper/container_config.go
+++ b/pkg/helper/container_config.go
@@ -244,26 +244,3 @@ func GetShortID(fullID string) string {
 func GetStringFromList(list []string) string {
 	return strings.Join(list, ";")
 }
-
-func SameStringSlice(x, y []string) bool {
-	if len(x) != len(y) {
-		return false
-	}
-	// create a map of string -> int
-	diff := make(map[string]int, len(x))
-	for _, _x := range x {
-		// 0 value for int is 0, so just increment a counter for the string
-		diff[_x]++
-	}
-	for _, _y := range y {
-		// If the string _y is not in diff bail out early
-		if _, ok := diff[_y]; !ok {
-			return false
-		}
-		diff[_y] -= 1
-		if diff[_y] == 0 {
-			delete(diff, _y)
-		}
-	}
-	return len(diff) == 0
-}

--- a/pkg/helper/container_export.go
+++ b/pkg/helper/container_export.go
@@ -160,10 +160,14 @@ func GetContainerByAcceptedInfoV2(
 	includeEnvRegex map[string]*regexp.Regexp,
 	excludeEnvRegex map[string]*regexp.Regexp,
 	k8sFilter *K8SFilter,
-) (newCount, delCount int, matchAddedList, matchDeletedList, fullAddedList, fullDeletedList []string) {
+) (newCount, delCount int, matchAddedList, matchDeletedList []string) {
 	return getDockerCenterInstance().getAllAcceptedInfoV2(
 		fullList, matchList, includeLabel, excludeLabel, includeLabelRegex, excludeLabelRegex, includeEnv, excludeEnv, includeEnvRegex, excludeEnvRegex, k8sFilter)
 
+}
+
+func GetDiffContainers(fullList map[string]struct{}) (fullAddedList, fullDeletedList []string) {
+	return getDockerCenterInstance().getDiffContainers(fullList)
 }
 
 // SplitRegexFromMap extract regex from user config

--- a/pkg/helper/docker_center.go
+++ b/pkg/helper/docker_center.go
@@ -854,11 +854,7 @@ func (dc *DockerCenter) getAllAcceptedInfoV2(
 	fullAddedList = make([]string, 0)
 	// Remove deleted containers from match list and full list.
 	delCount = 0
-	// 第一次启动的时候，会有全量的容器信息，不需要这里上报，因此忽略掉
-	flagFirstInitContainers := false
-	if len(fullList) == 0 && len(dc.containerMap) != 0 {
-		flagFirstInitContainers = true
-	}
+
 	for id := range fullList {
 		if _, exist := dc.containerMap[id]; !exist {
 			delete(fullList, id)
@@ -887,17 +883,13 @@ func (dc *DockerCenter) getAllAcceptedInfoV2(
 	for id, info := range dc.containerMap {
 		if _, exist := fullList[id]; !exist {
 			fullList[id] = true
-			if !flagFirstInitContainers {
-				fullAddedList = append(fullAddedList, id)
-			}
+			fullAddedList = append(fullAddedList, id)
 			if isContainerLabelMatch(includeLabel, excludeLabel, includeLabelRegex, excludeLabelRegex, info) &&
 				isContainerEnvMatch(includeEnv, excludeEnv, includeEnvRegex, excludeEnvRegex, info) &&
 				info.K8SInfo.IsMatch(k8sFilter) {
 				newCount++
 				matchList[id] = info
-				if !flagFirstInitContainers {
-					matchAddedList = append(matchAddedList, id)
-				}
+				matchAddedList = append(matchAddedList, id)
 			}
 		}
 	}

--- a/pkg/helper/docker_center.go
+++ b/pkg/helper/docker_center.go
@@ -844,21 +844,18 @@ func (dc *DockerCenter) getAllAcceptedInfoV2(
 	includeEnvRegex map[string]*regexp.Regexp,
 	excludeEnvRegex map[string]*regexp.Regexp,
 	k8sFilter *K8SFilter,
-) (newCount, delCount int, matchAddedList, matchDeletedList, fullAddedList, fullDeletedList []string) {
+) (newCount, delCount int, matchAddedList, matchDeletedList []string) {
 
 	dc.lock.RLock()
 	defer dc.lock.RUnlock()
 	matchDeletedList = make([]string, 0)
 	matchAddedList = make([]string, 0)
-	fullDeletedList = make([]string, 0)
-	fullAddedList = make([]string, 0)
 	// Remove deleted containers from match list and full list.
 	delCount = 0
 
 	for id := range fullList {
 		if _, exist := dc.containerMap[id]; !exist {
 			delete(fullList, id)
-			fullDeletedList = append(fullDeletedList, id)
 			if _, matched := matchList[id]; matched {
 				delete(matchList, id)
 				matchDeletedList = append(matchDeletedList, id)
@@ -883,7 +880,6 @@ func (dc *DockerCenter) getAllAcceptedInfoV2(
 	for id, info := range dc.containerMap {
 		if _, exist := fullList[id]; !exist {
 			fullList[id] = true
-			fullAddedList = append(fullAddedList, id)
 			if isContainerLabelMatch(includeLabel, excludeLabel, includeLabelRegex, excludeLabelRegex, info) &&
 				isContainerEnvMatch(includeEnv, excludeEnv, includeEnvRegex, excludeEnvRegex, info) &&
 				info.K8SInfo.IsMatch(k8sFilter) {
@@ -893,7 +889,27 @@ func (dc *DockerCenter) getAllAcceptedInfoV2(
 			}
 		}
 	}
-	return newCount, delCount, matchAddedList, matchDeletedList, fullAddedList, fullDeletedList
+	return newCount, delCount, matchAddedList, matchDeletedList
+}
+
+func (dc *DockerCenter) getDiffContainers(fullList map[string]struct{}) (fullAddedList, fullDeletedList []string) {
+	dc.lock.RLock()
+	defer dc.lock.RUnlock()
+	fullDeletedList = make([]string, 0)
+	fullAddedList = make([]string, 0)
+	for id := range fullList {
+		if _, exist := dc.containerMap[id]; !exist {
+			delete(fullList, id)
+			fullDeletedList = append(fullDeletedList, id)
+		}
+	}
+	for id := range dc.containerMap {
+		if _, exist := fullList[id]; !exist {
+			fullList[id] = struct{}{}
+			fullAddedList = append(fullAddedList, id)
+		}
+	}
+	return fullAddedList, fullDeletedList
 }
 
 func (dc *DockerCenter) getAllSpecificInfo(filter func(*DockerInfoDetail) bool) (infoList []*DockerInfoDetail) {

--- a/pkg/helper/docker_center_test.go
+++ b/pkg/helper/docker_center_test.go
@@ -99,7 +99,7 @@ func TestGetAllAcceptedInfoV2(t *testing.T) {
 			"c1": newContainer("c1"),
 		})
 
-		newCount, delCount, matchAddedList, matchDeletedList, fullAddedList, fullDeletedList := dc.getAllAcceptedInfoV2(
+		newCount, delCount, matchAddedList, matchDeletedList := dc.getAllAcceptedInfoV2(
 			fullList,
 			matchList,
 			nil, nil, nil, nil, nil, nil, nil, nil, nil)
@@ -111,15 +111,13 @@ func TestGetAllAcceptedInfoV2(t *testing.T) {
 		require.Equal(t, delCount, 0)
 		require.Equal(t, len(matchAddedList), 0)
 		require.Equal(t, len(matchDeletedList), 0)
-		require.Equal(t, len(fullAddedList), 0)
-		require.Equal(t, len(fullDeletedList), 0)
 	}
 
 	// New container.
 	{
 		dc.updateContainer("c2", newContainer("c2"))
 
-		newCount, delCount, matchAddedList, matchDeletedList, fullAddedList, fullDeletedList := dc.getAllAcceptedInfoV2(
+		newCount, delCount, matchAddedList, matchDeletedList := dc.getAllAcceptedInfoV2(
 			fullList,
 			matchList,
 			nil, nil, nil, nil, nil, nil, nil, nil, nil)
@@ -133,15 +131,13 @@ func TestGetAllAcceptedInfoV2(t *testing.T) {
 		require.Equal(t, delCount, 0)
 		require.Equal(t, len(matchAddedList), 1)
 		require.Equal(t, len(matchDeletedList), 0)
-		require.Equal(t, len(fullAddedList), 1)
-		require.Equal(t, len(fullDeletedList), 0)
 	}
 
 	// Delete container.
 	{
 		delete(dc.containerMap, "c1")
 
-		newCount, delCount, matchAddedList, matchDeletedList, fullAddedList, fullDeletedList := dc.getAllAcceptedInfoV2(
+		newCount, delCount, matchAddedList, matchDeletedList := dc.getAllAcceptedInfoV2(
 			fullList,
 			matchList,
 			nil, nil, nil, nil, nil, nil, nil, nil, nil)
@@ -153,8 +149,6 @@ func TestGetAllAcceptedInfoV2(t *testing.T) {
 		require.Equal(t, delCount, 1)
 		require.Equal(t, len(matchAddedList), 0)
 		require.Equal(t, len(matchDeletedList), 1)
-		require.Equal(t, len(fullAddedList), 0)
-		require.Equal(t, len(fullDeletedList), 1)
 	}
 
 	// New and Delete container.
@@ -165,7 +159,7 @@ func TestGetAllAcceptedInfoV2(t *testing.T) {
 		})
 		delete(dc.containerMap, "c2")
 
-		newCount, delCount, matchAddedList, matchDeletedList, fullAddedList, fullDeletedList := dc.getAllAcceptedInfoV2(
+		newCount, delCount, matchAddedList, matchDeletedList := dc.getAllAcceptedInfoV2(
 			fullList,
 			matchList,
 			nil, nil, nil, nil, nil, nil, nil, nil, nil)
@@ -179,15 +173,13 @@ func TestGetAllAcceptedInfoV2(t *testing.T) {
 		require.Equal(t, delCount, 1)
 		require.Equal(t, len(matchAddedList), 2)
 		require.Equal(t, len(matchDeletedList), 1)
-		require.Equal(t, len(fullAddedList), 2)
-		require.Equal(t, len(fullDeletedList), 1)
 	}
 
 	// With unmatched filter.
 	fullList = make(map[string]bool)
 	matchList = make(map[string]*DockerInfoDetail)
 	{
-		newCount, delCount, matchAddedList, matchDeletedList, fullAddedList, fullDeletedList := dc.getAllAcceptedInfoV2(
+		newCount, delCount, matchAddedList, matchDeletedList := dc.getAllAcceptedInfoV2(
 			fullList,
 			matchList,
 			map[string]string{
@@ -202,15 +194,13 @@ func TestGetAllAcceptedInfoV2(t *testing.T) {
 		require.Equal(t, delCount, 0)
 		require.Equal(t, len(matchAddedList), 0)
 		require.Equal(t, len(matchDeletedList), 0)
-		require.Equal(t, len(fullAddedList), 0)
-		require.Equal(t, len(fullDeletedList), 0)
 	}
 
 	// Delete unmatched container.
 	{
 		delete(dc.containerMap, "c3")
 
-		newCount, delCount, matchAddedList, matchDeletedList, fullAddedList, fullDeletedList := dc.getAllAcceptedInfoV2(
+		newCount, delCount, matchAddedList, matchDeletedList := dc.getAllAcceptedInfoV2(
 			fullList,
 			matchList,
 			map[string]string{
@@ -224,8 +214,6 @@ func TestGetAllAcceptedInfoV2(t *testing.T) {
 		require.Equal(t, delCount, 0)
 		require.Equal(t, len(matchAddedList), 0)
 		require.Equal(t, len(matchDeletedList), 0)
-		require.Equal(t, len(fullAddedList), 0)
-		require.Equal(t, len(fullDeletedList), 1)
 	}
 }
 

--- a/pluginmanager/container_config_manager.go
+++ b/pluginmanager/container_config_manager.go
@@ -27,8 +27,6 @@ import (
 // 12h
 var FetchAllInterval = time.Second * time.Duration(12*60*60)
 
-var timerFetchRunning = false
-
 var envAndLabelMutex sync.Mutex
 
 var envSet map[string]struct{}
@@ -37,6 +35,7 @@ var k8sLabelSet map[string]struct{}
 
 var cachedFullList map[string]struct{}
 var containerMutex sync.Mutex
+var once sync.Once
 
 func timerRecordData() {
 	containerMutex.Lock()
@@ -287,15 +286,13 @@ func TimerFetchFuction() {
 					refreshEnvAndLabel()
 					timerRecordData()
 					lastFetchAllTime = time.Now()
-
 				} else {
 					compareEnvAndLabelAndRecordContainer()
 				}
 			}
 		}
 	}
-	if !timerFetchRunning {
+	once.Do(func() {
 		go timerFetch()
-		timerFetchRunning = true
-	}
+	})
 }

--- a/pluginmanager/container_config_manager.go
+++ b/pluginmanager/container_config_manager.go
@@ -27,8 +27,8 @@ import (
 // 24h
 var FetchAllInterval = time.Second * time.Duration(24*60*60)
 
-// 30min
-var FirstFetchAllInterval = time.Second * time.Duration(30*60)
+// 10min
+var FirstFetchAllInterval = time.Second * time.Duration(5*60)
 
 var timerFetchRunning = false
 

--- a/pluginmanager/container_config_manager_test.go
+++ b/pluginmanager/container_config_manager_test.go
@@ -82,9 +82,8 @@ func (s *containerConfigTestSuite) TestCompareEnvAndLabelAndRecordContainer() {
 	cMap := helper.GetContainerMap()
 	cMap["test"] = info
 
-	compareEnvAndLabelAndRecordContainer()
-	s.Equal(1, len(helper.AddedContainers))
-	helper.AddedContainers = helper.AddedContainers[:0]
+	containers := compareEnvAndLabelAndRecordContainer()
+	s.Equal(1, len(containers))
 }
 
 func (s *containerConfigTestSuite) TestRecordContainers() {
@@ -94,9 +93,8 @@ func (s *containerConfigTestSuite) TestRecordContainers() {
 
 	containerIDs := make(map[string]struct{})
 	containerIDs["test"] = struct{}{}
-	recordContainers(containerIDs)
-	s.Equal(1, len(helper.AddedContainers))
-	helper.AddedContainers = helper.AddedContainers[:0]
+	recordedIds, _ := getContainersToRecord(containerIDs)
+	s.Equal(1, len(recordedIds))
 }
 
 type containerConfigTestSuite struct {

--- a/pluginmanager/plugin_manager.go
+++ b/pluginmanager/plugin_manager.go
@@ -131,7 +131,6 @@ func Init() (err error) {
 		return
 	}
 	logger.Info(context.Background(), "loadBuiltinConfig container")
-	TimerFetchFuction()
 	return
 }
 

--- a/pluginmanager/self_telemetry_container_config.go
+++ b/pluginmanager/self_telemetry_container_config.go
@@ -38,7 +38,6 @@ func (r *InputContainer) Collect(collector pipeline.Collector) error {
 	loggroup := &protocol.LogGroup{}
 
 	CollectContainers(loggroup)
-	CollectDeleteContainers(loggroup)
 	CollectConfigResult(loggroup)
 
 	if len(loggroup.Logs) > 0 && ContainerConfig != nil {

--- a/plugins/input/docker/logmeta/metric_docker_file.go
+++ b/plugins/input/docker/logmeta/metric_docker_file.go
@@ -289,7 +289,7 @@ func (idf *InputDockerFile) Collect(collector pipeline.Collector) error {
 	if len(idf.lastPathMappingCache) == 0 {
 		allCmd = new(DockerFileUpdateCmdAll)
 	}
-	newCount, delCount, addResultList, deleteResultList, addFullList, deleteFullList := helper.GetContainerByAcceptedInfoV2(
+	newCount, delCount, addResultList, deleteResultList := helper.GetContainerByAcceptedInfoV2(
 
 		idf.fullList, idf.matchList,
 		idf.IncludeLabel, idf.ExcludeLabel,
@@ -298,24 +298,6 @@ func (idf *InputDockerFile) Collect(collector pipeline.Collector) error {
 		idf.IncludeEnvRegex, idf.ExcludeEnvRegex,
 		idf.K8sFilter)
 	idf.lastUpdateTime = newUpdateTime
-	if idf.CollectContainersFlag {
-		// record added container id
-		if len(addFullList) > 0 {
-			for _, id := range addFullList {
-				if len(id) > 0 {
-					helper.RecordAddedContainerIDs(addFullList)
-				}
-			}
-		}
-		// record deleted container id
-		if len(deleteFullList) > 0 {
-			for _, id := range deleteFullList {
-				if len(id) > 0 {
-					helper.RecordDeletedContainerIDs(helper.GetShortID(id))
-				}
-			}
-		}
-	}
 	// record config result
 	havingPathkeys := make([]string, 0)
 	nothavingPathkeys := make([]string, 0)
@@ -377,7 +359,7 @@ func (idf *InputDockerFile) Collect(collector pipeline.Collector) error {
 		if newCount != 0 || delCount != 0 {
 			helper.RecordContainerConfigResultIncrement(configResult)
 		}
-		logger.Debugf(idf.context.GetRuntimeContext(), "update match list, addResultList: %v, deleteResultList: %v, addFullList: %v, deleteFullList: %v", addResultList, deleteResultList, addFullList, deleteFullList)
+		logger.Debugf(idf.context.GetRuntimeContext(), "update match list, addResultList: %v, deleteResultList: %v", addResultList, deleteResultList)
 	}
 
 	for id := range idf.lastPathMappingCache {

--- a/plugins/input/docker/logmeta/metric_docker_file.go
+++ b/plugins/input/docker/logmeta/metric_docker_file.go
@@ -90,6 +90,7 @@ type InputDockerFile struct {
 	fullList              map[string]bool
 	matchList             map[string]*helper.DockerInfoDetail
 	CollectContainersFlag bool
+	firstStart            bool
 }
 
 func formatPath(path string) string {
@@ -112,6 +113,7 @@ func (idf *InputDockerFile) Name() string {
 func (idf *InputDockerFile) Init(context pipeline.Context) (int, error) {
 	idf.context = context
 	idf.lastPathMappingCache = make(map[string]string)
+	idf.firstStart = true
 	idf.fullList = make(map[string]bool)
 	idf.matchList = make(map[string]*helper.DockerInfoDetail)
 	// Because docker on Windows will convert all mounted path to lowercase (see
@@ -356,8 +358,9 @@ func (idf *InputDockerFile) Collect(collector pipeline.Collector) error {
 			FlusherTargetAddress:          fmt.Sprintf("%s/%s", idf.context.GetProject(), idf.context.GetLogstore()),
 		}
 		helper.RecordContainerConfigResultMap(configResult)
-		if newCount != 0 || delCount != 0 {
+		if newCount != 0 || delCount != 0 || idf.firstStart {
 			helper.RecordContainerConfigResultIncrement(configResult)
+			idf.firstStart = false
 		}
 		logger.Debugf(idf.context.GetRuntimeContext(), "update match list, addResultList: %v, deleteResultList: %v", addResultList, deleteResultList)
 	}

--- a/plugins/input/docker/logmeta/metric_docker_file.go
+++ b/plugins/input/docker/logmeta/metric_docker_file.go
@@ -303,7 +303,7 @@ func (idf *InputDockerFile) Collect(collector pipeline.Collector) error {
 		if len(addFullList) > 0 {
 			for _, id := range addFullList {
 				if len(id) > 0 {
-					helper.RecordAddedContainerIDs(id)
+					helper.RecordAddedContainerIDs(addFullList)
 				}
 			}
 		}

--- a/plugins/input/docker/stdout/input_docker_stdout.go
+++ b/plugins/input/docker/stdout/input_docker_stdout.go
@@ -263,7 +263,7 @@ func (sds *ServiceDockerStdout) FlushAll(c pipeline.Collector, firstStart bool) 
 	}
 
 	var err error
-	newCount, delCount, addResultList, deleteResultList, addFullList, deleteFullList := helper.GetContainerByAcceptedInfoV2(
+	newCount, delCount, addResultList, deleteResultList := helper.GetContainerByAcceptedInfoV2(
 		sds.fullList, sds.matchList,
 		sds.IncludeLabel, sds.ExcludeLabel,
 		sds.IncludeLabelRegex, sds.ExcludeLabelRegex,
@@ -273,24 +273,6 @@ func (sds *ServiceDockerStdout) FlushAll(c pipeline.Collector, firstStart bool) 
 	sds.lastUpdateTime = newUpdateTime
 
 	if sds.CollectContainersFlag {
-		// record added container id
-		if len(addFullList) > 0 {
-			for _, id := range addFullList {
-				if len(id) > 0 {
-					// full id，to get info from container map
-					helper.RecordAddedContainerIDs(addFullList)
-				}
-			}
-		}
-		// record deleted container id
-		if len(deleteFullList) > 0 {
-			for _, id := range deleteFullList {
-				if len(id) > 0 {
-					// short id， to record
-					helper.RecordDeletedContainerIDs(helper.GetShortID(id))
-				}
-			}
-		}
 		// record config result
 		{
 			keys := make([]string, 0, len(sds.matchList))
@@ -314,7 +296,7 @@ func (sds *ServiceDockerStdout) FlushAll(c pipeline.Collector, firstStart bool) 
 			if newCount != 0 || delCount != 0 {
 				helper.RecordContainerConfigResultIncrement(configResult)
 			}
-			logger.Debugf(sds.context.GetRuntimeContext(), "update match list, addResultList: %v, deleteResultList: %v, addFullList: %v, deleteFullList: %v", addResultList, deleteResultList, addFullList, deleteFullList)
+			logger.Debugf(sds.context.GetRuntimeContext(), "update match list, addResultList: %v, deleteResultList: %v", addResultList, deleteResultList)
 		}
 	}
 

--- a/plugins/input/docker/stdout/input_docker_stdout.go
+++ b/plugins/input/docker/stdout/input_docker_stdout.go
@@ -176,9 +176,6 @@ type ServiceDockerStdout struct {
 	matchList             map[string]*helper.DockerInfoDetail
 	lastUpdateTime        int64
 	CollectContainersFlag bool
-
-	flagFirstInitContainers bool
-	matchIDList             []string
 }
 
 func (sds *ServiceDockerStdout) Init(context pipeline.Context) (int, error) {
@@ -187,6 +184,7 @@ func (sds *ServiceDockerStdout) Init(context pipeline.Context) (int, error) {
 	sds.fullList = make(map[string]bool)
 	sds.matchList = make(map[string]*helper.DockerInfoDetail)
 	sds.synerMap = make(map[string]*DockerFileSyner)
+
 	if sds.MaxLogSize < 1024 {
 		sds.MaxLogSize = 1024
 	}
@@ -242,7 +240,6 @@ func (sds *ServiceDockerStdout) Init(context pipeline.Context) (int, error) {
 		logger.Warning(sds.context.GetRuntimeContext(), "INVALID_REGEX_ALARM", "init exclude label regex error", err)
 	}
 	sds.K8sFilter, err = helper.CreateK8SFilter(sds.K8sNamespaceRegex, sds.K8sPodRegex, sds.K8sContainerRegex, sds.IncludeK8sLabel, sds.ExcludeK8sLabel)
-
 	return 0, err
 }
 
@@ -293,7 +290,7 @@ func (sds *ServiceDockerStdout) FlushAll(c pipeline.Collector, firstStart bool) 
 				FlusherTargetAddress:       fmt.Sprintf("%s/%s", sds.context.GetProject(), sds.context.GetLogstore()),
 			}
 			helper.RecordContainerConfigResultMap(configResult)
-			if newCount != 0 || delCount != 0 {
+			if newCount != 0 || delCount != 0 || firstStart {
 				helper.RecordContainerConfigResultIncrement(configResult)
 			}
 			logger.Debugf(sds.context.GetRuntimeContext(), "update match list, addResultList: %v, deleteResultList: %v", addResultList, deleteResultList)

--- a/plugins/input/docker/stdout/input_docker_stdout.go
+++ b/plugins/input/docker/stdout/input_docker_stdout.go
@@ -176,6 +176,9 @@ type ServiceDockerStdout struct {
 	matchList             map[string]*helper.DockerInfoDetail
 	lastUpdateTime        int64
 	CollectContainersFlag bool
+
+	flagFirstInitContainers bool
+	matchIDList             []string
 }
 
 func (sds *ServiceDockerStdout) Init(context pipeline.Context) (int, error) {
@@ -274,7 +277,8 @@ func (sds *ServiceDockerStdout) FlushAll(c pipeline.Collector, firstStart bool) 
 		if len(addFullList) > 0 {
 			for _, id := range addFullList {
 				if len(id) > 0 {
-					helper.RecordAddedContainerIDs(id)
+					// full id，to get info from container map
+					helper.RecordAddedContainerIDs(addFullList)
 				}
 			}
 		}
@@ -282,6 +286,7 @@ func (sds *ServiceDockerStdout) FlushAll(c pipeline.Collector, firstStart bool) 
 		if len(deleteFullList) > 0 {
 			for _, id := range deleteFullList {
 				if len(id) > 0 {
+					// short id， to record
 					helper.RecordDeletedContainerIDs(helper.GetShortID(id))
 				}
 			}


### PR DESCRIPTION
主要优化点：
1. 增量/删除容器由各个采集diff计算，统一到一个线程里进行diff计算。由此原container_config.go里带锁的逻辑全部删除
2. 采集配置加载的时候，第一次一定上报采集配置结果，避免信息漏上报
3. 原来计时器逻辑删除，由self_telemetry_container_config.go触发定时逻辑
4. PluginStats中增加容器信息采集标志
