### PR TITLE
修改flusher_kafka_v2插件文档样例的错误描述

### DIFF
--- a/docs/cn/data-pipeline/flusher/flusher-kafka_v2.md
+++ b/docs/cn/data-pipeline/flusher/flusher-kafka_v2.md
@@ -82,7 +82,7 @@ inputs:
     LogPath: /home/test_log
     FilePattern: "*.log"
 flushers:
-  - Type: flusher_kafka
+  - Type: flusher_kafka_v2
     Brokers:
       - 192.XX.XX.1:9092
       - 192.XX.XX.2:9092
@@ -101,7 +101,7 @@ inputs:
     LogPath: /home/test_log
     FilePattern: "*.log"
 flushers:
-  - Type: flusher_kafka
+  - Type: flusher_kafka_v2
     Brokers: 
       - 192.XX.XX.1:9092
       - 192.XX.XX.2:9092
@@ -221,7 +221,7 @@ inputs:
     LogPath: /home/test_log
     FilePattern: "*.log"
 flushers:
-  - Type: flusher_kafka
+  - Type: flusher_kafka_v2
     Brokers: 
       - 192.XX.XX.1:9092
       - 192.XX.XX.2:9092


### PR DESCRIPTION
修改flusher_kafka_v2插件文档样例，里面flushers的Type字段描述有误