### PR TITLE
[backport]fix memory leak in ProcessorParseDelimiterNative

### DIFF
--- a/core/processor/ProcessorParseDelimiterNative.cpp
+++ b/core/processor/ProcessorParseDelimiterNative.cpp
@@ -58,7 +58,7 @@ bool ProcessorParseDelimiterNative::Init(const ComponentConfig& componentConfig)
         }
     }
 
-    mDelimiterModeFsmParserPtr = new DelimiterModeFsmParser(mQuote, mSeparatorChar);
+    mDelimiterModeFsmParserPtr.reset(new DelimiterModeFsmParser(mQuote, mSeparatorChar));
     mParseFailures = &(GetContext().GetProcessProfile().parseFailures);
     mLogGroupSize = &(GetContext().GetProcessProfile().logGroupSize);
 

--- a/core/processor/ProcessorParseDelimiterNative.h
+++ b/core/processor/ProcessorParseDelimiterNative.h
@@ -15,6 +15,7 @@
  */
 
 #include "plugin/interface/Processor.h"
+#include <memory>
 #include <string>
 #include <boost/regex.hpp>
 #include "parser/DelimiterModeFsmParser.h"
@@ -49,7 +50,7 @@ private:
     bool mRawLogTagOverwritten = false;
     char mQuote;
     char mSeparatorChar;
-    DelimiterModeFsmParser* mDelimiterModeFsmParserPtr;
+    std::unique_ptr<DelimiterModeFsmParser> mDelimiterModeFsmParserPtr;
 
     int* mLogGroupSize = nullptr;
     int* mParseFailures = nullptr;


### PR DESCRIPTION
Memeber mDelimiterModeFsmParserPtr is a raw pointer. It is not released in destructor. This patch fixed it by using a smart pointer instead.