### PR TITLE
Fix timestamp parsing compatibility issue for apsara log

### DIFF
--- a/core/processor/ProcessorParseApsaraNative.cpp
+++ b/core/processor/ProcessorParseApsaraNative.cpp
@@ -260,6 +260,7 @@ time_t ProcessorParseApsaraNative::ApsaraEasyReadLogTimeParser(StringView& buffe
             LOG_WARNING(sLogger, ("parse apsara log time", "fail")("string", buffer));
             return 0;
         }
+        // strTime is the content between '[' and ']' and ends with '\0'
         std::string strTime = buffer.substr(1, pos).to_string();
         auto strptimeResult = Strptime(strTime.c_str(), "%s", &lastLogTime, nanosecondLength);
         if (NULL == strptimeResult || strptimeResult[0] != ']') {
@@ -276,6 +277,7 @@ time_t ProcessorParseApsaraNative::ApsaraEasyReadLogTimeParser(StringView& buffe
             LOG_WARNING(sLogger, ("parse apsara log time", "fail")("string", buffer));
             return 0;
         }
+        // strTime is the content between '[' and ']' and ends with '\0'
         std::string strTime = buffer.substr(1, pos).to_string();
         if (IsPrefixString(strTime.c_str(), timeStr) == true) {
             microTime = (int64_t)lastLogTime.tv_sec * 1000000 + lastLogTime.tv_nsec / 1000;

--- a/core/processor/ProcessorParseApsaraNative.cpp
+++ b/core/processor/ProcessorParseApsaraNative.cpp
@@ -294,7 +294,7 @@ time_t ProcessorParseApsaraNative::ApsaraEasyReadLogTimeParser(StringView& buffe
             return 0;
         }
         // parse nanosecond part (optional)
-        if (*(strptimeResult + 1) != '\0') {
+        if (*strptimeResult != '\0') {
             strptimeResult = Strptime(strptimeResult + 1, "%f", &lastLogTime, nanosecondLength);
             if (NULL == strptimeResult) {
                 LOG_WARNING(sLogger,

--- a/core/processor/ProcessorParseApsaraNative.cpp
+++ b/core/processor/ProcessorParseApsaraNative.cpp
@@ -291,16 +291,12 @@ time_t ProcessorParseApsaraNative::ApsaraEasyReadLogTimeParser(StringView& buffe
                         ("parse apsara log time", "fail")("string", buffer)("timeformat", "%Y-%m-%d %H:%M:%S"));
             return 0;
         }
-        // parse nanosecond part (optional)
-        strptimeResult = Strptime(strptimeResult + 1, "%f", &lastLogTime, nanosecondLength);
-        if (NULL == strptimeResult) {
-            LOG_WARNING(sLogger,
-                        ("parse apsara log time", "fail")("string", buffer)("timeformat", "%Y-%m-%d %H:%M:%S.%f"));
-        }
+        auto microTimePart = GetApsaraLogMicroTimePart(strptimeResult);
         // if the time is valid (strptime not return NULL), the date value size must be 19 ,like '2013-09-11 03:11:05'
         timeStr = StringView(buffer.data() + 1, 19);
         lastLogTime.tv_sec = lastLogTime.tv_sec - mLogTimeZoneOffsetSecond;
-        microTime = (int64_t)lastLogTime.tv_sec * 1000000 + lastLogTime.tv_nsec / 1000;
+        lastLogTime.tv_nsec = microTimePart * 1000;
+        microTime = (int64_t)lastLogTime.tv_sec * 1000000 + microTimePart;
         return lastLogTime.tv_sec;
     }
 }
@@ -467,6 +463,32 @@ void ProcessorParseApsaraNative::AddLog(const StringView& key,
 
 bool ProcessorParseApsaraNative::IsSupportedEvent(const PipelineEventPtr& e) const {
     return e.Is<LogEvent>();
+}
+
+int32_t ProcessorParseApsaraNative::GetApsaraLogMicroTimePart(const char* buffer) {
+    int begIndex = 0;
+    static const int MICRO_TIME_LEN = 6;
+    char tmp[MICRO_TIME_LEN + 1]{};
+    while (buffer[begIndex]) {
+        if (buffer[begIndex] == '.') {
+            begIndex++;
+            break;
+        }
+        begIndex++;
+    }
+    int index = 0;
+    while (buffer[begIndex + index] && index < MICRO_TIME_LEN) {
+        if (buffer[begIndex + index] == ']' || buffer[begIndex + index] == '\0') {
+            break;
+        }
+        tmp[index] = buffer[begIndex + index];
+        index++;
+    }
+    for (; index < MICRO_TIME_LEN; ++index) {
+        tmp[index] = '0';
+    }
+    char* endPtr{};
+    return strtol(tmp, &endPtr, 10);
 }
 
 } // namespace logtail

--- a/core/processor/ProcessorParseApsaraNative.h
+++ b/core/processor/ProcessorParseApsaraNative.h
@@ -48,7 +48,6 @@ private:
     ApsaraEasyReadLogTimeParser(StringView& buffer, StringView& timeStr, LogtailTime& lastLogTime, int64_t& microTime);
     bool IsPrefixString(const char* all, const StringView& prefix);
     int32_t ParseApsaraBaseFields(const StringView& buffer, LogEvent& sourceEvent);
-    int32_t GetApsaraLogMicroTimePart(const char* buffer);
 
     int32_t mLogTimeZoneOffsetSecond = 0;
     bool mSourceKeyOverwritten = false;

--- a/core/processor/ProcessorParseApsaraNative.h
+++ b/core/processor/ProcessorParseApsaraNative.h
@@ -48,6 +48,7 @@ private:
     ApsaraEasyReadLogTimeParser(StringView& buffer, StringView& timeStr, LogtailTime& lastLogTime, int64_t& microTime);
     bool IsPrefixString(const char* all, const StringView& prefix);
     int32_t ParseApsaraBaseFields(const StringView& buffer, LogEvent& sourceEvent);
+    int32_t GetApsaraLogMicroTimePart(const char* buffer);
 
     int32_t mLogTimeZoneOffsetSecond = 0;
     bool mSourceKeyOverwritten = false;

--- a/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
@@ -864,6 +864,14 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventMicrosecondUnmatch() {
                 },
                 "timestamp" : 12345678901,
                 "type" : 1
+            },
+            {
+                "contents" :
+                {
+                    "content" : "[2023-09-04 13:18:04"
+                },
+                "timestamp" : 12345678901,
+                "type" : 1
             }
         ]
     })";
