### PR TITLE
Support jsonline protocol

### DIFF
--- a/docs/cn/data-pipeline/flusher/flusher-http.md
+++ b/docs/cn/data-pipeline/flusher/flusher-http.md
@@ -10,27 +10,27 @@
 
 ## 配置参数
 
-| 参数                           | 类型                 | 是否必选 | 说明                                                                                                                                                                                         |
-|------------------------------|--------------------| -------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Type                         | String             | 是       | 插件类型，固定为`flusher_http`                                                                                                                                                                     |
-| RemoteURL                    | String             | 是       | 要发送到的URL地址，示例：`http://localhost:8086/write`                                                                                                                                                |
+| 参数                           | 类型                 | 是否必选 | 说明                                                                                                                                                                                       |
+|------------------------------|--------------------| -------- |------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Type                         | String             | 是       | 插件类型，固定为`flusher_http`                                                                                                                                                                   |
+| RemoteURL                    | String             | 是       | 要发送到的URL地址，示例：`http://localhost:8086/write`                                                                                                                                              |
 | Headers                      | Map<String,String> | 否       | 发送时附加的http请求header，如可添加 Authorization、Content-Type等信息，支持动态变量写法，如`{"x-db":"%{tag.db}"}`<p>v2版本支持从Group的Metadata或者Group.Tags中获取动态变量，如`{"x-db":"%{metadata.db}"}`或者`{"x-db":"%{tag.db}"}`</p> |
