### PR TITLE
Improve goprofile plugin to support real local IP inclusion

### DIFF
--- a/pkg/util/net_helper.go
+++ b/pkg/util/net_helper.go
@@ -85,7 +85,7 @@ func getExternalIP() (string, error) {
 	return "", errors.New("are you connected to the network?")
 }
 
-func TryConvertLocalhost2RealIp(ip string) string {
+func TryConvertLocalhost2RealIP(ip string) string {
 	if ip == "localhost" || ip == "127.0.0.1" || ip == "0.0.0.0" {
 		return GetIPAddress()
 	}

--- a/pkg/util/net_helper.go
+++ b/pkg/util/net_helper.go
@@ -84,3 +84,10 @@ func getExternalIP() (string, error) {
 	}
 	return "", errors.New("are you connected to the network?")
 }
+
+func TryConvertLocalhost2RealIp(ip string) string {
+	if ip == "localhost" || ip == "127.0.0.1" || ip == "0.0.0.0" {
+		return GetIPAddress()
+	}
+	return ip
+}

--- a/plugins/input/goprofile/discovery_static.go
+++ b/plugins/input/goprofile/discovery_static.go
@@ -64,11 +64,11 @@ func (k *StaticConfig) convertStaticConfig() (discovery.StaticConfig, error) {
 		} else {
 			return nil, errors.New("not found required service labels")
 		}
-		addr := net.JoinHostPort(util.TryConvertLocalhost2RealIP(address.Host), strconv.Itoa(int(address.Port)))
+		addr := net.JoinHostPort(address.Host, strconv.Itoa(int(address.Port)))
 		innerLabels := make(model.LabelSet)
 		innerLabels[model.AddressLabel] = model.LabelValue(addr)
 		innerLabels[model.AppNameLabel] = appName
-
+		innerLabels["__ip__"] = model.LabelValue(util.TryConvertLocalhost2RealIP(address.Host))
 		for key, val := range address.InstanceLabels {
 			innerLabels[model.LabelName(key)] = model.LabelValue(val)
 		}

--- a/plugins/input/goprofile/discovery_static.go
+++ b/plugins/input/goprofile/discovery_static.go
@@ -19,6 +19,8 @@ import (
 	"net"
 	"strconv"
 
+	"github.com/alibaba/ilogtail/pkg/util"
+
 	"github.com/pyroscope-io/pyroscope/pkg/scrape/discovery"
 	"github.com/pyroscope-io/pyroscope/pkg/scrape/discovery/targetgroup"
 	"github.com/pyroscope-io/pyroscope/pkg/scrape/model"
@@ -62,7 +64,7 @@ func (k *StaticConfig) convertStaticConfig() (discovery.StaticConfig, error) {
 		} else {
 			return nil, errors.New("not found required service labels")
 		}
-		addr := net.JoinHostPort(address.Host, strconv.Itoa(int(address.Port)))
+		addr := net.JoinHostPort(util.TryConvertLocalhost2RealIp(address.Host), strconv.Itoa(int(address.Port)))
 		innerLabels := make(model.LabelSet)
 		innerLabels[model.AddressLabel] = model.LabelValue(addr)
 		innerLabels[model.AppNameLabel] = appName

--- a/plugins/input/goprofile/discovery_static.go
+++ b/plugins/input/goprofile/discovery_static.go
@@ -16,9 +16,10 @@ package goprofile
 
 import (
 	"errors"
-	"github.com/alibaba/ilogtail/pkg/util"
 	"net"
 	"strconv"
+
+	"github.com/alibaba/ilogtail/pkg/util"
 
 	"github.com/pyroscope-io/pyroscope/pkg/scrape/discovery"
 	"github.com/pyroscope-io/pyroscope/pkg/scrape/discovery/targetgroup"

--- a/plugins/input/goprofile/discovery_static.go
+++ b/plugins/input/goprofile/discovery_static.go
@@ -16,10 +16,9 @@ package goprofile
 
 import (
 	"errors"
+	"github.com/alibaba/ilogtail/pkg/util"
 	"net"
 	"strconv"
-
-	"github.com/alibaba/ilogtail/pkg/util"
 
 	"github.com/pyroscope-io/pyroscope/pkg/scrape/discovery"
 	"github.com/pyroscope-io/pyroscope/pkg/scrape/discovery/targetgroup"
@@ -68,9 +67,8 @@ func (k *StaticConfig) convertStaticConfig() (discovery.StaticConfig, error) {
 		innerLabels := make(model.LabelSet)
 		innerLabels[model.AddressLabel] = model.LabelValue(addr)
 		innerLabels[model.AppNameLabel] = appName
-		innerLabels["__ip__"] = model.LabelValue(util.TryConvertLocalhost2RealIP(address.Host))
 		for key, val := range address.InstanceLabels {
-			innerLabels[model.LabelName(key)] = model.LabelValue(val)
+			innerLabels[model.LabelName(key)] = model.LabelValue(util.TryConvertLocalhost2RealIP(val))
 		}
 		cfg = append(cfg, &targetgroup.Group{
 			Source:  addr,

--- a/plugins/input/goprofile/discovery_static.go
+++ b/plugins/input/goprofile/discovery_static.go
@@ -64,7 +64,7 @@ func (k *StaticConfig) convertStaticConfig() (discovery.StaticConfig, error) {
 		} else {
 			return nil, errors.New("not found required service labels")
 		}
-		addr := net.JoinHostPort(util.TryConvertLocalhost2RealIp(address.Host), strconv.Itoa(int(address.Port)))
+		addr := net.JoinHostPort(util.TryConvertLocalhost2RealIP(address.Host), strconv.Itoa(int(address.Port)))
 		innerLabels := make(model.LabelSet)
 		innerLabels[model.AddressLabel] = model.LabelValue(addr)
 		innerLabels[model.AppNameLabel] = appName

--- a/plugins/input/jmxfetch/jmxfetch.go
+++ b/plugins/input/jmxfetch/jmxfetch.go
@@ -27,7 +27,6 @@ import (
 	"github.com/alibaba/ilogtail/pkg/helper"
 	"github.com/alibaba/ilogtail/pkg/logger"
 	"github.com/alibaba/ilogtail/pkg/pipeline"
-	"github.com/alibaba/ilogtail/pkg/util"
 )
 
 type Instance struct {
@@ -159,7 +158,7 @@ func (m *Jmx) Start(collector pipeline.Collector) error {
 			for k, v := range m.Tags {
 				m.StaticInstances[i].Tags[k] = v
 			}
-			inner := NewInstanceInner(m.StaticInstances[i].Port, util.TryConvertLocalhost2RealIP(m.StaticInstances[i].Host), m.StaticInstances[i].User,
+			inner := NewInstanceInner(m.StaticInstances[i].Port, m.StaticInstances[i].Host, m.StaticInstances[i].User,
 				m.StaticInstances[i].Password, m.StaticInstances[i].Tags, m.DefaultJvmMetrics)
 			m.instances[inner.Hash()] = inner
 		}

--- a/plugins/input/jmxfetch/jmxfetch.go
+++ b/plugins/input/jmxfetch/jmxfetch.go
@@ -27,6 +27,7 @@ import (
 	"github.com/alibaba/ilogtail/pkg/helper"
 	"github.com/alibaba/ilogtail/pkg/logger"
 	"github.com/alibaba/ilogtail/pkg/pipeline"
+	"github.com/alibaba/ilogtail/pkg/util"
 )
 
 type Instance struct {
@@ -158,7 +159,7 @@ func (m *Jmx) Start(collector pipeline.Collector) error {
 			for k, v := range m.Tags {
 				m.StaticInstances[i].Tags[k] = v
 			}
-			inner := NewInstanceInner(m.StaticInstances[i].Port, m.StaticInstances[i].Host, m.StaticInstances[i].User,
+			inner := NewInstanceInner(m.StaticInstances[i].Port, util.TryConvertLocalhost2RealIp(m.StaticInstances[i].Host), m.StaticInstances[i].User,
 				m.StaticInstances[i].Password, m.StaticInstances[i].Tags, m.DefaultJvmMetrics)
 			m.instances[inner.Hash()] = inner
 		}

--- a/plugins/input/jmxfetch/jmxfetch.go
+++ b/plugins/input/jmxfetch/jmxfetch.go
@@ -159,7 +159,7 @@ func (m *Jmx) Start(collector pipeline.Collector) error {
 			for k, v := range m.Tags {
 				m.StaticInstances[i].Tags[k] = v
 			}
-			inner := NewInstanceInner(m.StaticInstances[i].Port, util.TryConvertLocalhost2RealIp(m.StaticInstances[i].Host), m.StaticInstances[i].User,
+			inner := NewInstanceInner(m.StaticInstances[i].Port, util.TryConvertLocalhost2RealIP(m.StaticInstances[i].Host), m.StaticInstances[i].User,
 				m.StaticInstances[i].Password, m.StaticInstances[i].Tags, m.DefaultJvmMetrics)
 			m.instances[inner.Hash()] = inner
 		}


### PR DESCRIPTION
This commit addresses the limitation within the logtail profile schema regarding the inability to include the actual local IP address using the goprofile plugin. When profiling, the collection of non-specific host addresses (e.g., 127.0.0.1, localhost, or 0.0.0.0) leads to confusion over multiple target identification. To resolve this, the goprofile plugin has been enhanced to recognize and replace these generic addresses with the real local IP address of the machine.

Changes include:
- Automatic substitution of custom label values that correspond to 127.0.0.1, localhost, or 0.0.0.0 with the machine's actual local IP address.