### PR TITLE
 Fix memory leak by deleting unused log readers during container update

### DIFF
--- a/core/dependencies.cmake
+++ b/core/dependencies.cmake
@@ -145,7 +145,7 @@ macro(link_tcmalloc target_name)
         if (tcmalloc_${LINK_OPTION_SUFFIX})
             target_link_libraries(${target_name} "${tcmalloc_${LINK_OPTION_SUFFIX}}")
         elseif (UNIX)
-            target_link_libraries(${target_name} "${tcmalloc_${LIBRARY_DIR_SUFFIX}}/libtcmalloc.a")
+            target_link_libraries(${target_name} "${tcmalloc_${LIBRARY_DIR_SUFFIX}}/libtcmalloc_and_profiler.a")
         elseif (MSVC)
             add_definitions(-DPERFTOOLS_DLL_DECL=)
             target_link_libraries(${target_name}

--- a/core/pipeline/PipelineManager.cpp
+++ b/core/pipeline/PipelineManager.cpp
@@ -166,10 +166,6 @@ void logtail::PipelineManager::UpdatePipelines(ConfigDiff& diff) {
         ShennongManager::GetInstance()->Resume();
     }
 #endif
-    // destruct event handlers here so that it will not block file reading task
-    if (isInputFileChanged) {
-        ConfigManager::GetInstance()->DeleteHandlers();
-    }
 #endif
 }
 


### PR DESCRIPTION
During refactor, function DeleteHandlers() is altered so that only called during pipeline update, not on container update. This would lead to memory leak in k8s.