-| Query                        | Map<String,String> | 否       | 发送时附加到url上的query参数，支持动态变量写法，如`{"db":"%{tag.db}"}`<p>v2版本支持从Group的Metadata或者Group.Tags中获取动态变量，如`{"db":"%{metadata.db}"}`或者`{"db":"%{tag.db}"}`</p>                                          |
-| Timeout                      | String             | 否       | 请求的超时时间，默认 `60s`                                                                                                                                                                           |
-| Retry.Enable                 | Boolean            | 否       | 是否开启失败重试，默认为 `true`                                                                                                                                                                        |
-| Retry.MaxRetryTimes          | Int                | 否       | 最大重试次数，默认为 `3`                                                                                                                                                                             |
-| Retry.InitialDelay           | String             | 否       | 首次重试时间间隔，默认为 `1s`，重试间隔以会2的倍数递增                                                                                                                                                             |
-| Retry.MaxDelay               | String             | 否       | 最大重试时间间隔，默认为 `30s`                                                                                                                                                                         |
-| Convert                      | Struct             | 否       | ilogtail数据转换协议配置                                                                                                                                                                           |
-| Convert.Protocol             | String             | 否       | ilogtail数据转换协议，可选值：`custom_single`,`influxdb`。默认值：`custom_single`<p>v2版本可选值：`raw`</p>                                                                                                      |
-| Convert.Encoding             | String             | 否       | ilogtail flusher数据转换编码，可选值：`json`, `custom`，默认值：`json`                                                                                                                                     |
-| Convert.Separator            | String             | 否       | ilogtail数据转换时，PipelineGroupEvents中多个Events之间拼接使用的分隔符。如`\n`。若不设置，则默认不拼接Events，即每个Event作为独立请求向后发送。 默认值为空。<p>当前仅在`Convert.Protocol: raw`有效。</p>      |
-| Convert.IgnoreUnExpectedData | Boolean            | 否       | ilogtail数据转换时，遇到非预期的数据的行为，true 跳过，false 报错。默认值 true                                                                                               |
-| Convert.TagFieldsRename      | Map<String,String> | 否       | 对日志中tags中的json字段重命名                                                                                                                               |
-| Convert.ProtocolFieldsRename | Map<String,String> | 否       | ilogtail日志协议字段重命名，可当前可重命名的字段：`contents`,`tags`和`time`                                                                                             |
-| Concurrency                  | Int                | 否       | 向url发起请求的并发数，默认为`1`                                                                                                                               |
-| QueueCapacity                  | Int                | 否       | 内部channel的缓存大小，默认为1024      
-| AsyncIntercept                  | Boolean                | 否       | 异步过滤数据，默认为否  
+| Query                        | Map<String,String> | 否       | 发送时附加到url上的query参数，支持动态变量写法，如`{"db":"%{tag.db}"}`<p>v2版本支持从Group的Metadata或者Group.Tags中获取动态变量，如`{"db":"%{metadata.db}"}`或者`{"db":"%{tag.db}"}`</p>                                        |
+| Timeout                      | String             | 否       | 请求的超时时间，默认 `60s`                                                                                                                                                                         |
+| Retry.Enable                 | Boolean            | 否       | 是否开启失败重试，默认为 `true`                                                                                                                                                                      |
+| Retry.MaxRetryTimes          | Int                | 否       | 最大重试次数，默认为 `3`                                                                                                                                                                           |
+| Retry.InitialDelay           | String             | 否       | 首次重试时间间隔，默认为 `1s`，重试间隔以会2的倍数递增                                                                                                                                                           |
+| Retry.MaxDelay               | String             | 否       | 最大重试时间间隔，默认为 `30s`                                                                                                                                                                       |
+| Convert                      | Struct             | 否       | ilogtail数据转换协议配置                                                                                                                                                                         |
+| Convert.Protocol             | String             | 否       | ilogtail数据转换协议，可选值：`custom_single`,`influxdb`, `jsonline`。默认值：`custom_single`<p>v2版本可选值：`raw`</p>                                                                                        |
+| Convert.Encoding             | String             | 否       | ilogtail flusher数据转换编码，可选值：`json`, `custom`，默认值：`json`                                                                                                                                   |
+| Convert.Separator            | String             | 否       | ilogtail数据转换时，PipelineGroupEvents中多个Events之间拼接使用的分隔符。如`\n`。若不设置，则默认不拼接Events，即每个Event作为独立请求向后发送。 默认值为空。<p>当前仅在`Convert.Protocol: raw`有效。</p>                                             |
+| Convert.IgnoreUnExpectedData | Boolean            | 否       | ilogtail数据转换时，遇到非预期的数据的行为，true 跳过，false 报错。默认值 true                                                                                                                                      |
+| Convert.TagFieldsRename      | Map<String,String> | 否       | 对日志中tags中的json字段重命名                                                                                                                                                                      |
+| Convert.ProtocolFieldsRename | Map<String,String> | 否       | ilogtail日志协议字段重命名，可当前可重命名的字段：`contents`,`tags`和`time`                                                                                                                                    |
+| Concurrency                  | Int                | 否       | 向url发起请求的并发数，默认为`1`                                                                                                                                                                      |
+| QueueCapacity                  | Int                | 否       | 内部channel的缓存大小，默认为1024                                                                                                                                                                   
+| AsyncIntercept                  | Boolean                | 否       | 异步过滤数据，默认为否                                                                                                                                                                              
 
 ## 样例
 
@@ -52,3 +52,30 @@ flushers:
       Protocol: custom_single
       Encoding: json
 ```
+
+采集Docker日志，并将采集结果以`jsonline`协议发送到`http://localhost:9428/insert/jsonline`。
+
+```yaml
+enable: true
+inputs:
+  - Type: service_docker_stdout
+    Stderr: true
+    Stdout: true
+processors:
+  - Type: processor_json
+    SourceKey: content
+    KeepSource: true
+    ExpandDepth: 1
+    ExpandConnector: ""
+    KeepSourceIfParseError: true
+flushers:
+  - Type: flusher_http
+    RemoteURL: http://localhsot:9428/insert/jsonline
+    QueueCapacity: 64
+    Convert:
+      Protocol: jsonline
+      Encoding: json
+```
+
+需要注意的是，由于使用`jsonline`协议（会将日志的content和tag打平），所以仅支持使用`json`格式进行提交。
+由于`jsonline`默认会批量提交日志，所以建议调低`QueueCapacity`，避免在日志量较大的情况下，发生内存占用过多或OOM的问题。