@@ -915,17 +923,25 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventMicrosecondUnmatch() {
                 "timestamp": 1693833424,
                 "timestampNanosecond": 100000000,
                 "type": 1
+            },
+            {
+                "contents": {
+                    "rawLog": "[2023-09-04 13:18:04"
+                },
+                "timestamp": 12345678901,
+                "timestampNanosecond": 0,
+                "type": 1
             }
         ]
     })";
     std::string outJson = eventGroupList[0].ToJsonString();
     APSARA_TEST_STREQ_FATAL(CompactJson(expectJson).c_str(), CompactJson(outJson).c_str());
     // check observablity
-    APSARA_TEST_EQUAL_FATAL(0, processor.GetContext().GetProcessProfile().parseFailures);
-    APSARA_TEST_EQUAL_FATAL(uint64_t(3), processorInstance.mProcInRecordsTotal->GetValue());
-    APSARA_TEST_EQUAL_FATAL(uint64_t(3), processorInstance.mProcOutRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(1, processor.GetContext().GetProcessProfile().parseFailures);
+    APSARA_TEST_EQUAL_FATAL(uint64_t(4), processorInstance.mProcInRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(4), processorInstance.mProcOutRecordsTotal->GetValue());
     APSARA_TEST_EQUAL_FATAL(uint64_t(0), processor.mProcDiscardRecordsTotal->GetValue());
-    APSARA_TEST_EQUAL_FATAL(uint64_t(0), processor.mProcParseErrorTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(1), processor.mProcParseErrorTotal->GetValue());
 }
 
 } // namespace logtail

--- a/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
@@ -856,6 +856,14 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventMicrosecondUnmatch() {
                 },
                 "timestamp" : 12345678901,
                 "type" : 1
+            },
+            {
+                "contents" :
+                {
+                    "content" : "[2023-09-04 13:17:04,1]	[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success"
+                },
+                "timestamp" : 12345678901,
+                "type" : 1
             }
         ]
     })";
