### PR TITLE
Fix: remove content if native processor parse failed

### DIFF
--- a/core/processor/ProcessorFilterNative.h
+++ b/core/processor/ProcessorFilterNative.h
@@ -37,7 +37,6 @@ private:
     std::shared_ptr<LogFilterRule> mFilterRule;
     BaseFilterNodePtr mFilterExpressionRoot = nullptr;
     std::unordered_map<std::string, LogFilterRule*> mFilters;
-    LogType mLogType;
     bool mDiscardNoneUtf8;
     Mode mFilterMode;
 

--- a/core/processor/ProcessorParseApsaraNative.cpp
+++ b/core/processor/ProcessorParseApsaraNative.cpp
@@ -121,6 +121,8 @@ bool ProcessorParseApsaraNative::ProcessEvent(const StringView& logPath,
         mProcParseErrorTotal->Add(1);
         ++(*mParseFailures);
         if (!mDiscardUnmatch) {
+            sourceEvent.DelContent(mSourceKey);
+            mProcParseOutSizeBytes->Add(-mSourceKey.size() - buffer.size());
             AddLog(LogParser::UNMATCH_LOG_KEY, // __raw_log__
                    buffer,
                    sourceEvent); // legacy behavior, should use sourceKey

--- a/core/processor/ProcessorParseDelimiterNative.cpp
+++ b/core/processor/ProcessorParseDelimiterNative.cpp
@@ -217,6 +217,8 @@ bool ProcessorParseDelimiterNative::ProcessEvent(const StringView& logPath, Pipe
             }
         }
     } else if (!mDiscardUnmatch) {
+        sourceEvent.DelContent(mSourceKey);
+        mProcParseOutSizeBytes->Add(-mSourceKey.size() - buffer.size());
         AddLog(LogParser::UNMATCH_LOG_KEY, // __raw_log__
                buffer,
                sourceEvent); // legacy behavior, should use sourceKey

--- a/core/processor/ProcessorParseJsonNative.cpp
+++ b/core/processor/ProcessorParseJsonNative.cpp
@@ -82,6 +82,8 @@ bool ProcessorParseJsonNative::ProcessEvent(const StringView& logPath, PipelineE
     bool res = JsonLogLineParser(sourceEvent, logPath, e, sourceKeyOverwritten, rawLogTagOverwritten);
 
     if (!res && !mDiscardUnmatch) {
+        sourceEvent.DelContent(mSourceKey);
+        mProcParseOutSizeBytes->Add(-mSourceKey.size() - rawContent.size());
         AddLog(LogParser::UNMATCH_LOG_KEY, // __raw_log__
                rawContent,
                sourceEvent); // legacy behavior, should use sourceKey

--- a/core/processor/ProcessorParseRegexNative.cpp
+++ b/core/processor/ProcessorParseRegexNative.cpp
@@ -102,6 +102,8 @@ bool ProcessorParseRegexNative::ProcessEvent(const StringView& logPath, Pipeline
         }
     }
     if (!res && !mDiscardUnmatch) {
+        sourceEvent.DelContent(mSourceKey);
+        mProcParseOutSizeBytes->Add(-mSourceKey.size() - rawContent.size());
         AddLog(LogParser::UNMATCH_LOG_KEY, // __raw_log__
                rawContent,
                sourceEvent); // legacy behavior, should use sourceKey

--- a/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
@@ -135,7 +135,6 @@ void ProcessorParseApsaraNativeUnittest::TestMultipleLines() {
             {
                 "contents": {
                     "__raw_log__": "[2023-09-04 13:15",
-                    "content": "[2023-09-04 13:15",
                     "log.file.offset": "0"
                 },
                 "timestamp": 12345678901,
@@ -145,7 +144,6 @@ void ProcessorParseApsaraNativeUnittest::TestMultipleLines() {
             {
                 "contents": {
                     "__raw_log__": ":50.1]\t[ERROR]\t[1]\t/ilogtail/AppConfigBase.cpp:1\t\tAppConfigBase AppConfigBase:1",
-                    "content": ":50.1]\t[ERROR]\t[1]\t/ilogtail/AppConfigBase.cpp:1\t\tAppConfigBase AppConfigBase:1",
                     "log.file.offset": "0"
                 },
                 "timestamp": 12345678901,
@@ -504,7 +502,6 @@ void ProcessorParseApsaraNativeUnittest::TestProcessKeyOverwritten() {
                 "contents": {
                     "__raw__": "value1",
                     "__raw_log__": "value1",
-                    "content": "value1",
                     "log.file.offset": "0"
                 },
                 "timestamp": 12345678901,
@@ -580,7 +577,6 @@ void ProcessorParseApsaraNativeUnittest::TestUploadRawLog() {
                 "contents": {
                     "__raw__": "value1",
                     "__raw_log__": "value1",
-                    "content": "value1",
                     "log.file.offset": "0"
                 },
                 "timestamp": 12345678901,
@@ -690,7 +686,6 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventKeepUnmatch() {
                 "contents" :
                 {
                     "__raw_log__" : "value1",
-                    "content": "value1",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -701,7 +696,6 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventKeepUnmatch() {
                 "contents" :
                 {
                     "__raw_log__" : "value1",
-                    "content": "value1",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -712,7 +706,6 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventKeepUnmatch() {
                 "contents" :
                 {
                     "__raw_log__" : "value1",
-                    "content": "value1",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -723,7 +716,6 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventKeepUnmatch() {
                 "contents" :
                 {
                     "__raw_log__" : "value1",
-                    "content": "value1",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -734,7 +726,6 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventKeepUnmatch() {
                 "contents" :
                 {
                     "__raw_log__" : "value1",
-                    "content": "value1",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -752,8 +743,8 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventKeepUnmatch() {
     std::string expectValue = "value1";
     APSARA_TEST_EQUAL_FATAL((expectValue.length()) * count, processor.mProcParseInSizeBytes->GetValue());
     APSARA_TEST_EQUAL_FATAL(uint64_t(count), processorInstance.mProcOutRecordsTotal->GetValue());
-    expectValue = "__raw_log__value1";
-    APSARA_TEST_EQUAL_FATAL((expectValue.length()) * count, processor.mProcParseOutSizeBytes->GetValue());
+    APSARA_TEST_EQUAL_FATAL((std::string("__raw_log__").size() - std::string("content").size()) * count,
+                            processor.mProcParseOutSizeBytes->GetValue());
 
     APSARA_TEST_EQUAL_FATAL(uint64_t(0), processor.mProcDiscardRecordsTotal->GetValue());
 
@@ -942,8 +933,7 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventMicrosecondUnmatch() {
             },
             {
                 "contents": {
-                    "__raw_log__": "[2023-09-04 13:18:04",
-                    "content":"[2023-09-04 13:18:04"
+                    "__raw_log__": "[2023-09-04 13:18:04"
                 },
                 "timestamp": 12345678901,
                 "timestampNanosecond": 0,

--- a/core/unittest/processor/ProcessorParseDelimiterNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseDelimiterNativeUnittest.cpp
@@ -102,7 +102,6 @@ void ProcessorParseDelimiterNativeUnittest::TestAcceptNoEnoughKeys() {
                 {
                     "contents": {
                         "__raw_log__": "123@@45",
-                        "content": "123@@45",
                         "log.file.offset": "0"
                     },
                     "timestamp": 12345678901,
@@ -112,7 +111,6 @@ void ProcessorParseDelimiterNativeUnittest::TestAcceptNoEnoughKeys() {
                 {
                     "contents": {
                         "__raw_log__": "012@@34",
-                        "content": "012@@34",
                         "log.file.offset": "0"
                     },
                     "timestamp": 12345678901,
@@ -554,7 +552,6 @@ void ProcessorParseDelimiterNativeUnittest::TestMultipleLines() {
                 {
                     "contents": {
                         "__raw_log__": "123@@456",
-                        "content": "123@@456",
                         "log.file.offset": "0"
                     },
                     "timestamp": 12345678901,
@@ -564,7 +561,6 @@ void ProcessorParseDelimiterNativeUnittest::TestMultipleLines() {
                 {
                     "contents": {
                         "__raw_log__": "012@@345",
-                        "content": "012@@345",
                         "log.file.offset": "0"
                     },
                     "timestamp": 12345678901,
@@ -1135,7 +1131,6 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessQuote() {
                 "contents" :
                 {
                     "__raw_log__": "2013-10-31 21:03:49,POST,'PutData?Category=YunOsAccountOpLog,0.024",
-                    "content" : "2013-10-31 21:03:49,POST,'PutData?Category=YunOsAccountOpLog,0.024",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -1146,7 +1141,6 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessQuote() {
                 "contents" :
                 {
                     "__raw_log__": "2013-10-31 21:03:49,POST,'PutData?Category=YunOs'AccountOpLog',0.024",
-                    "content" : "2013-10-31 21:03:49,POST,'PutData?Category=YunOs'AccountOpLog',0.024",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -1225,7 +1219,6 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessKeyOverwritten() {
                 {
                     "__raw__": "value1",
                     "__raw_log__": "value1",
-                    "content" : "value1",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -1304,7 +1297,6 @@ void ProcessorParseDelimiterNativeUnittest::TestUploadRawLog() {
                 {
                     "__raw__": "value1",
                     "__raw_log__": "value1",
-                    "content" : "value1",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -1413,7 +1405,6 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessEventKeepUnmatch() {
                 "contents" :
                 {
                     "__raw_log__" : "value1",
-                    "content" : "value1",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -1424,7 +1415,6 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessEventKeepUnmatch() {
                 "contents" :
                 {
                     "__raw_log__" : "value1",
-                    "content" : "value1",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -1435,7 +1425,6 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessEventKeepUnmatch() {
                 "contents" :
                 {
                     "__raw_log__" : "value1",
-                    "content" : "value1",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -1446,7 +1435,6 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessEventKeepUnmatch() {
                 "contents" :
                 {
                     "__raw_log__" : "value1",
-                    "content" : "value1",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -1457,7 +1445,6 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessEventKeepUnmatch() {
                 "contents" :
                 {
                     "__raw_log__" : "value1",
-                    "content" : "value1",
                     "log.file.offset": "0"
                 },
                 "timestamp" : 12345678901,
@@ -1475,8 +1462,8 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessEventKeepUnmatch() {
     std::string expectValue = "value1";
     APSARA_TEST_EQUAL_FATAL(uint64_t(expectValue.length() * count), processor.mProcParseInSizeBytes->GetValue());
     APSARA_TEST_EQUAL_FATAL(uint64_t(count), processorInstance.mProcOutRecordsTotal->GetValue());
-    expectValue = "__raw_log__value1";
-    APSARA_TEST_EQUAL_FATAL(uint64_t(expectValue.length() * count), processor.mProcParseOutSizeBytes->GetValue());
+    APSARA_TEST_EQUAL_FATAL((std::string("__raw_log__").size() - std::string("content").size()) * count,
+                            processor.mProcParseOutSizeBytes->GetValue());
 
     APSARA_TEST_EQUAL_FATAL(uint64_t(0), processor.mProcDiscardRecordsTotal->GetValue());
 

--- a/core/unittest/processor/ProcessorParseJsonNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseJsonNativeUnittest.cpp
@@ -100,7 +100,6 @@ void ProcessorParseJsonNativeUnittest::TestMultipleLines() {
                     {
                         "__raw__" : "{\"name\":\"Mike\",\"age\":25,\"is_student\":asdfsadf,\"address\":{\"city\":\"Hangzhou\",\"postal_code\":\"100000\"},\"courses\":[\"Math\",\"English\",\"Science\"],\"scores\":{\"Math\":90,\"English\":85,\"Science\":95}}",
                         "__raw_log__" : "{\"name\":\"Mike\",\"age\":25,\"is_student\":asdfsadf,\"address\":{\"city\":\"Hangzhou\",\"postal_code\":\"100000\"},\"courses\":[\"Math\",\"English\",\"Science\"],\"scores\":{\"Math\":90,\"English\":85,\"Science\":95}}",
-                        "content" : "{\"name\":\"Mike\",\"age\":25,\"is_student\":asdfsadf,\"address\":{\"city\":\"Hangzhou\",\"postal_code\":\"100000\"},\"courses\":[\"Math\",\"English\",\"Science\"],\"scores\":{\"Math\":90,\"English\":85,\"Science\":95}}",
                         "log.file.offset":"0"
                     },
                     "timestamp" : 12345678901,
@@ -567,9 +566,8 @@ void ProcessorParseJsonNativeUnittest::TestProcessEventKeepUnmatch() {
         = "{\"url\": \"POST /PutData?Category=YunOsAccountOpLog HTTP/1.1\",\"time\": \"07/Jul/2022:10:30:28\"";
     APSARA_TEST_EQUAL_FATAL((expectValue.length()) * count, processor.mProcParseInSizeBytes->GetValue());
     APSARA_TEST_EQUAL_FATAL(uint64_t(count), processorInstance.mProcOutRecordsTotal->GetValue());
-    expectValue = "__raw_log__{\"url\": \"POST /PutData?Category=YunOsAccountOpLog HTTP/1.1\",\"time\": "
-                  "\"07/Jul/2022:10:30:28\"";
-    APSARA_TEST_EQUAL_FATAL(uint64_t(expectValue.length() * count), processor.mProcParseOutSizeBytes->GetValue());
+    APSARA_TEST_EQUAL_FATAL((std::string("__raw_log__").size() - std::string("content").size()) * count,
+                            processor.mProcParseOutSizeBytes->GetValue());
 
     APSARA_TEST_EQUAL_FATAL(uint64_t(0), processor.mProcDiscardRecordsTotal->GetValue());
 
@@ -583,7 +581,6 @@ void ProcessorParseJsonNativeUnittest::TestProcessEventKeepUnmatch() {
                 "contents" :
                 {
                     "__raw_log__" : "{\"url\": \"POST /PutData?Category=YunOsAccountOpLog HTTP/1.1\",\"time\": \"07/Jul/2022:10:30:28\"",
-                    "content" : "{\"url\": \"POST /PutData?Category=YunOsAccountOpLog HTTP/1.1\",\"time\": \"07/Jul/2022:10:30:28\"",
                     "log.file.offset":"0"
                 },
                 "timestamp" : 12345678901,

--- a/core/unittest/processor/ProcessorParseRegexNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseRegexNativeUnittest.cpp
@@ -220,7 +220,7 @@ void ProcessorParseRegexNativeUnittest::TestProcessRegex() {
     })";
     std::string outJson = eventGroup.ToJsonString();
     APSARA_TEST_STREQ_FATAL(CompactJson(expectJson).c_str(), CompactJson(outJson).c_str());
-    APSARA_TEST_GT_FATAL(processorInstance.mProcTimeMS->GetValue(), 0);
+    APSARA_TEST_GT_FATAL(processorInstance.mProcTimeMS->GetValue(), 0UL);
 }
 
 void ProcessorParseRegexNativeUnittest::TestProcessRegexRaw() {
@@ -393,7 +393,7 @@ void ProcessorParseRegexNativeUnittest::TestAddLog() {
     char value[] = "value";
     processor.AddLog(key, value, *logEvent);
     // check observability
-    APSARA_TEST_EQUAL_FATAL(strlen(key) + strlen(value) + 5, processor.GetContext().GetProcessProfile().logGroupSize);
+    APSARA_TEST_EQUAL_FATAL(static_cast<int>(strlen(key) + strlen(value) + 5), processor.GetContext().GetProcessProfile().logGroupSize);
 }
 
 void ProcessorParseRegexNativeUnittest::TestProcessEventKeepUnmatch() {
@@ -479,8 +479,8 @@ void ProcessorParseRegexNativeUnittest::TestProcessEventKeepUnmatch() {
     std::string expectValue = "value1";
     APSARA_TEST_EQUAL_FATAL((expectValue.length()) * count, processor.mProcParseInSizeBytes->GetValue());
     APSARA_TEST_EQUAL_FATAL(count, processorInstance.mProcOutRecordsTotal->GetValue());
-    expectValue = "__raw_log__value1";
-    APSARA_TEST_EQUAL_FATAL((expectValue.length()) * count, processor.mProcParseOutSizeBytes->GetValue());
+    APSARA_TEST_EQUAL_FATAL((std::string("__raw_log__").size() - std::string("content").size()) * count,
+                            processor.mProcParseOutSizeBytes->GetValue());
 
     APSARA_TEST_EQUAL_FATAL(0, processor.mProcDiscardRecordsTotal->GetValue());
 


### PR DESCRIPTION
Before, the native processors chose to keep both source key and __raw_log__ if parsing fails and keeping unmatched content is desired. Keeping unmatched content in __raw_log__ is to be compatible with older version.
Keeping unmatched content in the source key is convenient if one want data to fall through the next processor when the previous one fails and such behavior is consistent with the behavior of the Go plugin. However, this could result in a doubling of the data volume. As connecting multiple native parsers or connecting native parsers with Go processors is rare now, after this patch only __raw_log__ will be kept. If one want to process the data that previous native processor fails, __raw_log__ must be configured as the source_key in the next processor.