### PR TITLE
fix: deprecate param Include in processor_filter_regex_native and add replacement instead

### DIFF
--- a/core/processor/ProcessorFilterNative.cpp
+++ b/core/processor/ProcessorFilterNative.cpp
@@ -32,16 +32,8 @@ bool ProcessorFilterNative::Init(const Json::Value& config) {
 
     // FilterKey + FilterRegex
     std::vector<std::string> filterKeys, filterRegs;
-    if (!GetOptionalListParam(config, "FilterKey", filterKeys, errorMsg)) {
-        PARAM_WARNING_IGNORE(mContext->GetLogger(),
-                             mContext->GetAlarm(),
-                             errorMsg,
-                             sName,
-                             mContext->GetConfigName(),
-                             mContext->GetProjectName(),
-                             mContext->GetLogstoreName(),
-                             mContext->GetRegion());
-    } else if (!GetOptionalListParam(config, "FilterRegex", filterRegs, errorMsg)) {
+    if (!GetOptionalListParam(config, "FilterKey", filterKeys, errorMsg)
+        || !GetOptionalListParam(config, "FilterRegex", filterRegs, errorMsg)) {
         PARAM_WARNING_IGNORE(mContext->GetLogger(),
                              mContext->GetAlarm(),
                              errorMsg,

--- a/core/processor/ProcessorFilterNative.h
+++ b/core/processor/ProcessorFilterNative.h
@@ -86,8 +86,8 @@ private:
 // UnaryFilterOperatorNode
 class UnaryFilterOperatorNode : public BaseFilterNode {
 public:
-    UnaryFilterOperatorNode(FilterOperator op, BaseFilterNodePtr child)
-        : BaseFilterNode(OPERATOR_NODE), op(op), child(child) {}
+    UnaryFilterOperatorNode(BaseFilterNodePtr child)
+        : BaseFilterNode(OPERATOR_NODE), child(child) {}
 
     virtual ~UnaryFilterOperatorNode(){};
 
@@ -97,7 +97,6 @@ public:
     virtual bool Match(const LogContents& contents, const PipelineContext& mContext);
 
 private:
-    FilterOperator op;
     BaseFilterNodePtr child;
 };
 

--- a/docs/cn/installation/release-notes.md
+++ b/docs/cn/installation/release-notes.md
@@ -60,4 +60,4 @@ docker pull sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-communi
 
 ## 1.x版本
 
-[发布记录(1.x版本)](installation/release-notes-1.md)
+[发布记录(1.x版本)](release-notes-1.md)

--- a/docs/cn/plugins/processor/native/processor-filter-regex-native.md
+++ b/docs/cn/plugins/processor/native/processor-filter-regex-native.md
@@ -13,7 +13,8 @@
 |  **参数**  |  **类型**  |  **是否必填**  |  **默认值**  |  **说明**  |
 | --- | --- | --- | --- | --- |
 |  Type  |  string  |  是  |  /  |  插件类型。固定为processor\_filter\_regex\_native。  |
-|  Include  |  map  |  是  |  /  |  日志字段白名单，其中key为字段名，value为正则表达式，表示如果当前事件要被采集，则key指定的字段内容所需要满足的条件。多个条件之间为“且”的关系，仅当所有条件均满足时，该条日志才会被采集。  |
+|  FilterKey  |  \[string\]  |  是  |  /  |  过滤字段名，需配套`FilterRegex`参数使用，表示如果当前事件要被采集，则key指定的字段内容所需要满足的条件。多个条件之间为“且”的关系，仅当所有条件均满足时，该条日志才会被采集。  |
+|  FilterRegex  |  \[string\]  |  是  |  /  |  与`FilterKey`对应的过滤正则表达式。必须与`FilterKey`长度相同。  |
 
 ## 样例
 
@@ -50,9 +51,12 @@ processors:
       - ref_url
       - browser
   - Type: processor_filter_regex_native
-    Include:
-      method: ^(POST|PUT)$
-      status: ^200$
+    FilterKey: 
+      - method
+      - status
+    FilterRegex:
+      - ^(POST|PUT)$
+      - ^200$
 flushers:
   - Type: flusher_stdout
     OnlyStdout: true


### PR DESCRIPTION
Since same keys are allowed for filter function in old config, the map structure in processor_filter_regex_native is incompatable with that. Thus, we should maintain old param FilterKey and FilterRegex. 