@@ -878,10 +886,10 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventMicrosecondUnmatch() {
                     "AppConfigBase AppConfigBase": "success",
                     "__LEVEL__": "INFO",
                     "__THREAD__": "385658",
-                    "microtime": "1693833304000000"
+                    "microtime": "1693833304862181"
                 },
                 "timestamp": 1693833304,
-                "timestampNanosecond": 0,
+                "timestampNanosecond": 862181000,
                 "type": 1
             },
             {
@@ -895,6 +903,18 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventMicrosecondUnmatch() {
                 "timestamp": 1693833364,
                 "timestampNanosecond": 0,
                 "type": 1
+            },
+            {
+                "contents": {
+                    "/ilogtail/AppConfigBase.cpp": "100",
+                    "AppConfigBase AppConfigBase": "success",
+                    "__LEVEL__": "INFO",
+                    "__THREAD__": "385658",
+                    "microtime": "1693833424100000"
+                },
+                "timestamp": 1693833424,
+                "timestampNanosecond": 100000000,
+                "type": 1
             }
         ]
     })";
@@ -902,8 +922,8 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventMicrosecondUnmatch() {
     APSARA_TEST_STREQ_FATAL(CompactJson(expectJson).c_str(), CompactJson(outJson).c_str());
     // check observablity
     APSARA_TEST_EQUAL_FATAL(0, processor.GetContext().GetProcessProfile().parseFailures);
-    APSARA_TEST_EQUAL_FATAL(uint64_t(2), processorInstance.mProcInRecordsTotal->GetValue());
-    APSARA_TEST_EQUAL_FATAL(uint64_t(2), processorInstance.mProcOutRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(3), processorInstance.mProcInRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(3), processorInstance.mProcOutRecordsTotal->GetValue());
     APSARA_TEST_EQUAL_FATAL(uint64_t(0), processor.mProcDiscardRecordsTotal->GetValue());
     APSARA_TEST_EQUAL_FATAL(uint64_t(0), processor.mProcParseErrorTotal->GetValue());
 }

--- a/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
@@ -41,6 +41,7 @@ public:
     void TestProcessEventKeepUnmatch();
     void TestProcessEventDiscardUnmatch();
     void TestMultipleLines();
+    void TestProcessEventNanosecondUnmatch();
 
     PipelineContext mContext;
 };
@@ -54,6 +55,7 @@ UNIT_TEST_CASE(ProcessorParseApsaraNativeUnittest, TestAddLog);
 UNIT_TEST_CASE(ProcessorParseApsaraNativeUnittest, TestProcessEventKeepUnmatch);
 UNIT_TEST_CASE(ProcessorParseApsaraNativeUnittest, TestProcessEventDiscardUnmatch);
 UNIT_TEST_CASE(ProcessorParseApsaraNativeUnittest, TestMultipleLines);
+UNIT_TEST_CASE(ProcessorParseApsaraNativeUnittest, TestProcessEventNanosecondUnmatch);
 
 void ProcessorParseApsaraNativeUnittest::TestMultipleLines() {
     // 第一个contents 测试多行下的解析，第二个contents测试多行下time的解析
@@ -395,16 +397,41 @@ void ProcessorParseApsaraNativeUnittest::TestProcessWholeLinePart() {
 
     // judge result
     std::string outJson = eventGroupList[0].ToJsonString();
-    APSARA_TEST_STREQ_FATAL("null", CompactJson(outJson).c_str());
+    std::string expectJson = R"({
+        "events": [
+            {
+                "contents": {
+                    "/ilogtail/AppConfigBase.cpp": "100",
+                    "AppConfigBase AppConfigBase": "success",
+                    "__LEVEL__": "INFO",
+                    "__THREAD__": "385658",
+                    "microtime": "1693833300000000"
+                },
+                "timestamp": 1693833300,
+                "timestampNanosecond": 0,
+                "type": 1
+            },
+            {
+                "contents": {
+                    "/ilogtail/AppConfigBase.cpp": "100",
+                    "AppConfigBase AppConfigBase": "success",
+                    "__THREAD__": "385658",
+                    "microtime": "1693833360000000"
+                },
+                "timestamp": 1693833360,
+                "timestampNanosecond": 0,
+                "type": 1
+            }
+        ]
+    })";
+    APSARA_TEST_STREQ_FATAL(CompactJson(expectJson).c_str(), CompactJson(outJson).c_str());
     // check observablity
