### PR TITLE
[backport] fix: reset checkpoint dump time after dir registration completes to avoid log duplication

### DIFF
--- a/core/controller/EventDispatcherBase.cpp
+++ b/core/controller/EventDispatcherBase.cpp
@@ -1223,13 +1223,13 @@ void EventDispatcherBase::UpdateConfig() {
         }
         ConfigManager::GetInstance()->SetConfigRemoveFlag(false);
     }
-    // reset last dump time to prevent check point manager to dump check point and delete check point.
-    // because this may mix check point when init reader and dump check point happen in same time
-    CheckPointManager::Instance()->ResetLastDumpTime();
     // we should add checkpoint events
 
     LogtailPlugin::GetInstance()->Resume();
     LogInput::GetInstance()->Resume(true);
+    // reset last dump time to prevent check point manager to dump check point and delete check point.
+    // because this may mix check point when init reader and dump check point happen in same time
+    CheckPointManager::Instance()->ResetLastDumpTime();
 
 #if defined(__linux__)
     if (mStreamLogManagerPtr != NULL) {


### PR DESCRIPTION
For file log collection, if watched dirs are in NFS, chances are it will take long to complete dir registration. Since current checkpoint dump time is reset before dir registration, and checkpoint dump period is set to 1 min in k8s, chances are checkpoints are dumped and cleared immediately after dir registration with NFS, right before log reader status can be recovered from checkpoints, which finally leads to log duplication.

Therefore, we should reset dump time after dir registration.