### PR TITLE
fix memory leak in ProcessorParseDelimiterNative

### DIFF
--- a/core/processor/ProcessorParseDelimiterNative.cpp
+++ b/core/processor/ProcessorParseDelimiterNative.cpp
@@ -106,7 +106,7 @@ bool ProcessorParseDelimiterNative::Init(const Json::Value& config) {
                              mContext->GetRegion());
     }
 
-    mDelimiterModeFsmParserPtr = new DelimiterModeFsmParser(mQuote, mSeparatorChar);
+    mDelimiterModeFsmParserPtr.reset(new DelimiterModeFsmParser(mQuote, mSeparatorChar));
 
     // Keys
     if (!GetMandatoryListParam(config, "Keys", mKeys, errorMsg)) {

--- a/core/processor/ProcessorParseDelimiterNative.h
+++ b/core/processor/ProcessorParseDelimiterNative.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "models/LogEvent.h"
 #include "parser/DelimiterModeFsmParser.h"
 #include "plugin/interface/Processor.h"
@@ -70,8 +72,8 @@ private:
 
     char mSeparatorChar;
     bool mSourceKeyOverwritten = false;
-    DelimiterModeFsmParser* mDelimiterModeFsmParserPtr = nullptr;
-    
+    std::unique_ptr<DelimiterModeFsmParser> mDelimiterModeFsmParserPtr;
+
     int* mLogGroupSize = nullptr;
     int* mParseFailures = nullptr;
     CounterPtr mProcParseInSizeBytes;


### PR DESCRIPTION
Memeber mDelimiterModeFsmParserPtr is a raw pointer. It is not released in destructor. This patch fixed it by using a smart pointer instead.