### PR TITLE
fix heartbeat miss filling hostname

### DIFF
--- a/core/config_manager/ConfigManager.cpp
+++ b/core/config_manager/ConfigManager.cpp
@@ -278,6 +278,7 @@ ConfigManager::SendHeartbeat(const AppConfig::ConfigServerAddress& configServerA
     heartBeatReq.set_agent_type("iLogtail");
     attributes.set_version(ILOGTAIL_VERSION);
     attributes.set_ip(LogFileProfiler::mIpAddr);
+    attributes.set_hostname(LogFileProfiler::mHostname);
     heartBeatReq.mutable_attributes()->MergeFrom(attributes);
     heartBeatReq.mutable_tags()->MergeFrom({AppConfig::GetInstance()->GetConfigServerTags().begin(),
                                             AppConfig::GetInstance()->GetConfigServerTags().end()});

--- a/core/config_manager/ConfigManagerBase.cpp
+++ b/core/config_manager/ConfigManagerBase.cpp
@@ -1312,7 +1312,7 @@ ConfigManagerBase::ConfigManagerBase() {
     CorrectionLogtailSysConfDir(); // first create dir then rewrite system-uuid file in GetSystemUUID
     // use a thread to get uuid, work around for CalculateDmiUUID hang
     // mUUID = CalculateDmiUUID();
-    mInstanceId = CalculateRandomUUID() + "_" + LogFileProfiler::mIpAddr + "_" + ToString(time(NULL));
+    mInstanceId = LogFileProfiler::mIpAddr + "_" + ToString(getpid()) + "_" + ToString(time(NULL));
     ReloadMappingConfig();
 }
 


### PR DESCRIPTION
 1. agent should report hostname to config server
 2. uuid is not helpful to identify agent. ip, pid and time is enough