### PR TITLE
Fix timezone handling in native processors

### DIFF
--- a/core/processor/ProcessorParseApsaraNative.cpp
+++ b/core/processor/ProcessorParseApsaraNative.cpp
@@ -35,10 +35,12 @@ bool ProcessorParseApsaraNative::Init(const ComponentConfig& componentConfig) {
     mDiscardUnmatch = config.mDiscardUnmatch;
     mUploadRawLog = config.mUploadRawLog;
     mRawLogTag = config.mAdvancedConfig.mRawLogTag;
-    mLogTimeZoneOffsetSecond = config.mLogTimeZoneOffsetSecond;
+    mLogTimeZoneOffsetSecond
+        = config.mTimeZoneAdjust ? config.mLogTimeZoneOffsetSecond - GetLocalTimeZoneOffsetSecond() : 0;
     if (mUploadRawLog && mRawLogTag == mSourceKey) {
         mSourceKeyOverwritten = true;
     }
+    mAdjustApsaraMicroTimezone = config.mAdvancedConfig.mAdjustApsaraMicroTimezone;
     mLogGroupSize = &(GetContext().GetProcessProfile().logGroupSize);
     mParseFailures = &(GetContext().GetProcessProfile().parseFailures);
     mHistoryFailures = &(GetContext().GetProcessProfile().historyFailures);
@@ -78,7 +80,10 @@ void ProcessorParseApsaraNative::Process(PipelineEventGroup& logGroup) {
  * @param timeStrCache - 缓存时间字符串，用于比较和更新。
  * @return 如果事件被处理且保留，则返回true，如果事件被丢弃，则返回false。
  */
-bool ProcessorParseApsaraNative::ProcessEvent(const StringView& logPath, PipelineEventPtr& e, LogtailTime& lastLogTime, StringView& timeStrCache) {
+bool ProcessorParseApsaraNative::ProcessEvent(const StringView& logPath,
+                                              PipelineEventPtr& e,
+                                              LogtailTime& lastLogTime,
+                                              StringView& timeStrCache) {
     if (!IsSupportedEvent(e)) {
         return true;
     }
@@ -109,10 +114,10 @@ bool ProcessorParseApsaraNative::ProcessEvent(const StringView& logPath, Pipelin
         }
 
         GetContext().GetAlarm().SendAlarm(PARSE_TIME_FAIL_ALARM,
-                                               bufOut.to_string() + " $ " + ToString(logTime),
-                                               GetContext().GetProjectName(),
-                                               GetContext().GetLogstoreName(),
-                                               GetContext().GetRegion());
+                                          bufOut.to_string() + " $ " + ToString(logTime),
+                                          GetContext().GetProjectName(),
+                                          GetContext().GetLogstoreName(),
+                                          GetContext().GetRegion());
         mProcParseErrorTotal->Add(1);
         ++(*mParseFailures);
         if (!mDiscardUnmatch) {
@@ -127,21 +132,24 @@ bool ProcessorParseApsaraNative::ProcessEvent(const StringView& logPath, Pipelin
         mProcDiscardRecordsTotal->Add(1);
         return false;
     }
-    if (BOOL_FLAG(ilogtail_discard_old_data)
-        && (time(NULL) - logTime + mLogTimeZoneOffsetSecond) > INT32_FLAG(ilogtail_discard_interval)) {
+    if (BOOL_FLAG(ilogtail_discard_old_data) && (time(NULL) - logTime) > INT32_FLAG(ilogtail_discard_interval)) {
         if (AppConfig::GetInstance()->IsLogParseAlarmValid()) {
             StringView bufOut(buffer);
             if (buffer.size() > (size_t)(1024)) {
                 bufOut = buffer.substr(0, 1024);
             }
             if (GetContext().GetAlarm().IsLowLevelAlarmValid()) {
-                LOG_WARNING(sLogger,
-                            ("discard history data, first 1k",
-                             bufOut)("parsed time", logTime)("project", GetContext().GetProjectName())(
-                                "logstore", GetContext().GetLogstoreName())("file", logPath));
+                LOG_WARNING(
+                    sLogger,
+                    ("drop log event",
+                     "log time falls more than " + ToString(INT32_FLAG(ilogtail_discard_interval))
+                         + " secs behind current time")("log time", logTime)("gap", ToString(time(NULL) - logTime))(
+                        "project", GetContext().GetProjectName())("logstore", GetContext().GetLogstoreName())(
+                        "config", GetContext().GetConfigName())("file", logPath));
             }
             GetContext().GetAlarm().SendAlarm(OUTDATED_LOG_ALARM,
-                                              std::string("logTime: ") + ToString(logTime) + ", log:" + bufOut.to_string(),
+                                              std::string("logTime: ") + ToString(logTime)
+                                                  + ", log:" + bufOut.to_string(),
                                               GetContext().GetProjectName(),
                                               GetContext().GetLogstoreName(),
                                               GetContext().GetRegion());
@@ -181,10 +189,6 @@ bool ProcessorParseApsaraNative::ProcessEvent(const StringView& logPath, Pipelin
             }
         }
     }
-    // TODO: deprecated
-    if (mAdjustApsaraMicroTimezone) {
-        logTime_in_micro = (int64_t)logTime_in_micro - (int64_t)mLogTimeZoneOffsetSecond * (int64_t)1000000;
-    }
     StringBuffer sb = sourceEvent.GetSourceBuffer()->AllocateStringBuffer(20);
 #if defined(__linux__)
     sb.size = std::min(20, snprintf(sb.data, sb.capacity, "%ld", logTime_in_micro));
@@ -209,7 +213,10 @@ bool ProcessorParseApsaraNative::ProcessEvent(const StringView& logPath, Pipelin
  * @param microTime - 解析出的微秒时间戳。
  * @return 解析出的时间戳（秒），如果解析失败，则返回0。
  */
-time_t ProcessorParseApsaraNative::ApsaraEasyReadLogTimeParser(StringView& buffer, StringView& timeStr, LogtailTime& lastLogTime, int64_t& microTime) {
+time_t ProcessorParseApsaraNative::ApsaraEasyReadLogTimeParser(StringView& buffer,
+                                                               StringView& timeStr,
+                                                               LogtailTime& lastLogTime,
+                                                               int64_t& microTime) {
     if (buffer[0] != '[') {
         return 0;
     }
@@ -224,8 +231,7 @@ time_t ProcessorParseApsaraNative::ApsaraEasyReadLogTimeParser(StringView& buffe
         std::string strTime = buffer.substr(1, pos).to_string();
         auto strptimeResult = Strptime(strTime.c_str(), "%s", &lastLogTime, nanosecondLength);
         if (NULL == strptimeResult || strptimeResult[0] != ']') {
-            LOG_WARNING(sLogger,
-                        ("parse apsara log time", "fail")("string", buffer)("timeformat", "%s"));
+            LOG_WARNING(sLogger, ("parse apsara log time", "fail")("string", buffer)("timeformat", "%s"));
             return 0;
         }
         microTime = (int64_t)lastLogTime.tv_sec * 1000000 + lastLogTime.tv_nsec / 1000;
@@ -254,7 +260,12 @@ time_t ProcessorParseApsaraNative::ApsaraEasyReadLogTimeParser(StringView& buffe
         }
         // if the time is valid (strptime not return NULL), the date value size must be 19 ,like '2013-09-11 03:11:05'
         timeStr = StringView(buffer.data() + 1, 19);
+        lastLogTime.tv_sec = lastLogTime.tv_sec - mLogTimeZoneOffsetSecond;
         microTime = (int64_t)lastLogTime.tv_sec * 1000000 + lastLogTime.tv_nsec / 1000;
+        // TODO: deprecated
+        if (!mAdjustApsaraMicroTimezone) {
+            microTime = (int64_t)microTime + (int64_t)mLogTimeZoneOffsetSecond * (int64_t)1000000;
+        }
         return lastLogTime.tv_sec;
     }
 }
@@ -390,16 +401,20 @@ int32_t ProcessorParseApsaraNative::ParseApsaraBaseFields(const StringView& buff
         endIndex = endIndexArray[i];
         if ((findFieldBitMap & 0x1) == 0 && IsFieldLevel(buffer, beginIndex, endIndex)) {
             findFieldBitMap |= 0x1;
-            AddLog(LogParser::SLS_KEY_LEVEL, StringView(buffer.data() + beginIndex, endIndex - beginIndex), sourceEvent);
+            AddLog(
+                LogParser::SLS_KEY_LEVEL, StringView(buffer.data() + beginIndex, endIndex - beginIndex), sourceEvent);
         } else if ((findFieldBitMap & 0x10) == 0 && IsFieldThread(buffer, beginIndex, endIndex)) {
             findFieldBitMap |= 0x10;
-            AddLog(LogParser::SLS_KEY_THREAD, StringView(buffer.data() + beginIndex, endIndex - beginIndex), sourceEvent);
+            AddLog(
+                LogParser::SLS_KEY_THREAD, StringView(buffer.data() + beginIndex, endIndex - beginIndex), sourceEvent);
         } else if ((findFieldBitMap & 0x100) == 0 && IsFieldFileLine(buffer, beginIndex, endIndex)) {
             findFieldBitMap |= 0x100;
             int32_t colonIndex = FindColonIndex(buffer, beginIndex, endIndex);
             AddLog(LogParser::SLS_KEY_FILE, StringView(buffer.data() + beginIndex, endIndex - beginIndex), sourceEvent);
             if (colonIndex < endIndex) {
-                AddLog(LogParser::SLS_KEY_LINE, StringView(buffer.data() + colonIndex + 1, endIndex - colonIndex - 1), sourceEvent);
+                AddLog(LogParser::SLS_KEY_LINE,
+                       StringView(buffer.data() + colonIndex + 1, endIndex - colonIndex - 1),
+                       sourceEvent);
             }
         }
     }

--- a/core/processor/ProcessorParseTimestampNative.cpp
+++ b/core/processor/ProcessorParseTimestampNative.cpp
@@ -90,15 +90,15 @@ bool ProcessorParseTimestampNative::ProcessEvent(StringView logPath, PipelineEve
     if (logTime.tv_sec <= 0
         || (BOOL_FLAG(ilogtail_discard_old_data)
             // Adjust time(NULL) from local timezone to target timezone
-            && (time(NULL) - mLogTimeZoneOffsetSecond - logTime.tv_sec) > INT32_FLAG(ilogtail_discard_interval))) {
+            && (time(NULL) - logTime.tv_sec) > INT32_FLAG(ilogtail_discard_interval))) {
         if (AppConfig::GetInstance()->IsLogParseAlarmValid()) {
             if (LogtailAlarm::GetInstance()->IsLowLevelAlarmValid()) {
                 LOG_WARNING(sLogger,
-                            ("discard history data", timeStr)("time now", time(NULL))("timestamp", logTime.tv_sec)(
-                                "nanosecond", logTime.tv_nsec)("tzOffsetSecond", mLogTimeZoneOffsetSecond)(
-                                "INT32_FLAG(ilogtail_discard_interval)",
-                                INT32_FLAG(ilogtail_discard_interval))("project", GetContext().GetProjectName())(
-                                "logstore", GetContext().GetLogstoreName())("file", logPath));
+                            ("drop log event",
+                             "log time falls more than" + ToString(INT32_FLAG(ilogtail_discard_interval))
+                                 + " secs behind current time")("log time", logTime.tv_sec)(
+                                "project", GetContext().GetProjectName())("logstore", GetContext().GetLogstoreName())(
+                                "config", GetContext().GetConfigName())("file", logPath));
             }
             LogtailAlarm::GetInstance()->SendAlarm(OUTDATED_LOG_ALARM,
                                                    std::string("logTime: ") + ToString(logTime.tv_sec),


### PR DESCRIPTION
之前插件化的时候都改乱了，问题包括：

1. 飞天和时间解析插件丢弃历史日志的时间间隔不再是12小时，而是一个随时区变化的数字
2. 飞天的微妙调整无效，__time__时区错误

改动已通过回归测试

This commit resolves two timezone-related issues in iLogtail's native processors. Previously, ProcessorParseApsaraNative did not initialize the timezone option correctly, nor did it account for timezone settings when adjusting time. Additionally, ProcessorParseTimestampNative was incorrectly filtering timeout logs by subtracting the timezone offset twice.

Changes include:

- Correct initialization of the timezone option in ProcessorParseApsaraNative to ensure that log processing aligns with the configured timezone setting.
- Modification of time adjustment logic in ProcessorParseApsaraNative to correctly apply the timezone setting.
- Adjustment of the log filtering logic in ProcessorParseTimestampNative to prevent double subtraction of the timezone offset, ensuring accurate timeout log filtering.

These fixes improve the accuracy of log processing and filtering in environments with varying timezone configurations, ensuring that iLogtail consistently handles logs across different timezones.