### PR TITLE
用户手册中文本日志多行日志采集给的案例正则表达式错误

### DIFF
--- a/docs/cn/plugins/input/input-file.md
+++ b/docs/cn/plugins/input/input-file.md
@@ -152,7 +152,7 @@ inputs:
     FilePaths: 
       - /home/test-log/regMulti.log
     Multiline:
-      StartPattern: \[\d+-\d+-\w+:\d+:\d+,\d+]\s\[\w+]\s.*
+      StartPattern: \[\d+-\d+-\w+:\d+:\d+.\d+]\s\[\w+]\s.*
 processors:
   - Type: processor_parse_regex_native
     SourceKey: content


### PR DESCRIPTION
用户手册中文本日志多行日志采集给的案例正则表达式错误，导致无法采集案例中的多行日志