### PR TITLE
fix: Correct premature file read termination triggered by sender back pressure

### DIFF
--- a/core/event/BlockEventManager.h
+++ b/core/event/BlockEventManager.h
@@ -50,6 +50,9 @@ protected:
         BlockedEvent() : mLogstoreKey(0), mEvent(NULL), mInvalidTime(time(NULL)), mTimeout(1) {}
         void Update(const LogstoreFeedBackKey& logstoreKey, Event* pEvent, int32_t curTime) {
             if (mEvent != NULL) {
+                // There are only two situations where event coverage is possible
+                // 1. the new event is not timeout event
+                // 2. old event is timeout event
                 if (!pEvent->IsReaderFlushTimeout() || mEvent->IsReaderFlushTimeout()) {
                     delete mEvent;
                 } else {

--- a/core/event/BlockEventManager.h
+++ b/core/event/BlockEventManager.h
@@ -50,7 +50,11 @@ protected:
         BlockedEvent() : mLogstoreKey(0), mEvent(NULL), mInvalidTime(time(NULL)), mTimeout(1) {}
         void Update(const LogstoreFeedBackKey& logstoreKey, Event* pEvent, int32_t curTime) {
             if (mEvent != NULL) {
-                delete mEvent;
+                if (!pEvent->IsReaderFlushTimeout() || mEvent->IsReaderFlushTimeout()) {
+                    delete mEvent;
+                } else {
+                    return;
+                }
             }
             mEvent = pEvent;
             mLogstoreKey = logstoreKey;


### PR DESCRIPTION
修复BlockedEvent在update的时候，非预期的事件覆盖行为
问题现象：
NAS场景Json采集，CP文件的方式替代历史文件采集的情况下，发现大量文件只采集了一小部分。