-    int count = 3;
-    APSARA_TEST_EQUAL_FATAL(count, processor.GetContext().GetProcessProfile().parseFailures);
-    APSARA_TEST_EQUAL_FATAL(uint64_t(count), processorInstance.mProcInRecordsTotal->GetValue());
-    // discard unmatch, so output is 0
-    APSARA_TEST_EQUAL_FATAL(uint64_t(0), processorInstance.mProcOutRecordsTotal->GetValue());
-    APSARA_TEST_EQUAL_FATAL(uint64_t(0), processor.mProcParseOutSizeBytes->GetValue());
-    APSARA_TEST_EQUAL_FATAL(uint64_t(count), processor.mProcDiscardRecordsTotal->GetValue());
-    APSARA_TEST_EQUAL_FATAL(uint64_t(count), processor.mProcParseErrorTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(1, processor.GetContext().GetProcessProfile().parseFailures);
+    APSARA_TEST_EQUAL_FATAL(uint64_t(3), processorInstance.mProcInRecordsTotal->GetValue());
+    // only timestamp failed, so output is 2
+    APSARA_TEST_EQUAL_FATAL(uint64_t(2), processorInstance.mProcOutRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(1), processor.mProcDiscardRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(1), processor.mProcParseErrorTotal->GetValue());
 }
 
 void ProcessorParseApsaraNativeUnittest::TestProcessKeyOverwritten() {
@@ -798,6 +825,87 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventDiscardUnmatch() {
     APSARA_TEST_EQUAL_FATAL(uint64_t(0), processor.mProcParseOutSizeBytes->GetValue());
     APSARA_TEST_EQUAL_FATAL(uint64_t(count), processor.mProcDiscardRecordsTotal->GetValue());
     APSARA_TEST_EQUAL_FATAL(uint64_t(count), processor.mProcParseErrorTotal->GetValue());
+}
+
+void ProcessorParseApsaraNativeUnittest::TestProcessEventNanosecondUnmatch() {
+    // make config
+    Json::Value config;
+    config["SourceKey"] = "content";
+    config["KeepingSourceWhenParseFail"] = true;
+    config["KeepingSourceWhenParseSucceed"] = false;
+    config["CopingRawLog"] = false;
+    config["RenamedSourceKey"] = "rawLog";
+    // make events
+    auto sourceBuffer = std::make_shared<SourceBuffer>();
+    PipelineEventGroup eventGroup(sourceBuffer);
+    std::string inJson = R"({
+        "events" :
+        [
+            {
+                "contents" :
+                {
+                    "content" : "[2023-09-04 13:15:04,862181]	[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success"
+                },
+                "timestamp" : 12345678901,
+                "type" : 1
+            },
+            {
+                "contents" :
+                {
+                    "content" : "[2023-09-04 13:16:04,862181]	[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success"
+                },
+                "timestamp" : 12345678901,
+                "type" : 1
+            }
+        ]
+    })";
+    eventGroup.FromJsonString(inJson);
+    // run function
+    ProcessorParseApsaraNative& processor = *(new ProcessorParseApsaraNative);
+    std::string pluginId = "testID";
+    ProcessorInstance processorInstance(&processor, pluginId);
+    APSARA_TEST_TRUE_FATAL(processorInstance.Init(config, mContext));
+    std::vector<PipelineEventGroup> eventGroupList;
+    eventGroupList.emplace_back(std::move(eventGroup));
+    processorInstance.Process(eventGroupList);
+
+    // judge result
+    std::string expectJson = R"({
+        "events": [
+            {
+                "contents": {
+                    "/ilogtail/AppConfigBase.cpp": "100",
+                    "AppConfigBase AppConfigBase": "success",
+                    "__LEVEL__": "INFO",
+                    "__THREAD__": "385658",
+                    "microtime": "1693833304862181"
+                },
+                "timestamp": 1693833304,
+                "timestampNanosecond": 862181000,
+                "type": 1
+            },
+            {
+                "contents": {
+                    "/ilogtail/AppConfigBase.cpp": "100",
+                    "AppConfigBase AppConfigBase": "success",
+                    "__LEVEL__": "INFO",
+                    "__THREAD__": "385658",
+                    "microtime": "1693833364862181"
+                },
+                "timestamp": 1693833364,
+                "timestampNanosecond": 862181000,
+                "type": 1
+            }
+        ]
+    })";
+    std::string outJson = eventGroupList[0].ToJsonString();
+    APSARA_TEST_STREQ_FATAL(CompactJson(expectJson).c_str(), CompactJson(outJson).c_str());
+    // check observablity
+    APSARA_TEST_EQUAL_FATAL(0, processor.GetContext().GetProcessProfile().parseFailures);
+    APSARA_TEST_EQUAL_FATAL(uint64_t(2), processorInstance.mProcInRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(2), processorInstance.mProcOutRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(0), processor.mProcDiscardRecordsTotal->GetValue());
+    APSARA_TEST_EQUAL_FATAL(uint64_t(0), processor.mProcParseErrorTotal->GetValue());
 }
 
 } // namespace logtail

