### PR TITLE
feat: support labels for self_metric

### DIFF
--- a/pkg/helper/self_metric_imp.go
+++ b/pkg/helper/self_metric_imp.go
@@ -24,15 +24,17 @@ import (
 	"time"
 )
 
+var nameKey = "__name__"
 var mu sync.Mutex
 
 type StrMetric struct {
-	name  string
-	value string
+	name   string
+	value  string
+	labels []*protocol.Log_Content
 }
 
 func (s *StrMetric) Name() string {
-	return s.name
+	return getNameWithLables(s.name, s.labels)
 }
 
 func (s *StrMetric) Set(v string) {
@@ -49,12 +51,14 @@ func (s *StrMetric) Get() string {
 }
 
 func (s *StrMetric) Serialize(log *protocol.Log) {
-	log.Contents = append(log.Contents, &protocol.Log_Content{Key: s.name, Value: s.Get()})
+	log.Contents = append(log.Contents, &protocol.Log_Content{Key: s.name, Value: s.Get()}, &protocol.Log_Content{Key: nameKey, Value: s.name})
+	log.Contents = append(log.Contents, s.labels...)
 }
 
 type NormalMetric struct {
-	name  string
-	value int64
+	name   string
+	value  int64
+	labels []*protocol.Log_Content
 }
 
 func (s *NormalMetric) Add(v int64) {
@@ -70,11 +74,12 @@ func (s *NormalMetric) Get() int64 {
 }
 
 func (s *NormalMetric) Name() string {
-	return s.name
+	return getNameWithLables(s.name, s.labels)
 }
 
 func (s *NormalMetric) Serialize(log *protocol.Log) {
-	log.Contents = append(log.Contents, &protocol.Log_Content{Key: s.name, Value: strconv.FormatInt(s.Get(), 10)})
+	log.Contents = append(log.Contents, &protocol.Log_Content{Key: s.name, Value: strconv.FormatInt(s.Get(), 10)}, &protocol.Log_Content{Key: nameKey, Value: s.name})
+	log.Contents = append(log.Contents, s.labels...)
 }
 
 type AvgMetric struct {
@@ -82,6 +87,7 @@ type AvgMetric struct {
 	value   int64
 	count   int64
 	prevAvg float64
+	labels  []*protocol.Log_Content
 }
 
 func (s *AvgMetric) Add(v int64) {
@@ -118,11 +124,12 @@ func (s *AvgMetric) GetAvg() float64 {
 }
 
 func (s *AvgMetric) Name() string {
-	return s.name
+	return getNameWithLables(s.name, s.labels)
 }
 
 func (s *AvgMetric) Serialize(log *protocol.Log) {
-	log.Contents = append(log.Contents, &protocol.Log_Content{Key: s.name, Value: strconv.FormatFloat(s.GetAvg(), 'f', 4, 64)})
+	log.Contents = append(log.Contents, &protocol.Log_Content{Key: s.name, Value: strconv.FormatFloat(s.GetAvg(), 'f', 4, 64)}, &protocol.Log_Content{Key: nameKey, Value: s.name})
+	log.Contents = append(log.Contents, s.labels...)
 }
 
 type LatMetric struct {
@@ -130,10 +137,11 @@ type LatMetric struct {
 	t          time.Time
 	count      int
 	latencySum time.Duration
+	labels     []*protocol.Log_Content
 }
 
 func (s *LatMetric) Name() string {
-	return s.name
+	return getNameWithLables(s.name, s.labels)
 }
 
 func (s *LatMetric) Begin() {
@@ -169,45 +177,54 @@ func (s *LatMetric) Get() int64 {
 }
 
 func (s *LatMetric) Serialize(log *protocol.Log) {
-	log.Contents = append(log.Contents, &protocol.Log_Content{Key: s.name, Value: strconv.FormatFloat(float64(s.Get())/1000, 'f', 4, 64)})
+	log.Contents = append(log.Contents, &protocol.Log_Content{Key: s.name, Value: strconv.FormatFloat(float64(s.Get())/1000, 'f', 4, 64)}, &protocol.Log_Content{Key: nameKey, Value: s.name})
+	log.Contents = append(log.Contents, s.labels...)
 }
 
-func NewCounterMetric(n string) pipeline.CounterMetric {
-	return &NormalMetric{name: n}
+func getNameWithLables(name string, labels []*protocol.Log_Content) string {
+	n := name
+	for _, lable := range labels {
+		n = n + "#" + lable.Key + "=" + lable.Value
+	}
+	return n
 }
 
-func NewAverageMetric(n string) pipeline.CounterMetric {
-	return &AvgMetric{name: n}
+func NewCounterMetric(n string, lables ...*protocol.Log_Content) pipeline.CounterMetric {
+	return &NormalMetric{name: n, labels: lables}
 }
 
-func NewStringMetric(n string) pipeline.StringMetric {
-	return &StrMetric{name: n}
+func NewAverageMetric(n string, lables ...*protocol.Log_Content) pipeline.CounterMetric {
+	return &AvgMetric{name: n, labels: lables}
 }
 
-func NewLatencyMetric(n string) pipeline.LatencyMetric {
-	return &LatMetric{name: n}
+func NewStringMetric(n string, lables ...*protocol.Log_Content) pipeline.StringMetric {
+	return &StrMetric{name: n, labels: lables}
 }
 
-func NewCounterMetricAndRegister(n string, c pipeline.Context) pipeline.CounterMetric {
-	metric := &NormalMetric{name: n}
+func NewLatencyMetric(n string, lables ...*protocol.Log_Content) pipeline.LatencyMetric {
+	return &LatMetric{name: n, labels: lables}
+}
+
+func NewCounterMetricAndRegister(c pipeline.Context, n string, lables ...*protocol.Log_Content) pipeline.CounterMetric {
+	metric := &NormalMetric{name: n, labels: lables}
 	c.RegisterCounterMetric(metric)
 	return metric
 }
 
-func NewAverageMetricAndRegister(n string, c pipeline.Context) pipeline.CounterMetric {
-	metric := &AvgMetric{name: n}
+func NewAverageMetricAndRegister(c pipeline.Context, n string, lables ...*protocol.Log_Content) pipeline.CounterMetric {
+	metric := &AvgMetric{name: n, labels: lables}
 	c.RegisterCounterMetric(metric)
 	return metric
 }
 
-func NewStringMetricAndRegister(n string, c pipeline.Context) pipeline.StringMetric {
-	metric := &StrMetric{name: n}
+func NewStringMetricAndRegister(c pipeline.Context, n string, lables ...*protocol.Log_Content) pipeline.StringMetric {
+	metric := &StrMetric{name: n, labels: lables}
 	c.RegisterStringMetric(metric)
 	return metric
 }
 
-func NewLatencyMetricAndRegister(n string, c pipeline.Context) pipeline.LatencyMetric {
-	metric := &LatMetric{name: n}
+func NewLatencyMetricAndRegister(c pipeline.Context, n string, lables ...*protocol.Log_Content) pipeline.LatencyMetric {
+	metric := &LatMetric{name: n, labels: lables}
 	c.RegisterLatencyMetric(metric)
 	return metric
 }

--- a/pkg/helper/self_metric_imp.go
+++ b/pkg/helper/self_metric_imp.go
@@ -24,7 +24,8 @@ import (
 	"time"
 )
 
-var nameKey = "__name__"
+const SelfMetricNameKey = "__name__"
+
 var mu sync.Mutex
 
 type StrMetric struct {
@@ -51,7 +52,7 @@ func (s *StrMetric) Get() string {
 }
 
 func (s *StrMetric) Serialize(log *protocol.Log) {
-	log.Contents = append(log.Contents, &protocol.Log_Content{Key: s.name, Value: s.Get()}, &protocol.Log_Content{Key: nameKey, Value: s.name})
+	log.Contents = append(log.Contents, &protocol.Log_Content{Key: s.name, Value: s.Get()}, &protocol.Log_Content{Key: SelfMetricNameKey, Value: s.name})
 	log.Contents = append(log.Contents, s.labels...)
 }
 
@@ -78,7 +79,7 @@ func (s *NormalMetric) Name() string {
 }
 
 func (s *NormalMetric) Serialize(log *protocol.Log) {
-	log.Contents = append(log.Contents, &protocol.Log_Content{Key: s.name, Value: strconv.FormatInt(s.Get(), 10)}, &protocol.Log_Content{Key: nameKey, Value: s.name})
+	log.Contents = append(log.Contents, &protocol.Log_Content{Key: s.name, Value: strconv.FormatInt(s.Get(), 10)}, &protocol.Log_Content{Key: SelfMetricNameKey, Value: s.name})
 	log.Contents = append(log.Contents, s.labels...)
 }
 
@@ -128,7 +129,7 @@ func (s *AvgMetric) Name() string {
 }
 
 func (s *AvgMetric) Serialize(log *protocol.Log) {
-	log.Contents = append(log.Contents, &protocol.Log_Content{Key: s.name, Value: strconv.FormatFloat(s.GetAvg(), 'f', 4, 64)}, &protocol.Log_Content{Key: nameKey, Value: s.name})
+	log.Contents = append(log.Contents, &protocol.Log_Content{Key: s.name, Value: strconv.FormatFloat(s.GetAvg(), 'f', 4, 64)}, &protocol.Log_Content{Key: SelfMetricNameKey, Value: s.name})
 	log.Contents = append(log.Contents, s.labels...)
 }
 
@@ -177,7 +178,7 @@ func (s *LatMetric) Get() int64 {
 }
 
 func (s *LatMetric) Serialize(log *protocol.Log) {
-	log.Contents = append(log.Contents, &protocol.Log_Content{Key: s.name, Value: strconv.FormatFloat(float64(s.Get())/1000, 'f', 4, 64)}, &protocol.Log_Content{Key: nameKey, Value: s.name})
+	log.Contents = append(log.Contents, &protocol.Log_Content{Key: s.name, Value: strconv.FormatFloat(float64(s.Get())/1000, 'f', 4, 64)}, &protocol.Log_Content{Key: SelfMetricNameKey, Value: s.name})
 	log.Contents = append(log.Contents, s.labels...)
 }
 

--- a/pkg/helper/self_metric_imp_test.go
+++ b/pkg/helper/self_metric_imp_test.go
@@ -45,9 +45,14 @@ func TestStrMetric_Name(t *testing.T) {
 		{
 			name: "test_name",
 			fields: fields{
-				name:   "field",
-				value:  "v",
-				labels: []*protocol.Log_Content{&protocol.Log_Content{Key: "key", Value: "value"}},
+				name:  "field",
+				value: "v",
+				labels: []*protocol.Log_Content{
+					{
+						Key:   "key",
+						Value: "value",
+					},
+				},
 			},
 			want: "field#key=value",
 		},

--- a/pkg/helper/self_metric_imp_test.go
+++ b/pkg/helper/self_metric_imp_test.go
@@ -25,8 +25,9 @@ import (
 
 func TestStrMetric_Name(t *testing.T) {
 	type fields struct {
-		name  string
-		value string
+		name   string
+		value  string
+		labels []*protocol.Log_Content
 	}
 	tests := []struct {
 		name   string
@@ -41,12 +42,22 @@ func TestStrMetric_Name(t *testing.T) {
 			},
 			want: "field",
 		},
+		{
+			name: "test_name",
+			fields: fields{
+				name:   "field",
+				value:  "v",
+				labels: []*protocol.Log_Content{&protocol.Log_Content{Key: "key", Value: "value"}},
+			},
+			want: "field#key=value",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &StrMetric{
-				name:  tt.fields.name,
-				value: tt.fields.value,
+				name:   tt.fields.name,
+				value:  tt.fields.value,
+				labels: tt.fields.labels,
 			}
 			if got := s.Name(); got != tt.want {
 				t.Errorf("StrMetric.Name() = %v, want %v", got, tt.want)

--- a/plugins/input/canal/input_canal.go
+++ b/plugins/input/canal/input_canal.go
@@ -192,14 +192,14 @@ func (sc *ServiceCanal) Init(context pipeline.Context) (int, error) {
 
 	sc.lastErrorChan = make(chan error, 1)
 
-	sc.rotateCounter = helper.NewCounterMetricAndRegister("binlog_rotate", context)
-	sc.syncCounter = helper.NewCounterMetricAndRegister("binlog_sync", context)
-	sc.ddlCounter = helper.NewCounterMetricAndRegister("binlog_ddl", context)
-	sc.rowCounter = helper.NewCounterMetricAndRegister("binlog_row", context)
-	sc.xgidCounter = helper.NewCounterMetricAndRegister("binlog_xgid", context)
-	sc.checkpointCounter = helper.NewCounterMetricAndRegister("binlog_checkpoint", context)
-	sc.lastBinLogMetric = helper.NewStringMetricAndRegister("binlog_filename", context)
-	sc.lastGTIDMetric = helper.NewStringMetricAndRegister("binlog_gtid", context)
+	sc.rotateCounter = helper.NewCounterMetricAndRegister(context, "binlog_rotate")
+	sc.syncCounter = helper.NewCounterMetricAndRegister(context, "binlog_sync")
+	sc.ddlCounter = helper.NewCounterMetricAndRegister(context, "binlog_ddl")
+	sc.rowCounter = helper.NewCounterMetricAndRegister(context, "binlog_row")
+	sc.xgidCounter = helper.NewCounterMetricAndRegister(context, "binlog_xgid")
+	sc.checkpointCounter = helper.NewCounterMetricAndRegister(context, "binlog_checkpoint")
+	sc.lastBinLogMetric = helper.NewStringMetricAndRegister(context, "binlog_filename")
+	sc.lastGTIDMetric = helper.NewStringMetricAndRegister(context, "binlog_gtid")
 
 	return 0, nil
 }

--- a/plugins/processor/encrypt/processor_encrypt.go
+++ b/plugins/processor/encrypt/processor_encrypt.go
@@ -87,8 +87,8 @@ func (p *ProcessorEncrypt) Init(context pipeline.Context) error {
 		return err
 	}
 
-	p.encryptedCountMetric = helper.NewCounterMetricAndRegister("encrypted_count", p.context)
-	p.encryptedBytesMetric = helper.NewCounterMetricAndRegister("encrypted_bytes", p.context)
+	p.encryptedCountMetric = helper.NewCounterMetricAndRegister(p.context, "encrypted_count")
+	p.encryptedBytesMetric = helper.NewCounterMetricAndRegister(p.context, "encrypted_bytes")
 	return nil
 }
 


### PR DESCRIPTION
1. self_metric 支持创建时传入 labels，并且在Serialize时附加到 LogContents 种
2. 在Serialize时添加 `__name__` label ，该 label 在 convert 时使用