### PR TITLE
config server import local packages instead of github project packages

### DIFF
--- a/config_server/service/.gitignore
+++ b/config_server/service/.gitignore
@@ -1,3 +1,4 @@
 DB
 ConfigServer
 license.sh
+config-server

--- a/config_server/service/go.mod
+++ b/config_server/service/go.mod
@@ -1,4 +1,4 @@
-module github.com/alibaba/ilogtail/config_server/service
+module config-server
 
 go 1.19
 

--- a/config_server/service/interface/agent/collection_config.go
+++ b/config_server/service/interface/agent/collection_config.go
@@ -18,9 +18,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 
-	"github.com/alibaba/ilogtail/config_server/service/common"
-	"github.com/alibaba/ilogtail/config_server/service/manager"
-	proto "github.com/alibaba/ilogtail/config_server/service/proto"
+	"config-server/common"
+	"config-server/manager"
+	proto "config-server/proto"
 )
 
 func FetchPipelineConfig(c *gin.Context) {

--- a/config_server/service/interface/agent/status.go
+++ b/config_server/service/interface/agent/status.go
@@ -20,9 +20,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 
-	"github.com/alibaba/ilogtail/config_server/service/common"
-	"github.com/alibaba/ilogtail/config_server/service/manager"
-	proto "github.com/alibaba/ilogtail/config_server/service/proto"
+	"config-server/common"
+	"config-server/manager"
+	proto "config-server/proto"
 )
 
 func HeartBeat(c *gin.Context) {

--- a/config_server/service/interface/user/agent_group.go
+++ b/config_server/service/interface/user/agent_group.go
@@ -20,9 +20,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 
-	"github.com/alibaba/ilogtail/config_server/service/common"
-	"github.com/alibaba/ilogtail/config_server/service/manager"
-	proto "github.com/alibaba/ilogtail/config_server/service/proto"
+	"config-server/common"
+	"config-server/manager"
+	proto "config-server/proto"
 )
 
 func CreateAgentGroup(c *gin.Context) {

--- a/config_server/service/interface/user/collection_config.go
+++ b/config_server/service/interface/user/collection_config.go
@@ -20,9 +20,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 
-	"github.com/alibaba/ilogtail/config_server/service/common"
-	"github.com/alibaba/ilogtail/config_server/service/manager"
-	proto "github.com/alibaba/ilogtail/config_server/service/proto"
+	"config-server/common"
+	"config-server/manager"
+	proto "config-server/proto"
 )
 
 func CreateConfig(c *gin.Context) {

--- a/config_server/service/manager/agent/agent_manager.go
+++ b/config_server/service/manager/agent/agent_manager.go
@@ -17,8 +17,8 @@ package agentmanager
 import (
 	"sync"
 
-	"github.com/alibaba/ilogtail/config_server/service/model"
-	"github.com/alibaba/ilogtail/config_server/service/setting"
+	"config-server/model"
+	"config-server/setting"
 )
 
 type AgentManager struct {

--- a/config_server/service/manager/agent/agent_operator.go
+++ b/config_server/service/manager/agent/agent_operator.go
@@ -19,10 +19,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alibaba/ilogtail/config_server/service/common"
-	"github.com/alibaba/ilogtail/config_server/service/model"
-	proto "github.com/alibaba/ilogtail/config_server/service/proto"
-	"github.com/alibaba/ilogtail/config_server/service/store"
+	"config-server/common"
+	"config-server/model"
+	proto "config-server/proto"
+	"config-server/store"
 )
 
 func (a *AgentManager) HeartBeat(req *proto.HeartBeatRequest, res *proto.HeartBeatResponse) (int, *proto.HeartBeatResponse) {

--- a/config_server/service/manager/config/agent_operator.go
+++ b/config_server/service/manager/config/agent_operator.go
@@ -19,10 +19,10 @@ import (
 	"log"
 	"time"
 
-	"github.com/alibaba/ilogtail/config_server/service/common"
-	"github.com/alibaba/ilogtail/config_server/service/model"
-	proto "github.com/alibaba/ilogtail/config_server/service/proto"
-	"github.com/alibaba/ilogtail/config_server/service/store"
+	"config-server/common"
+	"config-server/model"
+	proto "config-server/proto"
+	"config-server/store"
 )
 
 func (c *ConfigManager) updateConfigList(interval int) {

--- a/config_server/service/manager/config/config_manager.go
+++ b/config_server/service/manager/config/config_manager.go
@@ -17,10 +17,10 @@ package configmanager
 import (
 	"sync"
 
-	"github.com/alibaba/ilogtail/config_server/service/common"
-	"github.com/alibaba/ilogtail/config_server/service/model"
-	"github.com/alibaba/ilogtail/config_server/service/setting"
-	"github.com/alibaba/ilogtail/config_server/service/store"
+	"config-server/common"
+	"config-server/model"
+	"config-server/setting"
+	"config-server/store"
 )
 
 type ConfigManager struct {

--- a/config_server/service/manager/config/user_operator.go
+++ b/config_server/service/manager/config/user_operator.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/alibaba/ilogtail/config_server/service/common"
-	"github.com/alibaba/ilogtail/config_server/service/model"
-	proto "github.com/alibaba/ilogtail/config_server/service/proto"
-	"github.com/alibaba/ilogtail/config_server/service/store"
+	"config-server/common"
+	"config-server/model"
+	proto "config-server/proto"
+	"config-server/store"
 )
 
 func (c *ConfigManager) CreateConfig(req *proto.CreateConfigRequest, res *proto.CreateConfigResponse) (int, *proto.CreateConfigResponse) {

--- a/config_server/service/manager/manager.go
+++ b/config_server/service/manager/manager.go
@@ -15,8 +15,8 @@
 package manager
 
 import (
-	agentManager "github.com/alibaba/ilogtail/config_server/service/manager/agent"
-	configManager "github.com/alibaba/ilogtail/config_server/service/manager/config"
+	agentManager "config-server/manager/agent"
+	configManager "config-server/manager/config"
 )
 
 var myAgentManager *agentManager.AgentManager

--- a/config_server/service/model/agent.go
+++ b/config_server/service/model/agent.go
@@ -15,7 +15,7 @@
 package model
 
 import (
-	proto "github.com/alibaba/ilogtail/config_server/service/proto"
+	proto "config-server/proto"
 )
 
 type AgentAttributes struct {

--- a/config_server/service/model/agent_group.go
+++ b/config_server/service/model/agent_group.go
@@ -14,7 +14,7 @@
 
 package model
 
-import proto "github.com/alibaba/ilogtail/config_server/service/proto"
+import proto "config-server/proto"
 
 type AgentGroupTag struct {
 	Name  string `json:"Name"`

--- a/config_server/service/model/collection_config.go
+++ b/config_server/service/model/collection_config.go
@@ -15,7 +15,7 @@
 package model
 
 import (
-	proto "github.com/alibaba/ilogtail/config_server/service/proto"
+	proto "config-server/proto"
 )
 
 var ConfigType = map[string]proto.ConfigType{

--- a/config_server/service/router/router.go
+++ b/config_server/service/router/router.go
@@ -17,9 +17,9 @@ package router
 import (
 	"github.com/gin-gonic/gin"
 
-	"github.com/alibaba/ilogtail/config_server/service/interface/agent"
-	"github.com/alibaba/ilogtail/config_server/service/interface/user"
-	"github.com/alibaba/ilogtail/config_server/service/setting"
+	"config-server/interface/agent"
+	"config-server/interface/user"
+	"config-server/setting"
 )
 
 func InitRouter() {

--- a/config_server/service/service.go
+++ b/config_server/service/service.go
@@ -15,8 +15,8 @@
 package main
 
 import (
-	"github.com/alibaba/ilogtail/config_server/service/router"
-	"github.com/alibaba/ilogtail/config_server/service/store"
+	"config-server/router"
+	"config-server/store"
 )
 
 func main() {

--- a/config_server/service/setting/setting.go
+++ b/config_server/service/setting/setting.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"reflect"
 
-	"github.com/alibaba/ilogtail/config_server/service/common"
+	"config-server/common"
 )
 
 type Setting struct {

--- a/config_server/service/store/interface_database/interface_database.go
+++ b/config_server/service/store/interface_database/interface_database.go
@@ -15,7 +15,7 @@
 package database
 
 import (
-	"github.com/alibaba/ilogtail/config_server/service/common"
+	"config-server/common"
 )
 
 /*

--- a/config_server/service/store/leveldb/leveldb.go
+++ b/config_server/service/store/leveldb/leveldb.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/syndtr/goleveldb/leveldb"
 
-	"github.com/alibaba/ilogtail/config_server/service/common"
-	"github.com/alibaba/ilogtail/config_server/service/model"
-	"github.com/alibaba/ilogtail/config_server/service/setting"
-	database "github.com/alibaba/ilogtail/config_server/service/store/interface_database"
+	"config-server/common"
+	"config-server/model"
+	"config-server/setting"
+	database "config-server/store/interface_database"
 )
 
 var dbPath = []string{

--- a/config_server/service/store/store.go
+++ b/config_server/service/store/store.go
@@ -15,9 +15,9 @@
 package store
 
 import (
-	"github.com/alibaba/ilogtail/config_server/service/setting"
-	database "github.com/alibaba/ilogtail/config_server/service/store/interface_database"
-	"github.com/alibaba/ilogtail/config_server/service/store/leveldb"
+	"config-server/setting"
+	database "config-server/store/interface_database"
+	"config-server/store/leveldb"
 )
 
 // Data in database

--- a/config_server/service/test/interface_test.go
+++ b/config_server/service/test/interface_test.go
@@ -22,9 +22,9 @@ import (
 	"github.com/gin-gonic/gin"
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/alibaba/ilogtail/config_server/service/common"
-	proto "github.com/alibaba/ilogtail/config_server/service/proto"
-	"github.com/alibaba/ilogtail/config_server/service/router"
+	"config-server/common"
+	proto "config-server/proto"
+	"config-server/router"
 )
 
 func TestBaseAgentGroup(t *testing.T) {

--- a/config_server/service/test/request.go
+++ b/config_server/service/test/request.go
@@ -23,7 +23,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"google.golang.org/protobuf/proto"
 
-	configserverproto "github.com/alibaba/ilogtail/config_server/service/proto"
+	configserverproto "config-server/proto"
 )
 
 func DeleteAgentGroup(r *gin.Engine, groupName string, requestID string) (int, *configserverproto.DeleteAgentGroupResponse) {

--- a/config_server/service/test/setting_test.go
+++ b/config_server/service/test/setting_test.go
@@ -19,7 +19,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/alibaba/ilogtail/config_server/service/setting"
+	"config-server/setting"
 )
 
 func TestSetting(t *testing.T) {

--- a/config_server/service/test/store_test.go
+++ b/config_server/service/test/store_test.go
@@ -19,9 +19,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/alibaba/ilogtail/config_server/service/common"
-	"github.com/alibaba/ilogtail/config_server/service/model"
-	"github.com/alibaba/ilogtail/config_server/service/store"
+	"config-server/common"
+	"config-server/model"
+	"config-server/store"
 )
 
 func TestStore(t *testing.T) {


### PR DESCRIPTION
去除对 github 仓库的依赖，方便用户对 ilogtail config server 进行二次开发