--- a/pkg/protocol/converter/converter.go
+++ b/pkg/protocol/converter/converter.go
@@ -29,6 +29,7 @@ const (
 	ProtocolCustomSingleFlatten = "custom_single_flatten"
 	ProtocolOtlpV1              = "otlp_v1"
 	ProtocolInfluxdb            = "influxdb"
+	ProtocolJsonline            = "jsonline"
 	ProtocolRaw                 = "raw"
 )
 
@@ -110,6 +111,9 @@ var supportedEncodingMap = map[string]map[string]bool{
 	ProtocolInfluxdb: {
 		EncodingCustom: true,
 	},
+	ProtocolJsonline: {
+		EncodingJSON: true,
+	},
 	ProtocolRaw: {
 		EncodingCustom: true,
 	},
@@ -181,6 +185,8 @@ func (c *Converter) ToByteStreamWithSelectedFields(logGroup *protocol.LogGroup, 
 		return c.ConvertToSingleProtocolStreamFlatten(logGroup, targetFields)
 	case ProtocolInfluxdb:
 		return c.ConvertToInfluxdbProtocolStream(logGroup, targetFields)
+	case ProtocolJsonline:
+		return c.ConvertToJsonlineProtocolStreamFlatten(logGroup)
 	default:
 		return nil, nil, fmt.Errorf("unsupported protocol: %s", c.Protocol)
 	}

--- a/pkg/protocol/converter/jsonline.go
+++ b/pkg/protocol/converter/jsonline.go
@@ -1,0 +1,57 @@
+package protocol
+
+import (
+	"bytes"
+	"fmt"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/alibaba/ilogtail/pkg/protocol"
+)
+
+var (
+	sep = []byte("\n")
+)
+
+func (c *Converter) ConvertToJsonlineProtocolStreamFlatten(logGroup *protocol.LogGroup) ([]byte, []map[string]string, error) {
+	convertedLogs, _, err := c.ConvertToSingleProtocolLogsFlatten(logGroup, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	joinedStream := *GetPooledByteBuf()
+	for i, log := range convertedLogs {
+		switch c.Encoding {
+		case EncodingJSON:
+			var err error
+			joinedStream, err = marshalWithoutHTMLEscapedWithoutAlloc(log, bytes.NewBuffer(joinedStream))
+			if err != nil {
+				// release byte buffer
+				PutPooledByteBuf(&joinedStream)
+				return nil, nil, fmt.Errorf("unable to marshal log: %v", log)
+			}
+			// trim and append a \n
+			joinedStream = trimRightByte(joinedStream, sep[0])
+			if i < len(convertedLogs)-1 {
+				joinedStream = append(joinedStream, sep[0])
+			}
+		default:
+			return nil, nil, fmt.Errorf("unsupported encoding format: %s", c.Encoding)
+		}
+	}
+	return joinedStream, nil, nil
+}
+
+func marshalWithoutHTMLEscapedWithoutAlloc(data interface{}, bf *bytes.Buffer) ([]byte, error) {
+	enc := jsoniter.ConfigFastest.NewEncoder(bf)
+	if err := enc.Encode(data); err != nil {
+		return nil, err
+	}
+	return bf.Bytes(), nil
+}
+
+func trimRightByte(s []byte, c byte) []byte {
+	for len(s) > 0 && s[len(s)-1] == c {
+		s = s[:len(s)-1]
+	}
+	return s
+}

--- a/pkg/protocol/converter/jsonline_test.go
+++ b/pkg/protocol/converter/jsonline_test.go
@@ -1,0 +1,246 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/alibaba/ilogtail/pkg/flags"
+	"github.com/alibaba/ilogtail/pkg/protocol"
+)
+
+func TestNewConvertToJsonlineLogs(t *testing.T) {
+	Convey("When constructing converter with unsupported encoding", t, func() {
+		_, err := NewConverter(ProtocolJsonline, EncodingNone, nil, nil)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("Given a converter with protocol: single, encoding: json, with tag rename and protocol key rename", t, func() {
+		keyRenameMap := map[string]string{
+			"k8s.node.ip": "ip",
+			"host.name":   "hostname",
+			"label":       "tag",
+			"env":         "env_tag",
+		}
+		protocolKeyRenameMap := map[string]string{
+			"time": "@timestamp",
+		}
+		c, err := NewConverter(ProtocolJsonline, EncodingJSON, keyRenameMap, protocolKeyRenameMap)
+		So(err, ShouldBeNil)
+
+		Convey("When the logGroup is generated from files and from k8s daemonset environment", func() {
+			*flags.K8sFlag = true
+			time := []uint32{1662434209, 1662434487}
+			method := []string{"PUT", "GET"}
+			status := []string{"200", "404"}
+			logs := make([]*protocol.Log, 2)
+			for i := 0; i < 2; i++ {
+				logs[i] = &protocol.Log{
+					Time: time[i],
+					Contents: []*protocol.Log_Content{
+						{Key: "method", Value: method[i]},
+						{Key: "status", Value: status[i]},
+						{Key: "__tag__:__user_defined_id__", Value: "machine"},
+						{Key: "__tag__:__path__", Value: "/root/test/origin/example.log"},
+						{Key: "__tag__:_node_name_", Value: "node"},
+						{Key: "__tag__:_node_ip_", Value: "172.10.1.19"},
+						{Key: "__tag__:_namespace_", Value: "default"},
+						{Key: "__tag__:_pod_name_", Value: "container"},
+						{Key: "__tag__:_pod_uid_", Value: "12AFERR234SG-SBH6D67HJ9-AAD-VF34"},
+						{Key: "__tag__:_container_name_", Value: "container"},
+						{Key: "__tag__:_container_ip_", Value: "172.10.0.45"},
+						{Key: "__tag__:_image_name_", Value: "image"},
+						{Key: "__tag__:label", Value: "tag"},
+						{Key: "__log_topic__", Value: "file"},
+					},
+				}
+			}
+			tags := []*protocol.LogTag{
+				{Key: "__hostname__", Value: "alje834hgf"},
+				{Key: "__pack_id__", Value: "AEDCFGHNJUIOPLMN-1E"},
+				{Key: "env", Value: "K8S"},
+			}
+			logGroup := &protocol.LogGroup{
+				Logs:     logs,
+				Category: "test",
+				Topic:    "file",
+				Source:   "172.10.0.56",
+				LogTags:  tags,
+			}
+
+			Convey("Then the converted log should be valid", func() {
+				b, err := c.ToByteStream(logGroup)
+				So(err, ShouldBeNil)
+
+				for _, s := range bytes.Split(b.([]byte), []byte("\n")) {
+					unmarshaledLog := make(map[string]interface{})
+					err = json.Unmarshal(s, &unmarshaledLog)
+					So(err, ShouldBeNil)
+					So(unmarshaledLog, ShouldContainKey, "method")
+					So(unmarshaledLog, ShouldContainKey, "@timestamp")
+					So(unmarshaledLog, ShouldContainKey, "log.file.path")
+					So(unmarshaledLog, ShouldContainKey, "hostname")
+					So(unmarshaledLog, ShouldContainKey, "host.ip")
+					So(unmarshaledLog, ShouldContainKey, "log.topic")
+					So(unmarshaledLog, ShouldContainKey, "ip")
+					So(unmarshaledLog, ShouldContainKey, "k8s.node.name")
+					So(unmarshaledLog, ShouldContainKey, "k8s.namespace.name")
+					So(unmarshaledLog, ShouldContainKey, "k8s.pod.name")
+					So(unmarshaledLog, ShouldContainKey, "k8s.pod.uid")
+					So(unmarshaledLog, ShouldContainKey, "k8s.container.name")
+					So(unmarshaledLog, ShouldContainKey, "k8s.container.ip")
+					So(unmarshaledLog, ShouldContainKey, "k8s.container.image.name")
+					So(unmarshaledLog, ShouldContainKey, "tag")
+					So(unmarshaledLog, ShouldContainKey, "env_tag")
+				}
+			})
+
+			Convey("Then the corresponding value of the required fields are returned correctly", func() {
+				_, values, err := c.ToByteStreamWithSelectedFields(logGroup, []string{"content.method", "tag.host.name", "tag.ip"})
+				So(err, ShouldBeNil)
+				So(values, ShouldHaveLength, 0)
+			})
+		})
+	})
+
+	Convey("Given a converter with protocol: single, encoding: json, with null tag rename", t, func() {
+		keyRenameMap := map[string]string{
+			"k8s.node.ip": "",
+			"host.name":   "",
+			"label":       "",
+			"env":         "",
+		}
+		c, err := NewConverter(ProtocolJsonline, EncodingJSON, keyRenameMap, nil)
+		So(err, ShouldBeNil)
+
+		Convey("When the logGroup is generated from files and from k8s daemonset environment", func() {
+			*flags.K8sFlag = true
+			time := []uint32{1662434209, 1662434487}
+			method := []string{"PUT", "GET"}
+			status := []string{"200", "404"}
+			logs := make([]*protocol.Log, 2)
+			for i := 0; i < 2; i++ {
+				logs[i] = &protocol.Log{
+					Time: time[i],
+					Contents: []*protocol.Log_Content{
+						{Key: "method", Value: method[i]},
+						{Key: "status", Value: status[i]},
+						{Key: "__tag__:__user_defined_id__", Value: "machine"},
+						{Key: "__tag__:__path__", Value: "/root/test/origin/example.log"},
+						{Key: "__tag__:_node_name_", Value: "node"},
+						{Key: "__tag__:_node_ip_", Value: "172.10.1.19"},
+						{Key: "__tag__:_namespace_", Value: "default"},
+						{Key: "__tag__:_pod_name_", Value: "container"},
+						{Key: "__tag__:_pod_uid_", Value: "12AFERR234SG-SBH6D67HJ9-AAD-VF34"},
+						{Key: "__tag__:_container_name_", Value: "container"},
+						{Key: "__tag__:_container_ip_", Value: "172.10.0.45"},
+						{Key: "__tag__:_image_name_", Value: "image"},
+						{Key: "__tag__:label", Value: "tag"},
+						{Key: "__log_topic__", Value: "file"},
+					},
+				}
+			}
+			tags := []*protocol.LogTag{
+				{Key: "__hostname__", Value: "alje834hgf"},
+				{Key: "__pack_id__", Value: "AEDCFGHNJUIOPLMN-1E"},
+				{Key: "env", Value: "K8S"},
+			}
+			logGroup := &protocol.LogGroup{
+				Logs:     logs,
+				Category: "test",
+				Topic:    "file",
+				Source:   "172.10.0.56",
+				LogTags:  tags,
+			}
+
+			Convey("Then the converted log should be valid", func() {
+				b, err := c.ToByteStream(logGroup)
+				So(err, ShouldBeNil)
+
+				for _, s := range bytes.Split(b.([]byte), []byte("\n")) {
+					unmarshaledLog := make(map[string]interface{})
+					err = json.Unmarshal(s, &unmarshaledLog)
+					So(err, ShouldBeNil)
+					So(unmarshaledLog, ShouldContainKey, "time")
+					So(unmarshaledLog, ShouldContainKey, "method")
+					So(unmarshaledLog, ShouldContainKey, "status")
+					So(unmarshaledLog, ShouldContainKey, "log.file.path")
+					So(unmarshaledLog, ShouldContainKey, "host.ip")
+					So(unmarshaledLog, ShouldContainKey, "log.topic")
+					So(unmarshaledLog, ShouldContainKey, "k8s.node.name")
+					So(unmarshaledLog, ShouldContainKey, "k8s.namespace.name")
+					So(unmarshaledLog, ShouldContainKey, "k8s.pod.name")
+					So(unmarshaledLog, ShouldContainKey, "k8s.pod.uid")
+					So(unmarshaledLog, ShouldContainKey, "k8s.container.name")
+					So(unmarshaledLog, ShouldContainKey, "k8s.container.ip")
+					So(unmarshaledLog, ShouldContainKey, "k8s.container.image.name")
+				}
+			})
+		})
+
+		Convey("When the log is standardized", func() {
+			*flags.K8sFlag = true
+			time := []uint32{1662434209, 1662434487}
+			method := []string{"PUT", "GET"}
+			status := []string{"200", "404"}
+			logs := make([]*protocol.Log, 2)
+			for i := 0; i < 2; i++ {
+				logs[i] = &protocol.Log{
+					Time: time[i],
+					Contents: []*protocol.Log_Content{
+						{Key: "method", Value: method[i]},
+						{Key: "status", Value: status[i]},
+					},
+				}
+			}
+			tags := []*protocol.LogTag{
+				{Key: "__user_defined_id__", Value: "machine"},
+				{Key: "__hostname__", Value: "alje834hgf"},
+				{Key: "__pack_id__", Value: "AEDCFGHNJUIOPLMN-1E"},
+				{Key: "__path__", Value: "/root/test/origin/example.log"},
+				{Key: "_node_name_", Value: "node"},
+				{Key: "_node_ip_", Value: "172.10.1.19"},
+				{Key: "_namespace_", Value: "default"},
+				{Key: "_pod_name_", Value: "container"},
+				{Key: "_pod_uid_", Value: "12AFERR234SG-SBH6D67HJ9-AAD-VF34"},
+				{Key: "_container_name_", Value: "container"},
+				{Key: "_container_ip_", Value: "172.10.0.45"},
+				{Key: "_image_name_", Value: "image"},
+				{Key: "label", Value: "tag"},
+			}
+			logGroup := &protocol.LogGroup{
+				Logs:     logs,
+				Category: "test",
+				Topic:    "topic",
+				Source:   "172.10.0.56",
+				LogTags:  tags,
+			}
+
+			Convey("Then the converted log should be valid", func() {
+				b, err := c.ToByteStream(logGroup)
+				So(err, ShouldBeNil)
+
+				for _, s := range bytes.Split(b.([]byte), []byte("\n")) {
+					unmarshaledLog := make(map[string]interface{})
+					err = json.Unmarshal(s, &unmarshaledLog)
+					So(err, ShouldBeNil)
+					So(unmarshaledLog, ShouldContainKey, "time")
+					So(unmarshaledLog, ShouldContainKey, "method")
+					So(unmarshaledLog, ShouldContainKey, "status")
+					So(unmarshaledLog, ShouldContainKey, "log.file.path")
+					So(unmarshaledLog, ShouldContainKey, "host.ip")
+					So(unmarshaledLog, ShouldContainKey, "log.topic")
+					So(unmarshaledLog, ShouldContainKey, "k8s.node.name")
+					So(unmarshaledLog, ShouldContainKey, "k8s.namespace.name")
+					So(unmarshaledLog, ShouldContainKey, "k8s.pod.name")
+					So(unmarshaledLog, ShouldContainKey, "k8s.pod.uid")
+					So(unmarshaledLog, ShouldContainKey, "k8s.container.name")
+					So(unmarshaledLog, ShouldContainKey, "k8s.container.ip")
+					So(unmarshaledLog, ShouldContainKey, "k8s.container.image.name")
+				}
+			})
+		})
+	})
+}

--- a/plugins/flusher/http/flusher_http.go
+++ b/plugins/flusher/http/flusher_http.go
@@ -246,7 +246,7 @@ func (f *FlusherHTTP) initRequestInterceptors(transport http.RoundTripper) (http
 }
 
 func (f *FlusherHTTP) getConverter() (*converter.Converter, error) {
-	return converter.NewConverterWithSep(f.Convert.Protocol, f.Convert.Encoding, f.Convert.Separator, f.Convert.IgnoreUnExpectedData, nil, nil)
+	return converter.NewConverterWithSep(f.Convert.Protocol, f.Convert.Encoding, f.Convert.Separator, f.Convert.IgnoreUnExpectedData, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename)
 }
 
 func (f *FlusherHTTP) addTask(log interface{}) {


### PR DESCRIPTION
This PR is to support [jsonline protocol](https://jsonlines.org/) which is supported by the [FluentBit collector](https://docs.fluentbit.io/manual/pipeline/outputs/http).

This could help ilogtail work with [VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/), the newly released open-source log solution this year.