### PR TITLE
feat: filter & rename processor support v2 model

### DIFF
--- a/plugins/processor/filter/regex/filter_regex_test.go
+++ b/plugins/processor/filter/regex/filter_regex_test.go
@@ -17,8 +17,11 @@ package regex
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/alibaba/ilogtail/pkg/models"
 	"github.com/pingcap/check"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/alibaba/ilogtail/pkg/logger"
 	"github.com/alibaba/ilogtail/pkg/pipeline"
@@ -131,5 +134,106 @@ func (s *processorTestSuite) TestNotMatch(c *check.C) {
 		logArray[0] = logPb
 		outLogs := s.processor.ProcessLogs(logArray)
 		c.Assert(len(outLogs), check.Equals, 0)
+	}
+}
+
+func TestFilterEvent(t *testing.T) {
+	timeNow := uint64(time.Now().UnixNano())
+	tests := []struct {
+		group   *models.PipelineGroupEvents
+		include map[string]string
+		exclude map[string]string
+		want    *models.PipelineGroupEvents
+	}{
+		{
+			group: &models.PipelineGroupEvents{
+				Group: models.NewGroup(models.NewMetadata(), models.NewTags()),
+				Events: []models.PipelineEvent{
+					models.NewSimpleLog([]byte("hello world1"), models.NewTagsWithMap(map[string]string{
+						"tag1": "xxxxx",
+					}), timeNow),
+					models.NewSimpleLog([]byte("hello world2"), models.NewTagsWithMap(map[string]string{
+						"tag1": "yyyyy",
+					}), timeNow),
+				},
+			},
+			exclude: map[string]string{
+				"content": `hello\sworld1`,
+			},
+			want: &models.PipelineGroupEvents{
+				Group: models.NewGroup(models.NewMetadata(), models.NewTags()),
+				Events: []models.PipelineEvent{
+					models.NewSimpleLog([]byte("hello world2"), models.NewTagsWithMap(map[string]string{
+						"tag1": "yyyyy",
+					}), timeNow),
+				},
+			},
+		},
+		{
+			group: &models.PipelineGroupEvents{
+				Group: models.NewGroup(models.NewMetadata(), models.NewTags()),
+				Events: []models.PipelineEvent{
+					models.NewSimpleLog([]byte("hello world1"), models.NewTagsWithMap(map[string]string{
+						"tag1": "xxxxx",
+					}), timeNow),
+					models.NewSimpleLog([]byte("hello world2"), models.NewTagsWithMap(map[string]string{
+						"tag1": "yyyyy",
+					}), timeNow),
+				},
+			},
+			include: map[string]string{
+				"content": `hello\sworld1`,
+			},
+			want: &models.PipelineGroupEvents{
+				Group: models.NewGroup(models.NewMetadata(), models.NewTags()),
+				Events: []models.PipelineEvent{
+					models.NewSimpleLog([]byte("hello world1"), models.NewTagsWithMap(map[string]string{
+						"tag1": "xxxxx",
+					}), timeNow),
+				},
+			},
+		},
+		{
+			group: &models.PipelineGroupEvents{
+				Group: models.NewGroup(models.NewMetadata(), models.NewTags()),
+				Events: []models.PipelineEvent{
+					models.NewSimpleLog([]byte("hello world1"), models.NewTagsWithMap(map[string]string{
+						"tag1": "xxxxx",
+					}), timeNow),
+					models.NewSimpleLog([]byte("hello world2"), models.NewTagsWithMap(map[string]string{
+						"tag1": "yyyyy",
+					}), timeNow),
+				},
+			},
+			include: map[string]string{
+				"tag1": `xxx`,
+			},
+			want: &models.PipelineGroupEvents{
+				Group: models.NewGroup(models.NewMetadata(), models.NewTags()),
+				Events: []models.PipelineEvent{
+					models.NewSimpleLog([]byte("hello world1"), models.NewTagsWithMap(map[string]string{
+						"tag1": "xxxxx",
+					}), timeNow),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		p := &ProcessorRegexFilter{
+			Include: test.include,
+			Exclude: test.exclude,
+		}
+		err := p.Init(mock.NewEmptyContext("p", "l", "c"))
+		assert.Nil(t, err)
+
+		ctx := pipeline.NewObservePipelineConext(10)
+		p.Process(test.group, ctx)
+		select {
+		case <-time.After(time.Second * 10):
+			assert.Fail(t, "should got data returned by processor")
+		case data := <-ctx.Collector().Observe():
+			assert.Equal(t, test.want, data)
+		}
 	}
 }

--- a/plugins/processor/filter/regex/processor_filter_regex.go
+++ b/plugins/processor/filter/regex/processor_filter_regex.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/alibaba/ilogtail/pkg/helper"
 	"github.com/alibaba/ilogtail/pkg/logger"
+	"github.com/alibaba/ilogtail/pkg/models"
 	"github.com/alibaba/ilogtail/pkg/pipeline"
 	"github.com/alibaba/ilogtail/pkg/protocol"
 )
@@ -130,6 +131,94 @@ func (p *ProcessorRegexFilter) ProcessLogs(logArray []*protocol.Log) []*protocol
 	}
 	logArray = logArray[:nextIdx]
 	return logArray
+}
+
+func (p *ProcessorRegexFilter) isEventMatch(event models.PipelineEvent) bool {
+	if log, ok := event.(*models.Log); ok {
+		return p.isLogEventMatch(log)
+	}
+	tags := event.GetTags().Iterator()
+	for key, reg := range p.includeRegex {
+		if v, ok := tags[key]; ok && reg.MatchString(v) {
+			continue
+		}
+		return false
+	}
+	for key, reg := range p.excludeRegex {
+		if v, ok := tags[key]; ok && reg.MatchString(v) {
+			return false
+		}
+	}
+	return true
+}
+
+func (p *ProcessorRegexFilter) isLogEventMatch(event *models.Log) bool {
+	tags := event.GetTags().Iterator()
+	contents := event.Contents.Iterator()
+	for key, reg := range p.includeRegex {
+		if v, ok := tags[key]; ok && reg.MatchString(v) {
+			continue
+		}
+		if v, ok := contents[key]; ok {
+			switch value := v.(type) {
+			case string:
+				if reg.MatchString(value) {
+					continue
+				}
+			case []byte:
+				if reg.Match(value) {
+					continue
+				}
+			default:
+				str := fmt.Sprintf("%v", value)
+				if reg.MatchString(str) {
+					continue
+				}
+			}
+		}
+		return false
+	}
+	for key, reg := range p.excludeRegex {
+		if v, ok := tags[key]; ok && reg.MatchString(v) {
+			return false
+		}
+		if v, ok := contents[key]; ok {
+			switch value := v.(type) {
+			case string:
+				if reg.MatchString(value) {
+					return false
+				}
+			case []byte:
+				if reg.Match(value) {
+					return false
+				}
+			default:
+				str := fmt.Sprintf("%v", value)
+				if reg.MatchString(str) {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+func (p *ProcessorRegexFilter) Process(in *models.PipelineGroupEvents, context pipeline.PipelineContext) {
+	totalLen := len(in.Events)
+	nextIdx := 0
+	for idx := 0; idx < totalLen; idx++ {
+		if p.isEventMatch(in.Events[idx]) {
+			if idx != nextIdx {
+				in.Events[nextIdx] = in.Events[idx]
+			}
+			nextIdx++
+		} else {
+			p.filterMetric.Add(1)
+		}
+		p.processedMetric.Add(1)
+	}
+	in.Events = in.Events[:nextIdx]
+	context.Collector().Collect(in.Group, in.Events...)
 }
 
 func init() {

--- a/plugins/processor/rename/processor_rename.go
+++ b/plugins/processor/rename/processor_rename.go
@@ -124,10 +124,14 @@ func (p *ProcessorRename) Process(in *models.PipelineGroupEvents, context pipeli
 
 func (p *ProcessorRename) processLogEvent(logEvent *models.Log) {
 	contents := logEvent.GetIndices()
+	tags := logEvent.GetTags()
 	for oldKey, newKey := range p.keyDictionary {
 		if contents.Contains(oldKey) {
 			contents.Add(newKey, contents.Get(oldKey))
 			contents.Delete(oldKey)
+		} else if tags.Contains(oldKey) {
+			tags.Add(newKey, tags.Get(oldKey))
+			tags.Delete(oldKey)
 		} else if p.NoKeyError {
 			p.noKeyErrorArray = append(p.noKeyErrorArray, oldKey)
 		}


### PR DESCRIPTION
1. filter processor support v2 model:
- for log event, filter tags and content keys
- for other event, filter tags

2. rename processor support v2 model:
- for log event, add support for rename tags