--- a/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
@@ -41,7 +41,7 @@ public:
     void TestProcessEventKeepUnmatch();
     void TestProcessEventDiscardUnmatch();
     void TestMultipleLines();
-    void TestProcessEventNanosecondUnmatch();
+    void TestProcessEventMicrosecondUnmatch();
 
     PipelineContext mContext;
 };
@@ -55,7 +55,7 @@ UNIT_TEST_CASE(ProcessorParseApsaraNativeUnittest, TestAddLog);
 UNIT_TEST_CASE(ProcessorParseApsaraNativeUnittest, TestProcessEventKeepUnmatch);
 UNIT_TEST_CASE(ProcessorParseApsaraNativeUnittest, TestProcessEventDiscardUnmatch);
 UNIT_TEST_CASE(ProcessorParseApsaraNativeUnittest, TestMultipleLines);
-UNIT_TEST_CASE(ProcessorParseApsaraNativeUnittest, TestProcessEventNanosecondUnmatch);
+UNIT_TEST_CASE(ProcessorParseApsaraNativeUnittest, TestProcessEventMicrosecondUnmatch);
 
 void ProcessorParseApsaraNativeUnittest::TestMultipleLines() {
     // 第一个contents 测试多行下的解析，第二个contents测试多行下time的解析
@@ -827,7 +827,7 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventDiscardUnmatch() {
     APSARA_TEST_EQUAL_FATAL(uint64_t(count), processor.mProcParseErrorTotal->GetValue());
 }
 
-void ProcessorParseApsaraNativeUnittest::TestProcessEventNanosecondUnmatch() {
+void ProcessorParseApsaraNativeUnittest::TestProcessEventMicrosecondUnmatch() {
     // make config
     Json::Value config;
     config["SourceKey"] = "content";
@@ -852,7 +852,7 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventNanosecondUnmatch() {
             {
                 "contents" :
                 {
-                    "content" : "[2023-09-04 13:16:04,862181]	[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success"
+                    "content" : "[2023-09-04 13:16:04]	[INFO]	[385658]	/ilogtail/AppConfigBase.cpp:100		AppConfigBase AppConfigBase:success"
                 },
                 "timestamp" : 12345678901,
                 "type" : 1
@@ -878,10 +878,10 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventNanosecondUnmatch() {
                     "AppConfigBase AppConfigBase": "success",
                     "__LEVEL__": "INFO",
                     "__THREAD__": "385658",
-                    "microtime": "1693833304862181"
+                    "microtime": "1693833304000000"
                 },
                 "timestamp": 1693833304,
-                "timestampNanosecond": 862181000,
+                "timestampNanosecond": 0,
                 "type": 1
             },
             {
@@ -890,10 +890,10 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventNanosecondUnmatch() {
                     "AppConfigBase AppConfigBase": "success",
                     "__LEVEL__": "INFO",
                     "__THREAD__": "385658",
-                    "microtime": "1693833364862181"
+                    "microtime": "1693833364000000"
                 },
                 "timestamp": 1693833364,
-                "timestampNanosecond": 862181000,
+                "timestampNanosecond": 0,
                 "type": 1
             }
         ]


### PR DESCRIPTION
This commit addresses a compatibility issue with timestamp parsing in apsara logs by ilogtail. Previously, ilogtail enforced a strict time format of %Y-%m-%d %H:%M:%S.%f, which resulted in failures when encountering apsara logs formatted with %Y-%m-%d %H:%M:%S,%f.

The fix introduces a more flexible parsing logic that disregards the character immediately following %S, allowing the parser to correctly handle sub-second parts denoted by any character. This patch also ensures that ilogtail can successfully parse timestamps without failing when the sub-second part is absent.