### PR TITLE
chore: Improve build script generation and environment setup

### DIFF
--- a/scripts/gen_build_scripts.sh
+++ b/scripts/gen_build_scripts.sh
@@ -60,7 +60,7 @@ ram_limit_nproc=\$((ram_size / 1024 / 768))
 EOF
 
   if [ $EXPORT_GO_ENVS ]; then
-    envs=($(go env | grep -E 'GOPRIVATE=".+"|GOPROXY=".+"'))
+    envs=($(go env | grep -E 'GOPRIVATE=(".+"|'\''.'\''|[^ ]+)|GOPROXY=(".+"|'\''.'\''|[^ ]+)'))
     for v in ${envs[@]}; do
       echo "go env -w $v" >> $BUILD_SCRIPT_FILE
     done


### PR DESCRIPTION
- Compatible with go version 1.21.0

#1069 

主要原因是`go 1.21.0`版本的`go env`输出都是单引号，原脚本中的正则只匹配双引号，因此修改为可以匹配单引号和双引号的正则。

`go 1.21.0`之前版本的`go env`输出：
```
GO111MODULE=""
GOARCH="arm64"
GOBIN=""
GOCACHE="/Users/cyshall/Library/Caches/go-build"
GOENV="/Users/cyshall/Library/Application Support/go/env"
GOEXE=""
GOEXPERIMENT=""
GOFLAGS=""
GOHOSTARCH="arm64"
GOHOSTOS="darwin"
GOINSECURE=""
GOMODCACHE="/Users/cyshall/.go/pkg/mod"
GONOPROXY="gitlab.bangdao-tech.com"
GONOSUMDB="gitlab.bangdao-tech.com"
GOOS="darwin"
GOPATH="/Users/cyshall/.go"
GOPRIVATE="gitlab.bangdao-tech.com"
GOPROXY="https://goproxy.cn,direct"
GOROOT="/Users/cyshall/.g/go"
GOSUMDB="sum.golang.org"
GOTMPDIR=""
GOTOOLDIR="/Users/cyshall/.g/go/pkg/tool/darwin_arm64"
GOVCS=""
GOVERSION="go1.20.7"
GCCGO="gccgo"
AR="ar"
CC="clang"
CXX="clang++"
CGO_ENABLED="1"
GOMOD="/dev/null"
GOWORK=""
CGO_CFLAGS="-O2 -g"
CGO_CPPFLAGS=""
CGO_CXXFLAGS="-O2 -g"
CGO_FFLAGS="-O2 -g"
CGO_LDFLAGS="-O2 -g"
PKG_CONFIG="pkg-config"
GOGCCFLAGS="-fPIC -arch arm64 -pthread -fno-caret-diagnostics -Qunused-arguments -fmessage-length=0 -fdebug-prefix-map=/var/folders/f5/fnnz8fmn1pn5ktj2r9frccxc0000gn/T/go-build281634852=/tmp/go-build -gno-record-gcc-switches -fno-common"
```

`go 1.21.0`版本的`go env`输出:
```
GO111MODULE=''
GOARCH='arm64'
GOBIN=''
GOCACHE='/Users/cyshall/Library/Caches/go-build'
GOENV='/Users/cyshall/Library/Application Support/go/env'
GOEXE=''
GOEXPERIMENT=''
GOFLAGS=''
GOHOSTARCH='arm64'
GOHOSTOS='darwin'
GOINSECURE=''
GOMODCACHE='/Users/cyshall/.go/pkg/mod'
GONOPROXY='gitlab.bangdao-tech.com'
GONOSUMDB='gitlab.bangdao-tech.com'
GOOS='darwin'
GOPATH='/Users/cyshall/.go'
GOPRIVATE='gitlab.bangdao-tech.com'
GOPROXY='https://goproxy.cn,direct'
GOROOT='/Users/cyshall/.g/go'
GOSUMDB='sum.golang.org'
GOTMPDIR=''
GOTOOLCHAIN='auto'
GOTOOLDIR='/Users/cyshall/.g/go/pkg/tool/darwin_arm64'
GOVCS=''
GOVERSION='go1.21.0'
GCCGO='gccgo'
AR='ar'
CC='clang'
CXX='clang++'
CGO_ENABLED='1'
GOMOD='/dev/null'
GOWORK=''
CGO_CFLAGS='-O2 -g'
CGO_CPPFLAGS=''
CGO_CXXFLAGS='-O2 -g'
CGO_FFLAGS='-O2 -g'
CGO_LDFLAGS='-O2 -g'
PKG_CONFIG='pkg-config'
GOGCCFLAGS='-fPIC -arch arm64 -pthread -fno-caret-diagnostics -Qunused-arguments -fmessage-length=0 -ffile-prefix-map=/var/folders/f5/fnnz8fmn1pn5ktj2r9frccxc0000gn/T/go-build2807620463=/tmp/go-build -gno-record-gcc-switches -fno-common'
```