### PR TITLE
fix: Correct parsing errors in ProcessorParseApsaraNative with large buffer input

### DIFF
--- a/core/common/JsonUtil.cpp
+++ b/core/common/JsonUtil.cpp
@@ -77,6 +77,8 @@ std::string CompactJson(const std::string& inJson) {
             case '\\':
                 if (++ch == inJson.end()) { // skip next char after escape char
                     --ch;
+                } else {
+                    outJson << '\\';
                 }
                 break;
             default:

--- a/core/config/Config.h
+++ b/core/config/Config.h
@@ -139,26 +139,26 @@ public:
     std::shared_ptr<LogFilterRule> mFilterRule;
     bool mLocalStorage;
     int mVersion;
-    bool mDiscardNoneUtf8;
+    bool mDiscardNoneUtf8 = false;
     std::string mAliuid;
     std::string mRegion;
     std::string mStreamLogTag;
-    bool mDiscardUnmatch;
+    bool mDiscardUnmatch = false;
     std::vector<std::string> mColumnKeys;
     std::string mSeparator;
     char mQuote;
     // for delimiter log, accept logs without enough keys or not
     // eg, keys -> [a, b, c], raw log "xx|yy", log -> [a->xx, b->yy]
-    bool mAcceptNoEnoughKeys;
-    bool mAutoExtend;
+    bool mAcceptNoEnoughKeys = false;
+    bool mAutoExtend = true;
     std::string mTimeKey;
     std::vector<std::string> mShardHashKey;
     bool mTailExisted;
     std::unordered_map<std::string, std::vector<SensitiveWordCastOption>> mSensitiveWordCastOptions;
-    bool mUploadRawLog; // true to update raw log to sls
+    bool mUploadRawLog = false; // true to update raw log to sls
     bool mSimpleLogFlag;
     bool mTimeZoneAdjust;
-    int mLogTimeZoneOffsetSecond;
+    int mLogTimeZoneOffsetSecond = 0;
     int32_t mCreateTime; // create time of this config
     int32_t
         mMaxSendBytesPerSecond; // limit for logstore, not just this config. so if we have multi configs with different

--- a/core/processor/ProcessorParseApsaraNative.cpp
+++ b/core/processor/ProcessorParseApsaraNative.cpp
@@ -153,9 +153,10 @@ bool ProcessorParseApsaraNative::ProcessEvent(const StringView& logPath,
     index = ParseApsaraBaseFields(buffer, sourceEvent);
     bool sourceKeyOverwritten = mSourceKeyOverwritten;
     bool rawLogTagOverwritten = false;
-    if (buffer.data()[index] != 0) {
-        for (index = index + 1; index <= buffer.size(); ++index) {
-            if (index == buffer.size() || buffer.data()[index] == '\t' || buffer.data()[index] == '\0') {
+    size_t length = buffer.size();
+    if (index < length && buffer.data()[index] != 0) {
+        for (index = index + 1; index <= length; ++index) {
+            if (index == length || buffer.data()[index] == '\t' || buffer.data()[index] == '\0') {
                 if (colon_index >= 0) {
                     StringView key(buffer.data() + beg_index, colon_index - beg_index);
                     StringView data(buffer.data() + colon_index + 1, index - colon_index - 1);

--- a/core/processor/ProcessorParseApsaraNative.cpp
+++ b/core/processor/ProcessorParseApsaraNative.cpp
@@ -87,6 +87,9 @@ bool ProcessorParseApsaraNative::ProcessEvent(const StringView& logPath, Pipelin
         return true;
     }
     StringView buffer = sourceEvent.GetContent(mSourceKey);
+    if (buffer.size() == 0) {
+        return true;
+    }
     mProcParseInSizeBytes->Add(buffer.size());
     int64_t logTime_in_micro = 0;
     time_t logTime = ApsaraEasyReadLogTimeParser(buffer, timeStrCache, lastLogTime, logTime_in_micro);

--- a/core/processor/ProcessorParseApsaraNative.cpp
+++ b/core/processor/ProcessorParseApsaraNative.cpp
@@ -154,8 +154,8 @@ bool ProcessorParseApsaraNative::ProcessEvent(const StringView& logPath,
     bool sourceKeyOverwritten = mSourceKeyOverwritten;
     bool rawLogTagOverwritten = false;
     if (buffer.data()[index] != 0) {
-        for (index = index + 1; index <= buffer.size(); index++) {
-            if (buffer.data()[index] == '\t' || buffer.data()[index] == '\0' || index == buffer.size()) {
+        for (index = index + 1; index <= buffer.size(); ++index) {
+            if (index == buffer.size() || buffer.data()[index] == '\t' || buffer.data()[index] == '\0') {
                 if (colon_index >= 0) {
                     StringView key(buffer.data() + beg_index, colon_index - beg_index);
                     StringView data(buffer.data() + colon_index + 1, index - colon_index - 1);

--- a/core/processor/ProcessorParseApsaraNative.cpp
+++ b/core/processor/ProcessorParseApsaraNative.cpp
@@ -154,8 +154,7 @@ bool ProcessorParseApsaraNative::ProcessEvent(const StringView& logPath,
     bool sourceKeyOverwritten = mSourceKeyOverwritten;
     bool rawLogTagOverwritten = false;
     if (buffer.data()[index] != 0) {
-        do {
-            ++index;
+        for (index = index + 1; index <= buffer.size(); index++) {
             if (buffer.data()[index] == '\t' || buffer.data()[index] == '\0' || index == buffer.size()) {
                 if (colon_index >= 0) {
                     StringView key(buffer.data() + beg_index, colon_index - beg_index);
@@ -173,7 +172,7 @@ bool ProcessorParseApsaraNative::ProcessEvent(const StringView& logPath,
             } else if (buffer.data()[index] == ':' && colon_index == -1) {
                 colon_index = index;
             }
-        } while (index <= buffer.size());
+        }
     }
     // TODO: deprecated
     if (mAdjustApsaraMicroTimezone) {

--- a/core/processor/ProcessorParseApsaraNative.h
+++ b/core/processor/ProcessorParseApsaraNative.h
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-#include <boost/regex.hpp>
-#include <string>
-
 #include "plugin/interface/Processor.h"
+#include <string>
+#include <boost/regex.hpp>
 
 namespace logtail {
 
@@ -33,11 +32,9 @@ protected:
     bool IsSupportedEvent(const PipelineEventPtr& e) const override;
 
 private:
-    bool
-    ProcessEvent(const StringView& logPath, PipelineEventPtr& e, LogtailTime& lastLogTime, StringView& timeStrCache);
+    bool ProcessEvent(const StringView& logPath, PipelineEventPtr& e, LogtailTime& lastLogTime, StringView& timeStrCache);
     void AddLog(const StringView& key, const StringView& value, LogEvent& targetEvent);
-    time_t
-    ApsaraEasyReadLogTimeParser(StringView& buffer, StringView& timeStr, LogtailTime& lastLogTime, int64_t& microTime);
+    time_t ApsaraEasyReadLogTimeParser(StringView& buffer, StringView& timeStr, LogtailTime& lastLogTime, int64_t& microTime);
     int32_t GetApsaraLogMicroTime(StringView& buffer);
     bool IsPrefixString(const char* all, const StringView& prefix);
     int32_t ParseApsaraBaseFields(const StringView& buffer, LogEvent& sourceEvent);

--- a/core/processor/ProcessorParseApsaraNative.h
+++ b/core/processor/ProcessorParseApsaraNative.h
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-#include "plugin/interface/Processor.h"
-#include <string>
 #include <boost/regex.hpp>
+#include <string>
+
+#include "plugin/interface/Processor.h"
 
 namespace logtail {
 
@@ -32,12 +33,14 @@ protected:
     bool IsSupportedEvent(const PipelineEventPtr& e) const override;
 
 private:
-    bool ProcessEvent(const StringView& logPath, PipelineEventPtr& e, LogtailTime& lastLogTime, StringView& timeStrCache);
+    bool
+    ProcessEvent(const StringView& logPath, PipelineEventPtr& e, LogtailTime& lastLogTime, StringView& timeStrCache);
     void AddLog(const StringView& key, const StringView& value, LogEvent& targetEvent);
-    time_t ApsaraEasyReadLogTimeParser(StringView& buffer, StringView& timeStr, LogtailTime& lastLogTime, int64_t& microTime);
+    time_t
+    ApsaraEasyReadLogTimeParser(StringView& buffer, StringView& timeStr, LogtailTime& lastLogTime, int64_t& microTime);
     int32_t GetApsaraLogMicroTime(StringView& buffer);
     bool IsPrefixString(const char* all, const StringView& prefix);
-    int32_t ParseApsaraBaseFields(StringView& buffer, LogEvent& sourceEvent);
+    int32_t ParseApsaraBaseFields(const StringView& buffer, LogEvent& sourceEvent);
 
     std::string mSourceKey;
     std::string mRawLogTag;

--- a/core/unittest/processor/ProcessorFilterNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorFilterNativeUnittest.cpp
@@ -191,7 +191,6 @@ void ProcessorFilterNativeUnittest::TestFilter() {
         ]
     })";
     eventGroup1.FromJsonString(inJson);
-    std::cout<<inJson<<std::endl;
     // run function
     processorInstance.Process(eventGroup1);
     std::string outJson = eventGroup1.ToJsonString();

--- a/core/unittest/processor/ProcessorFilterNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorFilterNativeUnittest.cpp
@@ -11,12 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "common/ExceptionBase.h"
-#include "common/JsonUtil.h"
-#include "config/UserLogConfigParser.h"
-#include "plugin/instance/ProcessorInstance.h"
-#include "processor/ProcessorFilterNative.h"
 #include "unittest/Unittest.h"
+#include "common/JsonUtil.h"
+#include "processor/ProcessorFilterNative.h"
+#include "plugin/instance/ProcessorInstance.h"
+#include "common/ExceptionBase.h"
+#include "config/UserLogConfigParser.h"
 
 using namespace std;
 using boost::regex;
@@ -181,8 +181,7 @@ void ProcessorFilterNativeUnittest::TestFilter() {
                 {
                     "key1" : "abcdeavalue1",
                     "key2" : "value2xxxxx",
-                    "key3)"
-        + std::string(illegalUtf8) + R"(": "abcdea)" + std::string(illegalUtf8) + R"(value1",
+                    "key3)" + std::string(illegalUtf8) + R"(": "abcdea)" + std::string(illegalUtf8) + R"(value1",
                     "log.file.offset": "0"
                 },
                 "timestampNanosecond" : 0,
@@ -192,6 +191,7 @@ void ProcessorFilterNativeUnittest::TestFilter() {
         ]
     })";
     eventGroup1.FromJsonString(inJson);
+    std::cout<<inJson<<std::endl;
     // run function
     processorInstance.Process(eventGroup1);
     std::string outJson = eventGroup1.ToJsonString();
@@ -1205,7 +1205,7 @@ void ProcessorFilterNativeUnittest::TestFilterNoneUtf8() {
         processor.FilterNoneUtf8(testStr);
         for (uint32_t indexOfString = 0; indexOfString < testStr.size(); ++indexOfString) {
             if (flow[indexOfString] == true) {
-                APSARA_TEST_EQUAL_FATAL(testStr[indexOfString], ' ');
+                APSARA_TEST_EQUAL_FATAL(testStr[indexOfString], ' ');  
             } else {
                 APSARA_TEST_NOT_EQUAL_FATAL(testStr[indexOfString], ' ');
             }

--- a/core/unittest/processor/ProcessorFilterNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorFilterNativeUnittest.cpp
@@ -11,12 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "unittest/Unittest.h"
-#include "common/JsonUtil.h"
-#include "processor/ProcessorFilterNative.h"
-#include "plugin/instance/ProcessorInstance.h"
 #include "common/ExceptionBase.h"
+#include "common/JsonUtil.h"
 #include "config/UserLogConfigParser.h"
+#include "plugin/instance/ProcessorInstance.h"
+#include "processor/ProcessorFilterNative.h"
+#include "unittest/Unittest.h"
 
 using namespace std;
 using boost::regex;
@@ -181,7 +181,8 @@ void ProcessorFilterNativeUnittest::TestFilter() {
                 {
                     "key1" : "abcdeavalue1",
                     "key2" : "value2xxxxx",
-                    "key3)" + std::string(illegalUtf8) + R"(": "abcdea)" + std::string(illegalUtf8) + R"(value1",
+                    "key3)"
+        + std::string(illegalUtf8) + R"(": "abcdea)" + std::string(illegalUtf8) + R"(value1",
                     "log.file.offset": "0"
                 },
                 "timestampNanosecond" : 0,
@@ -191,7 +192,6 @@ void ProcessorFilterNativeUnittest::TestFilter() {
         ]
     })";
     eventGroup1.FromJsonString(inJson);
-    std::cout<<inJson<<std::endl;
     // run function
     processorInstance.Process(eventGroup1);
     std::string outJson = eventGroup1.ToJsonString();
@@ -1205,7 +1205,7 @@ void ProcessorFilterNativeUnittest::TestFilterNoneUtf8() {
         processor.FilterNoneUtf8(testStr);
         for (uint32_t indexOfString = 0; indexOfString < testStr.size(); ++indexOfString) {
             if (flow[indexOfString] == true) {
-                APSARA_TEST_EQUAL_FATAL(testStr[indexOfString], ' ');  
+                APSARA_TEST_EQUAL_FATAL(testStr[indexOfString], ' ');
             } else {
                 APSARA_TEST_NOT_EQUAL_FATAL(testStr[indexOfString], ' ');
             }

--- a/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
@@ -65,9 +65,19 @@ void ProcessorParseApsaraNativeUnittest::TestMultipleLines() {
             {
                 "contents" :
                 {
-                    "content" : "[2023-09-04 13:15:50.1]	[error]	[1]	/ilogtail/AppConfigBase.cpp:1		AppConfigBase AppConfigBase:1
-[2023-09-04 13:15:33.2]	[info]	[2]	/ilogtail/AppConfigBase.cpp:2		AppConfigBase AppConfigBase:2
-[2023-09-04 13:15:22.3]	[warning]	[3]	/ilogtail/AppConfigBase.cpp:3		AppConfigBase AppConfigBase:3",
+                    "content" : "[2023-09-04 13:15:50.1]	[ERROR]	[1]	/ilogtail/AppConfigBase.cpp:1		AppConfigBase AppConfigBase:1
+[2023-09-04 13:15:33.2]	[INFO]	[2]	/ilogtail/AppConfigBase.cpp:2		AppConfigBase AppConfigBase:2
+[2023-09-04 13:15:22.3]	[WARNING]	[3]	/ilogtail/AppConfigBase.cpp:3		AppConfigBase AppConfigBase:3",
+                    "log.file.offset": "0"
+                },
+                "timestamp" : 12345678901,
+                "type" : 1
+            },
+            {
+                "contents" :
+                {
+                    "content" : "[2023-09-04 13:15:50.1] [ERROR] [1[2023-09-04 13:15:33.2]	[INFO]	[2]	/ilogtail/AppConfigBase.cpp:2		AppConfigBase AppConfigBase:2
+[2023-09-04 13:15:22.3]	[WARNING]	[3]	/ilogtail/AppConfigBase.cpp:3		AppConfigBase AppConfigBase:3",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -78,47 +88,72 @@ void ProcessorParseApsaraNativeUnittest::TestMultipleLines() {
 
 
     std::string expectJson = R"({
-        "events" : 
-        [
-                {
-                        "contents" : 
-                        {
-                                "/ilogtail/AppConfigBase.cpp" : "1",
-                                "AppConfigBase AppConfigBase" : "1",
-                                "__THREAD__" : "1",
-                                "log.file.offset" : "0",
-                                "microtime" : "1693833350100000"
-                        },
-                        "timestamp" : 1693833350,
-                        "timestampNanosecond" : 100000000,
-                        "type" : 1
+        "events": [
+            {
+                "contents": {
+                    "/ilogtail/AppConfigBase.cpp": "1",
+                    "AppConfigBase AppConfigBase": "1",
+                    "__LEVEL__": "ERROR",
+                    "__THREAD__": "1",
+                    "log.file.offset": "0",
+                    "microtime": "1693833350100000"
                 },
-                {
-                        "contents" : 
-                        {
-                                "/ilogtail/AppConfigBase.cpp" : "2",
-                                "AppConfigBase AppConfigBase" : "2",
-                                "__THREAD__" : "2",
-                                "log.file.offset" : "0",
-                                "microtime" : "1693833333200000"
-                        },
-                        "timestamp" : 1693833333,
-                        "timestampNanosecond" : 200000000,
-                        "type" : 1
+                "timestamp": 1693833350,
+                "timestampNanosecond": 100000000,
+                "type": 1
+            },
+            {
+                "contents": {
+                    "/ilogtail/AppConfigBase.cpp": "2",
+                    "AppConfigBase AppConfigBase": "2",
+                    "__LEVEL__": "INFO",
+                    "__THREAD__": "2",
+                    "log.file.offset": "0",
+                    "microtime": "1693833333200000"
                 },
-                {
-                        "contents" : 
-                        {
-                                "/ilogtail/AppConfigBase.cpp" : "3",
-                                "AppConfigBase AppConfigBase" : "3",
-                                "__THREAD__" : "3",
-                                "log.file.offset" : "0",
-                                "microtime" : "1693833322300000"
-                        },
-                        "timestamp" : 1693833322,
-                        "timestampNanosecond" : 300000000,
-                        "type" : 1
-                }
+                "timestamp": 1693833333,
+                "timestampNanosecond": 200000000,
+                "type": 1
+            },
+            {
+                "contents": {
+                    "/ilogtail/AppConfigBase.cpp": "3",
+                    "AppConfigBase AppConfigBase": "3",
+                    "__LEVEL__": "WARNING",
+                    "__THREAD__": "3",
+                    "log.file.offset": "0",
+                    "microtime": "1693833322300000"
+                },
+                "timestamp": 1693833322,
+                "timestampNanosecond": 300000000,
+                "type": 1
+            },
+            {
+                "contents": {
+                    "/ilogtail/AppConfigBase.cpp": "2",
+                    "AppConfigBase AppConfigBase": "2",
+                    "__LEVEL__": "INFO",
+                    "__THREAD__": "2",
+                    "log.file.offset": "0",
+                    "microtime": "1693833350100000"
+                },
+                "timestamp": 1693833350,
+                "timestampNanosecond": 100000000,
+                "type": 1
+            },
+            {
+                "contents": {
+                    "/ilogtail/AppConfigBase.cpp": "3",
+                    "AppConfigBase AppConfigBase": "3",
+                    "__LEVEL__": "WARNING",
+                    "__THREAD__": "3",
+                    "log.file.offset": "0",
+                    "microtime": "1693833322300000"
+                },
+                "timestamp": 1693833322,
+                "timestampNanosecond": 300000000,
+                "type": 1
+            }
         ]
     })";
 
@@ -219,7 +254,7 @@ void ProcessorParseApsaraNativeUnittest::TestProcessWholeLine() {
             {
                 "contents" :
                 {
-                    "content" : "[2023-09-04 13:15:04.862181]	[info]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
+                    "content" : "[2023-09-04 13:15:04.862181]	[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -228,7 +263,7 @@ void ProcessorParseApsaraNativeUnittest::TestProcessWholeLine() {
             {
                 "contents" :
                 {
-                    "content" : "[2023-09-04 13:16:04.862181]	[info]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
+                    "content" : "[2023-09-04 13:16:04.862181]	[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -237,7 +272,7 @@ void ProcessorParseApsaraNativeUnittest::TestProcessWholeLine() {
             {
                 "contents" :
                 {
-                    "content" : "[1693833364862181]	[info]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
+                    "content" : "[1693833364862181]	[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -255,46 +290,45 @@ void ProcessorParseApsaraNativeUnittest::TestProcessWholeLine() {
     APSARA_TEST_TRUE_FATAL(processorInstance.Init(componentConfig, mContext));
     processorInstance.Process(eventGroup);
     std::string expectJson = R"({
-        "events" :
-        [
+        "events": [
             {
-                "contents" :
-                {
+                "contents": {
                     "/ilogtail/AppConfigBase.cpp": "100",
                     "AppConfigBase AppConfigBase": "success",
+                    "__LEVEL__": "INFO",
                     "__THREAD__": "385658",
                     "log.file.offset": "0",
                     "microtime": "1693833304862181"
                 },
-                "timestamp" : 1693833304,
+                "timestamp": 1693833304,
                 "timestampNanosecond": 862181000,
-                "type" : 1
+                "type": 1
             },
             {
-                "contents" :
-                {
+                "contents": {
                     "/ilogtail/AppConfigBase.cpp": "100",
                     "AppConfigBase AppConfigBase": "success",
+                    "__LEVEL__": "INFO",
                     "__THREAD__": "385658",
                     "log.file.offset": "0",
                     "microtime": "1693833364862181"
                 },
-                "timestamp" : 1693833364,
+                "timestamp": 1693833364,
                 "timestampNanosecond": 862181000,
-                "type" : 1
+                "type": 1
             },
             {
-                "contents" :
-                {
+                "contents": {
                     "/ilogtail/AppConfigBase.cpp": "100",
                     "AppConfigBase AppConfigBase": "success",
+                    "__LEVEL__": "INFO",
                     "__THREAD__": "385658",
                     "log.file.offset": "0",
                     "microtime": "1693833364862181"
                 },
-                "timestamp" : 1693833364,
+                "timestamp": 1693833364,
                 "timestampNanosecond": 862181000,
-                "type" : 1
+                "type": 1
             }
         ]
     })";
@@ -319,7 +353,7 @@ void ProcessorParseApsaraNativeUnittest::TestProcessWholeLinePart() {
             {
                 "contents" :
                 {
-                    "content" : "[2023-09-04 13:15:0]	[info]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
+                    "content" : "[2023-09-04 13:15:0]	[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -328,7 +362,7 @@ void ProcessorParseApsaraNativeUnittest::TestProcessWholeLinePart() {
             {
                 "contents" :
                 {
-                    "content" : "[2023-09-04 13:16:0[info]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
+                    "content" : "[2023-09-04 13:16:0[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -337,7 +371,7 @@ void ProcessorParseApsaraNativeUnittest::TestProcessWholeLinePart() {
             {
                 "contents" :
                 {
-                    "content" : "[1234560	[info]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
+                    "content" : "[1234560	[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -360,12 +394,12 @@ void ProcessorParseApsaraNativeUnittest::TestProcessWholeLinePart() {
     // check observablity
     int count = 3;
     APSARA_TEST_EQUAL_FATAL(count, processor.GetContext().GetProcessProfile().parseFailures);
-    APSARA_TEST_EQUAL_FATAL(count, processorInstance.mProcInRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(count), processorInstance.mProcInRecordsTotal->GetValue());
     // discard unmatch, so output is 0
-    APSARA_TEST_EQUAL_FATAL(0, processorInstance.mProcOutRecordsTotal->GetValue());
-    APSARA_TEST_EQUAL_FATAL(0, processor.mProcParseOutSizeBytes->GetValue());
-    APSARA_TEST_EQUAL_FATAL(count, processor.mProcDiscardRecordsTotal->GetValue());
-    APSARA_TEST_EQUAL_FATAL(count, processor.mProcParseErrorTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(0), processorInstance.mProcOutRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(0), processor.mProcParseOutSizeBytes->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(count), processor.mProcDiscardRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(count), processor.mProcParseErrorTotal->GetValue());
 }
 
 void ProcessorParseApsaraNativeUnittest::TestProcessKeyOverwritten() {
@@ -384,7 +418,7 @@ void ProcessorParseApsaraNativeUnittest::TestProcessKeyOverwritten() {
             {
                 "contents" :
                 {
-                    "content" : "[2023-09-04 13:15:04.862181]	[info]	[385658]	content:100		__raw__:success		__raw_log__:success",
+                    "content" : "[2023-09-04 13:15:04.862181]	[INFO]	[385658]	content:100		__raw__:success		__raw_log__:success",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -411,11 +445,10 @@ void ProcessorParseApsaraNativeUnittest::TestProcessKeyOverwritten() {
     APSARA_TEST_TRUE_FATAL(processorInstance.Init(componentConfig, mContext));
     processorInstance.Process(eventGroup);
     std::string expectJson = R"({
-        "events" :
-        [
+        "events": [
             {
-                "contents" :
-                {
+                "contents": {
+                    "__LEVEL__": "INFO",
                     "__THREAD__": "385658",
                     "__raw__": "success",
                     "__raw_log__": "success",
@@ -423,21 +456,20 @@ void ProcessorParseApsaraNativeUnittest::TestProcessKeyOverwritten() {
                     "log.file.offset": "0",
                     "microtime": "1693833304862181"
                 },
-                "timestamp" : 1693833304,
+                "timestamp": 1693833304,
                 "timestampNanosecond": 862181000,
-                "type" : 1
+                "type": 1
             },
             {
-                "contents" :
-                {
+                "contents": {
                     "__raw__": "value1",
                     "__raw_log__": "value1",
                     "content": "value1",
                     "log.file.offset": "0"
                 },
-                "timestamp" : 12345678901,
+                "timestamp": 12345678901,
                 "timestampNanosecond": 0,
-                "type" : 1
+                "type": 1
             }
         ]
     })";
@@ -462,7 +494,7 @@ void ProcessorParseApsaraNativeUnittest::TestUploadRawLog() {
             {
                 "contents" :
                 {
-                    "content" : "[2023-09-04 13:15:04.862181]	[info]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
+                    "content" : "[2023-09-04 13:15:04.862181]	[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -489,33 +521,31 @@ void ProcessorParseApsaraNativeUnittest::TestUploadRawLog() {
     APSARA_TEST_TRUE_FATAL(processorInstance.Init(componentConfig, mContext));
     processorInstance.Process(eventGroup);
     std::string expectJson = R"({
-        "events" :
-        [
+        "events": [
             {
-                "contents" :
-                {
+                "contents": {
                     "/ilogtail/AppConfigBase.cpp": "100",
                     "AppConfigBase AppConfigBase": "success",
+                    "__LEVEL__": "INFO",
                     "__THREAD__": "385658",
-                    "__raw__": "[2023-09-04 13:15:04.862181]\t[info]\t[385658]\t/ilogtail/AppConfigBase.cpp:100\t\tAppConfigBase AppConfigBase:success",
+                    "__raw__": "[2023-09-04 13:15:04.862181]t[INFO]t[385658]t/ilogtail/AppConfigBase.cpp:100ttAppConfigBase AppConfigBase:success",
                     "log.file.offset": "0",
                     "microtime": "1693833304862181"
                 },
-                "timestamp" : 1693833304,
+                "timestamp": 1693833304,
                 "timestampNanosecond": 862181000,
-                "type" : 1
+                "type": 1
             },
             {
-                "contents" :
-                {
+                "contents": {
                     "__raw__": "value1",
                     "__raw_log__": "value1",
                     "content": "value1",
                     "log.file.offset": "0"
                 },
-                "timestamp" : 12345678901,
+                "timestamp": 12345678901,
                 "timestampNanosecond": 0,
-                "type" : 1
+                "type": 1
             }
         ]
     })";
@@ -539,7 +569,7 @@ void ProcessorParseApsaraNativeUnittest::TestAddLog() {
     char value[] = "value";
     processor.AddLog(key, value, *logEvent);
     // check observability
-    APSARA_TEST_EQUAL_FATAL(strlen(key) + strlen(value) + 5, processor.GetContext().GetProcessProfile().logGroupSize);
+    APSARA_TEST_EQUAL_FATAL(int(strlen(key) + strlen(value) + 5), processor.GetContext().GetProcessProfile().logGroupSize);
 }
 
 void ProcessorParseApsaraNativeUnittest::TestProcessEventKeepUnmatch() {
@@ -678,16 +708,16 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventKeepUnmatch() {
     // check observablity
     int count = 5;
     APSARA_TEST_EQUAL_FATAL(count, processor.GetContext().GetProcessProfile().parseFailures);
-    APSARA_TEST_EQUAL_FATAL(count, processorInstance.mProcInRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(count), processorInstance.mProcInRecordsTotal->GetValue());
     std::string expectValue = "value1";
     APSARA_TEST_EQUAL_FATAL((expectValue.length()) * count, processor.mProcParseInSizeBytes->GetValue());
-    APSARA_TEST_EQUAL_FATAL(count, processorInstance.mProcOutRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(count), processorInstance.mProcOutRecordsTotal->GetValue());
     expectValue = "__raw_log__value1";
     APSARA_TEST_EQUAL_FATAL((expectValue.length()) * count, processor.mProcParseOutSizeBytes->GetValue());
 
-    APSARA_TEST_EQUAL_FATAL(0, processor.mProcDiscardRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(0), processor.mProcDiscardRecordsTotal->GetValue());
 
-    APSARA_TEST_EQUAL_FATAL(count, processor.mProcParseErrorTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(count), processor.mProcParseErrorTotal->GetValue());
 }
 
 void ProcessorParseApsaraNativeUnittest::TestProcessEventDiscardUnmatch() {
@@ -766,14 +796,14 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventDiscardUnmatch() {
     // check observablity
     int count = 5;
     APSARA_TEST_EQUAL_FATAL(count, processor.GetContext().GetProcessProfile().parseFailures);
-    APSARA_TEST_EQUAL_FATAL(count, processorInstance.mProcInRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(count), processorInstance.mProcInRecordsTotal->GetValue());
     std::string expectValue = "value1";
     APSARA_TEST_EQUAL_FATAL((expectValue.length()) * count, processor.mProcParseInSizeBytes->GetValue());
     // discard unmatch, so output is 0
-    APSARA_TEST_EQUAL_FATAL(0, processorInstance.mProcOutRecordsTotal->GetValue());
-    APSARA_TEST_EQUAL_FATAL(0, processor.mProcParseOutSizeBytes->GetValue());
-    APSARA_TEST_EQUAL_FATAL(count, processor.mProcDiscardRecordsTotal->GetValue());
-    APSARA_TEST_EQUAL_FATAL(count, processor.mProcParseErrorTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(0), processorInstance.mProcOutRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(0), processor.mProcParseOutSizeBytes->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(count), processor.mProcDiscardRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(count), processor.mProcParseErrorTotal->GetValue());
 }
 
 } // namespace logtail

--- a/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
@@ -59,15 +59,16 @@ UNIT_TEST_CASE(ProcessorParseApsaraNativeUnittest, TestProcessEventDiscardUnmatc
 UNIT_TEST_CASE(ProcessorParseApsaraNativeUnittest, TestMultipleLines);
 
 void ProcessorParseApsaraNativeUnittest::TestMultipleLines() {
+    // 第一个contents 测试多行下的解析，第二个contents测试多行下time的解析
     std::string inJson = R"({
         "events" :
         [
             {
                 "contents" :
                 {
-                    "content" : "[2023-09-04 13:15:50.1]	[ERROR]	[1]	/ilogtail/AppConfigBase.cpp:1		AppConfigBase AppConfigBase:1
-[2023-09-04 13:15:33.2]	[INFO]	[2]	/ilogtail/AppConfigBase.cpp:2		AppConfigBase AppConfigBase:2
-[2023-09-04 13:15:22.3]	[WARNING]	[3]	/ilogtail/AppConfigBase.cpp:3		AppConfigBase AppConfigBase:3",
+                    "content" : "[2023-09-04 13:15:50.1]\t[ERROR]\t[1]\t/ilogtail/AppConfigBase.cpp:1\t\tAppConfigBase AppConfigBase:1
+[2023-09-04 13:15:33.2]\t[INFO]\t[2]\t/ilogtail/AppConfigBase.cpp:2\t\tAppConfigBase AppConfigBase:2
+[2023-09-04 13:15:22.3]\t[WARNING]\t[3]\t/ilogtail/AppConfigBase.cpp:3\t\tAppConfigBase AppConfigBase:3",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -76,8 +77,9 @@ void ProcessorParseApsaraNativeUnittest::TestMultipleLines() {
             {
                 "contents" :
                 {
-                    "content" : "[2023-09-04 13:15:50.1] [ERROR] [1[2023-09-04 13:15:33.2]	[INFO]	[2]	/ilogtail/AppConfigBase.cpp:2		AppConfigBase AppConfigBase:2
-[2023-09-04 13:15:22.3]	[WARNING]	[3]	/ilogtail/AppConfigBase.cpp:3		AppConfigBase AppConfigBase:3",
+                    "content" : "[2023-09-04 13:15
+:50.1]\t[ERROR]\t[1]\t/ilogtail/AppConfigBase.cpp:1\t\tAppConfigBase AppConfigBase:1
+[2023-09-04 13:15:22.3]\t[WARNING]\t[3]\t/ilogtail/AppConfigBase.cpp:3\t\tAppConfigBase AppConfigBase:3",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -130,15 +132,22 @@ void ProcessorParseApsaraNativeUnittest::TestMultipleLines() {
             },
             {
                 "contents": {
-                    "/ilogtail/AppConfigBase.cpp": "2",
-                    "AppConfigBase AppConfigBase": "2",
-                    "__LEVEL__": "INFO",
-                    "__THREAD__": "2",
-                    "log.file.offset": "0",
-                    "microtime": "1693833350100000"
+                    "__raw_log__": "[2023-09-04 13:15",
+                    "content": "[2023-09-04 13:15",
+                    "log.file.offset": "0"
                 },
-                "timestamp": 1693833350,
-                "timestampNanosecond": 100000000,
+                "timestamp": 12345678901,
+                "timestampNanosecond": 0,
+                "type": 1
+            },
+            {
+                "contents": {
+                    "__raw_log__": ":50.1]\t[ERROR]\t[1]\t/ilogtail/AppConfigBase.cpp:1\t\tAppConfigBase AppConfigBase:1",
+                    "content": ":50.1]\t[ERROR]\t[1]\t/ilogtail/AppConfigBase.cpp:1\t\tAppConfigBase AppConfigBase:1",
+                    "log.file.offset": "0"
+                },
+                "timestamp": 12345678901,
+                "timestampNanosecond": 0,
                 "type": 1
             },
             {
@@ -219,6 +228,8 @@ void ProcessorParseApsaraNativeUnittest::TestMultipleLines() {
         processor.Process(eventGroup);
         // judge result
         std::string outJson = eventGroup.ToJsonString();
+        std::string outJson2 = CompactJson(outJson);
+        
         APSARA_TEST_STREQ_FATAL(CompactJson(expectJson).c_str(), CompactJson(outJson).c_str());
     }
 }
@@ -254,7 +265,7 @@ void ProcessorParseApsaraNativeUnittest::TestProcessWholeLine() {
             {
                 "contents" :
                 {
-                    "content" : "[2023-09-04 13:15:04.862181]	[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
+                    "content" : "[2023-09-04 13:15:04.862181]\t[INFO]\t[385658]\t/ilogtail/AppConfigBase.cpp:100\t\tAppConfigBase AppConfigBase:success",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -263,7 +274,7 @@ void ProcessorParseApsaraNativeUnittest::TestProcessWholeLine() {
             {
                 "contents" :
                 {
-                    "content" : "[2023-09-04 13:16:04.862181]	[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
+                    "content" : "[2023-09-04 13:16:04.862181]\t[INFO]\t[385658]\t/ilogtail/AppConfigBase.cpp:100\t\tAppConfigBase AppConfigBase:success",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -272,7 +283,7 @@ void ProcessorParseApsaraNativeUnittest::TestProcessWholeLine() {
             {
                 "contents" :
                 {
-                    "content" : "[1693833364862181]	[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
+                    "content" : "[1693833364862181]\t[INFO]\t[385658]\t/ilogtail/AppConfigBase.cpp:100\t\tAppConfigBase AppConfigBase:success",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -353,7 +364,7 @@ void ProcessorParseApsaraNativeUnittest::TestProcessWholeLinePart() {
             {
                 "contents" :
                 {
-                    "content" : "[2023-09-04 13:15:0]	[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
+                    "content" : "[2023-09-04 13:15:0]\t[INFO]\t[385658]\t/ilogtail/AppConfigBase.cpp:100\t\tAppConfigBase AppConfigBase:success",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -362,7 +373,7 @@ void ProcessorParseApsaraNativeUnittest::TestProcessWholeLinePart() {
             {
                 "contents" :
                 {
-                    "content" : "[2023-09-04 13:16:0[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
+                    "content" : "[2023-09-04 13:16:0[INFO]\t[385658]\t/ilogtail/AppConfigBase.cpp:100\t\tAppConfigBase AppConfigBase:success",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -371,7 +382,7 @@ void ProcessorParseApsaraNativeUnittest::TestProcessWholeLinePart() {
             {
                 "contents" :
                 {
-                    "content" : "[1234560	[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
+                    "content" : "[1234560\t[INFO]\t[385658]\t/ilogtail/AppConfigBase.cpp:100\t\tAppConfigBase AppConfigBase:success",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -418,7 +429,7 @@ void ProcessorParseApsaraNativeUnittest::TestProcessKeyOverwritten() {
             {
                 "contents" :
                 {
-                    "content" : "[2023-09-04 13:15:04.862181]	[INFO]	[385658]	content:100		__raw__:success		__raw_log__:success",
+                    "content" : "[2023-09-04 13:15:04.862181]\t[INFO]\t[385658]\tcontent:100\t\t__raw__:success\t\t__raw_log__:success",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -494,7 +505,7 @@ void ProcessorParseApsaraNativeUnittest::TestUploadRawLog() {
             {
                 "contents" :
                 {
-                    "content" : "[2023-09-04 13:15:04.862181]	[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success",
+                    "content" : "[2023-09-04 13:15:04.862181]\t[INFO]\t[385658]\t/ilogtail/AppConfigBase.cpp:100\t\tAppConfigBase AppConfigBase:success",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -528,7 +539,7 @@ void ProcessorParseApsaraNativeUnittest::TestUploadRawLog() {
                     "AppConfigBase AppConfigBase": "success",
                     "__LEVEL__": "INFO",
                     "__THREAD__": "385658",
-                    "__raw__": "[2023-09-04 13:15:04.862181]t[INFO]t[385658]t/ilogtail/AppConfigBase.cpp:100ttAppConfigBase AppConfigBase:success",
+                    "__raw__": "[2023-09-04 13:15:04.862181]\t[INFO]\t[385658]\t/ilogtail/AppConfigBase.cpp:100\t\tAppConfigBase AppConfigBase:success",
                     "log.file.offset": "0",
                     "microtime": "1693833304862181"
                 },

--- a/core/unittest/processor/ProcessorParseJsonNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseJsonNativeUnittest.cpp
@@ -70,10 +70,7 @@ void ProcessorParseJsonNativeUnittest::TestMultipleLines() {
                 {
                     "contents" :
                     {
-                        "content" : "{\"url\": \"POST /PutData?Category=YunOsAccountOpLog HTTP/1.1\",\"time\": \"07/Jul/2022:10:30:28\"})";
-            inJson += '\0';
-            inJson
-                += R"({\"name\":\"Mike\",\"age\":25,\"is_student\":asdfsadf,\"address\":{\"city\":\"Hangzhou\",\"postal_code\":\"100000\"},\"courses\":[\"Math\",\"English\",\"Science\"],\"scores\":{\"Math\":90,\"English\":85,\"Science\":95}}",
+                        "content" : "{\"url\": \"POST /PutData?Category=YunOsAccountOpLog HTTP/1.1\",\"time\": \"07/Jul/2022:10:30:28\"}\u0000{\"name\":\"Mike\",\"age\":25,\"is_student\":asdfsadf,\"address\":{\"city\":\"Hangzhou\",\"postal_code\":\"100000\"},\"courses\":[\"Math\",\"English\",\"Science\"],\"scores\":{\"Math\":90,\"English\":85,\"Science\":95}}",
                         "log.file.offset": "0"
                     },
                     "timestampNanosecond" : 0,
@@ -154,10 +151,7 @@ void ProcessorParseJsonNativeUnittest::TestMultipleLines() {
                 {
                     "contents" :
                     {
-                        "content" : "{\"url\": \"POST /PutData?Category=YunOsAccountOpLog HTTP/1.1\",\"time\": \"07/Jul/2022:10:30:28\"})";
-            inJson += '\0';
-            inJson
-                += R"({\"name\":\"Mike\",\"age\":25,\"is_student\":false,\"address\":{\"city\":\"Hangzhou\",\"postal_code\":\"100000\"},\"courses\":[\"Math\",\"English\",\"Science\"],\"scores\":{\"Math\":90,\"English\":85,\"Science\":95}}",
+                        "content" : "{\"url\": \"POST /PutData?Category=YunOsAccountOpLog HTTP/1.1\",\"time\": \"07/Jul/2022:10:30:28\"}\u0000{\"name\":\"Mike\",\"age\":25,\"is_student\":false,\"address\":{\"city\":\"Hangzhou\",\"postal_code\":\"100000\"},\"courses\":[\"Math\",\"English\",\"Science\"],\"scores\":{\"Math\":90,\"English\":85,\"Science\":95}}",
                         "log.file.offset": "0"
                     },
                     "timestampNanosecond" : 0,


### PR DESCRIPTION
This commit addresses incorrect parsing outcomes in ProcessorParseApsaraNative when reading a large buffer that contains multiple log entries. New unit tests have been introduced for ProcessorParseApsaraNative, ProcessorParseDelimiterNative, and ProcessorParseJsonNative to verify accurate parsing of log data in scenarios involving large buffer inputs.