### PR TITLE
fix: reset checkpoint dump time after dir registration completes to avoid log duplication

### DIFF
--- a/core/file_server/FileServer.cpp
+++ b/core/file_server/FileServer.cpp
@@ -37,6 +37,8 @@ void FileServer::Start() {
     ConfigManager::GetInstance()->RegisterHandlers();
     LOG_INFO(sLogger, ("watch dirs", "succeeded"));
     EventDispatcher::GetInstance()->AddExistedCheckPointFileEvents();
+    // the dump time must be reset after dir registration, since it may take long on NFS.
+    CheckPointManager::Instance()->ResetLastDumpTime();
     if (BOOL_FLAG(enable_polling_discovery)) {
         PollingModify::GetInstance()->Start();
         PollingDirFile::GetInstance()->Start();
@@ -50,7 +52,6 @@ void FileServer::Pause(bool isConfigUpdate) {
     if (isConfigUpdate) {
         EventDispatcher::GetInstance()->DumpAllHandlersMeta(true);
         CheckPointManager::Instance()->DumpCheckPointToLocal();
-        CheckPointManager::Instance()->ResetLastDumpTime();
         EventDispatcher::GetInstance()->ClearBrokenLinkSet();
         PollingDirFile::GetInstance()->ClearCache();
         ConfigManager::GetInstance()->ClearFilePipelineMatchCache();


### PR DESCRIPTION
For file log collection, if watched dirs are in NFS, chances are it will take long to complete dir registration. Since current checkpoint dump time is reset before dir registration, and checkpoint dump period is set to 1 min in k8s, chances are checkpoints are dumped and cleared immediately after dir registration with NFS, right before log reader status can be recovered from checkpoints, which fianlly leads to log duplication.

Therefore, we should reset dump time after dir registration.