### PR TITLE
Fix: Delete mSourceKeyOverwritten in processorParseApsaraNative to prevent concurrency issues.

### DIFF
--- a/core/processor/ProcessorParseApsaraNative.cpp
+++ b/core/processor/ProcessorParseApsaraNative.cpp
@@ -125,7 +125,7 @@ bool ProcessorParseApsaraNative::ProcessEvent(const StringView& logPath,
     if (!sourceEvent.HasContent(mSourceKey)) {
         return true;
     }
-    mSourceKeyOverwritten = false;
+    bool sourceKeyOverwritten = false;
     StringView buffer = sourceEvent.GetContent(mSourceKey);
     if (buffer.size() == 0) {
         return true;
@@ -210,7 +210,7 @@ bool ProcessorParseApsaraNative::ProcessEvent(const StringView& logPath,
                     StringView data(buffer.data() + colon_index + 1, index - colon_index - 1);
                     AddLog(key, data, sourceEvent);
                     if (key == mSourceKey) {
-                        mSourceKeyOverwritten = true;
+                        sourceKeyOverwritten = true;
                     }
                     colon_index = -1;
                 }
@@ -228,7 +228,7 @@ bool ProcessorParseApsaraNative::ProcessEvent(const StringView& logPath,
     sb.size = std::min(20, snprintf(sb.data, sb.capacity, "%lld", logTime_in_micro));
 #endif
     AddLog("microtime", StringView(sb.data, sb.size), sourceEvent);
-    if (!mSourceKeyOverwritten) {
+    if (!sourceKeyOverwritten) {
         sourceEvent.DelContent(mSourceKey);
     }
     if (mCommonParserOptions.ShouldAddSourceContent(true)) {

--- a/core/processor/ProcessorParseApsaraNative.h
+++ b/core/processor/ProcessorParseApsaraNative.h
@@ -50,7 +50,6 @@ private:
     int32_t ParseApsaraBaseFields(const StringView& buffer, LogEvent& sourceEvent);
 
     int32_t mLogTimeZoneOffsetSecond = 0;
-    bool mSourceKeyOverwritten = false;
 
     int* mLogGroupSize = nullptr;
     int* mParseFailures = nullptr;


### PR DESCRIPTION
This submission resolves an issue in ProcessorParseApsaraNative. mSourceKeyOverwritten is no longer needed, and a local variable sourceKeyOverwritten has been defined to prevent concurrency issues.