### PR TITLE
fix: remove the ip restrict of config server address, allow domain and hostname

### DIFF
--- a/core/app_config/AppConfig.cpp
+++ b/core/app_config/AppConfig.cpp
@@ -54,14 +54,7 @@ void AppConfig::LoadAddrConfig(const Json::Value& confJson) {
             string host = configServerAddress[0];
             int32_t port = atoi(configServerAddress[1].c_str());
 
-            std::string exception;
-            // regular expressions to verify ip
-            boost::regex reg_ip
-                = boost::regex("(?:(?:1[0-9][0-9]\.)|(?:2[0-4][0-9]\.)|(?:25[0-5]\.)|(?:[1-9][0-9]\.)|(?:[0-9]\.)){3}(?"
-                               ":(?:1[0-9][0-9])|(?:2[0-4][0-9])|(?:25[0-5])|(?:[1-9][0-9])|(?:[0-9]))");  
-            if (!BoostRegexMatch(host.c_str(), reg_ip, exception))
-                LOG_WARNING(sLogger, ("ilogtail_configserver_address", "parse fail")("exception", exception));
-            else if (port < 1 || port > 65535)
+            if (port < 1 || port > 65535)
                 LOG_WARNING(sLogger, ("ilogtail_configserver_address", "illegal port")("port", port));
             else
                 mConfigServerAddresses.push_back(ConfigServerAddress(host, port));

--- a/core/config_manager/ConfigManager.cpp
+++ b/core/config_manager/ConfigManager.cpp
@@ -305,7 +305,7 @@ ConfigManager::SendHeartbeat(const AppConfig::ConfigServerAddress& configServerA
     } catch (const sdk::LOGException& e) {
         LOG_WARNING(
             sLogger,
-            ("SendHeartBeat", "fail")("reqBody", reqBody)("errCode", e.GetErrorCode())("errMsg", e.GetMessage()));
+            ("SendHeartBeat", "fail")("reqBody", reqBody)("errCode", e.GetErrorCode())("errMsg", e.GetMessage())("host", configServerAddress.host)("port", configServerAddress.port));
         return emptyResult;
     }
 }


### PR DESCRIPTION
不再检查 ilogtail_config.json 文件的配置 ilogtail_configserver_address 参数中地址的合法性，不限制只能输入 IP，可以是域名或者主机名，如果连接报错，打印出错地址和端口