### PR TITLE
feat: add full_drain_mode option to ensure complete data flush over network before shutdown

### DIFF
--- a/core/application/Application.h
+++ b/core/application/Application.h
@@ -20,8 +20,8 @@
 #include <cstdint>
 #include <string>
 
-#include "common/Thread.h"
 #include "common/Lock.h"
+#include "common/Thread.h"
 
 namespace logtail {
 
@@ -38,6 +38,7 @@ public:
     void Init();
     void Start();
     void SetSigTermSignalFlag(bool flag) { mSigTermSignalFlag = flag; }
+    bool IsExiting() { return mSigTermSignalFlag; }
 
     std::string GetInstanceId() { return mInstanceId; }
     bool TryGetUUID();

--- a/core/common/LogtailCommonFlags.cpp
+++ b/core/common/LogtailCommonFlags.cpp
@@ -83,6 +83,7 @@ DEFINE_FLAG_STRING(logtail_integrity_snapshot, "integrity file on local disk", "
 DEFINE_FLAG_STRING(ilogtail_config,
                    "set dataserver & configserver address; (optional)set cpu,mem,bufflerfile,buffermap and etc.",
                    "ilogtail_config.json");
+DEFINE_FLAG_BOOL(sidecar_mode, "", false);
 DEFINE_FLAG_INT32(cpu_limit_num, "cpu violate limit num before shutdown", 10);
 DEFINE_FLAG_INT32(mem_limit_num, "memory violate limit num before shutdown", 10);
 DEFINE_FLAG_DOUBLE(cpu_usage_up_limit, "cpu usage upper limit, cores", 2.0);

--- a/core/common/LogtailCommonFlags.cpp
+++ b/core/common/LogtailCommonFlags.cpp
@@ -83,7 +83,7 @@ DEFINE_FLAG_STRING(logtail_integrity_snapshot, "integrity file on local disk", "
 DEFINE_FLAG_STRING(ilogtail_config,
                    "set dataserver & configserver address; (optional)set cpu,mem,bufflerfile,buffermap and etc.",
                    "ilogtail_config.json");
-DEFINE_FLAG_BOOL(sidecar_mode, "", false);
+DEFINE_FLAG_BOOL(enable_full_drain_mode, "", false);
 DEFINE_FLAG_INT32(cpu_limit_num, "cpu violate limit num before shutdown", 10);
 DEFINE_FLAG_INT32(mem_limit_num, "memory violate limit num before shutdown", 10);
 DEFINE_FLAG_DOUBLE(cpu_usage_up_limit, "cpu usage upper limit, cores", 2.0);

--- a/core/common/LogtailCommonFlags.h
+++ b/core/common/LogtailCommonFlags.h
@@ -24,6 +24,7 @@ DECLARE_FLAG_STRING(logtail_integrity_snapshot);
 
 // app config
 DECLARE_FLAG_STRING(ilogtail_config);
+DECLARE_FLAG_BOOL(sidecar_mode);
 DECLARE_FLAG_INT32(cpu_limit_num);
 DECLARE_FLAG_INT32(mem_limit_num);
 DECLARE_FLAG_DOUBLE(cpu_usage_up_limit);

--- a/core/common/LogtailCommonFlags.h
+++ b/core/common/LogtailCommonFlags.h
@@ -24,7 +24,7 @@ DECLARE_FLAG_STRING(logtail_integrity_snapshot);
 
 // app config
 DECLARE_FLAG_STRING(ilogtail_config);
-DECLARE_FLAG_BOOL(sidecar_mode);
+DECLARE_FLAG_BOOL(enable_full_drain_mode);
 DECLARE_FLAG_INT32(cpu_limit_num);
 DECLARE_FLAG_INT32(mem_limit_num);
 DECLARE_FLAG_DOUBLE(cpu_usage_up_limit);

--- a/core/controller/EventDispatcher.cpp
+++ b/core/controller/EventDispatcher.cpp
@@ -1002,6 +1002,15 @@ void EventDispatcher::DumpCheckPointPeriod(int32_t curTime) {
     }
 }
 
+bool EventDispatcher::IsAllFileRead() {
+    for (auto it = mWdDirInfoMap.begin(); it != mWdDirInfoMap.end(); ++it) {
+        if (!((it->second)->mHandler)->IsAllFileRead()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 #ifdef APSARA_UNIT_TEST_MAIN
 void EventDispatcher::CleanEnviroments() {
     // mMainThreadRunning = false;

--- a/core/controller/EventDispatcher.h
+++ b/core/controller/EventDispatcher.h
@@ -217,6 +217,8 @@ public:
 
     void ClearBrokenLinkSet() { mBrokenLinkSet.clear(); }
 
+    bool IsAllFileRead();
+
 protected:
     EventDispatcher();
     ~EventDispatcher();

--- a/core/event_handler/EventHandler.cpp
+++ b/core/event_handler/EventHandler.cpp
@@ -958,6 +958,7 @@ bool ModifyHandler::IsAllFileRead() {
             return false;
         }
         if (!it->second.empty()) {
+            // force flushing the last line immediately instead of waiting for timeout
             ForceReadLogAndPush(it->second[0]);
         }
     }

--- a/core/event_handler/EventHandler.cpp
+++ b/core/event_handler/EventHandler.cpp
@@ -957,7 +957,9 @@ bool ModifyHandler::IsAllFileRead() {
         if (it->second.size() > 1 || (!it->second.empty() && !it->second[0]->IsReadToEnd())) {
             return false;
         }
-        ForceReadLogAndPush(it->second[0]);
+        if (!it->second.empty()) {
+            ForceReadLogAndPush(it->second[0]);
+        }
     }
     return true;
 }

--- a/core/event_handler/EventHandler.cpp
+++ b/core/event_handler/EventHandler.cpp
@@ -192,7 +192,7 @@ bool CreateModifyHandler::DumpReaderMeta(bool isRotatorReader, bool checkConfigF
 
 bool CreateModifyHandler::IsAllFileRead() {
     for (ModifyHandlerMap::iterator iter = mModifyHandlerPtrMap.begin(); iter != mModifyHandlerPtrMap.end(); ++iter) {
-        if (iter->second->IsAllFileRead()) {
+        if (!iter->second->IsAllFileRead()) {
             return false;
         }
     }
@@ -954,9 +954,10 @@ bool ModifyHandler::DumpReaderMeta(bool isRotatorReader, bool checkConfigFlag) {
 
 bool ModifyHandler::IsAllFileRead() {
     for (auto it = mNameReaderMap.begin(); it != mNameReaderMap.end(); ++it) {
-        if (it->second.size() > 1 || !it->second.empty() && !it->second[0]->IsReadToEnd()) {
+        if (it->second.size() > 1 || (!it->second.empty() && !it->second[0]->IsReadToEnd())) {
             return false;
         }
+        ForceReadLogAndPush(it->second[0]);
     }
     return true;
 }

--- a/core/event_handler/EventHandler.h
+++ b/core/event_handler/EventHandler.h
@@ -15,11 +15,13 @@
  */
 
 #pragma once
-#include "reader/LogFileReader.h"
 #include <time.h>
-#include <map>
+
 #include <deque>
+#include <map>
 #include <unordered_map>
+
+#include "reader/LogFileReader.h"
 
 namespace logtail {
 
@@ -37,6 +39,7 @@ public:
     virtual void Handle(const Event& event) = 0;
     virtual void HandleTimeOut() = 0;
     virtual bool DumpReaderMeta(bool isRotatorReader, bool checkConfigFlag) = 0;
+    virtual bool IsAllFileRead() { return true; }
     virtual ~EventHandler() {}
 };
 
@@ -94,6 +97,7 @@ public:
     virtual void Handle(const Event& event);
     virtual void HandleTimeOut();
     virtual bool DumpReaderMeta(bool isRotatorReader, bool checkConfigFlag);
+    bool IsAllFileRead() override;
 
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class ConfigUpdatorUnittest;
@@ -147,6 +151,7 @@ public:
     virtual void Handle(const Event& event);
     virtual void HandleTimeOut();
     virtual bool DumpReaderMeta(bool isRotatorReader, bool checkConfigFlag);
+    bool IsAllFileRead() override;
 
     ModifyHandler* GetOrCreateModifyHandler(const std::string& configName, const FileDiscoveryConfig& pConfig);
 

--- a/core/event_handler/LogInput.cpp
+++ b/core/event_handler/LogInput.cpp
@@ -458,7 +458,9 @@ void* LogInput::ProcessLoop() {
     mInteruptFlag = true;
     mStopCV.notify_one();
 
-    LOG_INFO(sLogger, ("LogInputThread", "Exit"));
+    if (!BOOL_FLAG(sidecar_mode)) {
+        LOG_WARNING(sLogger, ("LogInputThread", "Exit"));
+    }
     return NULL;
 }
 

--- a/core/event_handler/LogInput.cpp
+++ b/core/event_handler/LogInput.cpp
@@ -101,7 +101,7 @@ void LogInput::Resume() {
 
 void LogInput::HoldOn() {
     LOG_INFO(sLogger, ("event handle daemon pause", "starts"));
-    if (BOOL_FLAG(sidecar_mode)) {
+    if (BOOL_FLAG(enable_full_drain_mode)) {
         unique_lock<mutex> lock(mThreadRunningMux);
         mStopCV.wait(lock, [this]() { return mInteruptFlag; });
     } else {
@@ -449,7 +449,7 @@ void* LogInput::ProcessLoop() {
             lastClearConfigCache = curTime;
         }
 
-        if (BOOL_FLAG(sidecar_mode) && Application::GetInstance()->IsExiting()
+        if (BOOL_FLAG(enable_full_drain_mode) && Application::GetInstance()->IsExiting()
             && EventDispatcher::GetInstance()->IsAllFileRead()) {
             break;
         }
@@ -458,7 +458,7 @@ void* LogInput::ProcessLoop() {
     mInteruptFlag = true;
     mStopCV.notify_one();
 
-    if (!BOOL_FLAG(sidecar_mode)) {
+    if (!BOOL_FLAG(enable_full_drain_mode)) {
         LOG_WARNING(sLogger, ("LogInputThread", "Exit"));
     }
     return NULL;

--- a/core/event_handler/LogInput.h
+++ b/core/event_handler/LogInput.h
@@ -17,10 +17,12 @@
 #ifndef __LOG_ILOGTAIL_LOG_INPUT_H__
 #define __LOG_ILOGTAIL_LOG_INPUT_H__
 
-#include <string>
+#include <condition_variable>
 #include <queue>
-#include <vector>
+#include <string>
 #include <unordered_set>
+#include <vector>
+
 #include "common/Lock.h"
 #include "common/LogRunnable.h"
 
@@ -78,6 +80,8 @@ private:
     int32_t mLastUpdateMetricTime;
 
     std::atomic_int mLastReadEventTime{0};
+    mutable std::mutex mThreadRunningMux;
+    mutable std::condition_variable mStopCV;
 
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class LogInputUnittest;

--- a/core/pipeline/PipelineManager.cpp
+++ b/core/pipeline/PipelineManager.cpp
@@ -212,8 +212,6 @@ void PipelineManager::StopAllPipelines() {
     Sender::Instance()->SetQueueUrgent();
     bool logProcessFlushFlag = false;
     for (int i = 0; !logProcessFlushFlag && i < 500; ++i) {
-        // deamon send thread may reset flush, so we should set flush every time
-        Sender::Instance()->SetFlush();
         logProcessFlushFlag = LogProcess::GetInstance()->FlushOut(10);
     }
     if (!logProcessFlushFlag) {


### PR DESCRIPTION
Introducing the full_drain_mode configuration, which when enabled, triggers a comprehensive data flush across the network during the shutdown sequence. This mode is particularly beneficial for environments with sidecar and fat containers where data persistence is not guaranteed post-application exit. By ensuring all data is transmitted prior to shutdown, we prevent potential data loss that could occur with local dumps, making this feature a critical addition for systems that require high data integrity and resilience.