### PR TITLE
fix: maintain sequential info of the original log content and allow multivalue for single key for apsara processor

### DIFF
--- a/core/models/LogEvent.cpp
+++ b/core/models/LogEvent.cpp
@@ -50,12 +50,13 @@ void LogEvent::SetContentNoCopy(const StringBuffer& key, const StringBuffer& val
 }
 
 void LogEvent::SetContentNoCopy(StringView key, StringView val) {
-    mContents.emplace_back(std::pair<StringView, StringView>(key, val), true);
     auto it = mIndex.find(key);
     if (it != mIndex.end()) {
-        mContents[it->second].second = false;
+        mContents[it->second].first = std::pair<StringView, StringView>(key, val);
+    } else {
+        mContents.emplace_back(std::pair<StringView, StringView>(key, val), true);
+        mIndex[key] = mContents.size() - 1;
     }
-    mIndex[key] = mContents.size() - 1;
 }
 
 void LogEvent::DelContent(StringView key) {
@@ -91,6 +92,7 @@ LogEvent::ContentIterator LogEvent::begin() {
 }
 
 LogEvent::ContentIterator LogEvent::end() {
+    mContents.end() == mContents.end();
     return ContentIterator(mContents.end(), mContents);
 }
 

--- a/core/models/LogEvent.cpp
+++ b/core/models/LogEvent.cpp
@@ -116,7 +116,7 @@ LogEvent::ConstContentIterator LogEvent::cend() const {
     return ConstContentIterator(mContents.cend(), mContents);
 }
 
-void LogEvent::AppendContent(StringView key, StringView val) {
+void LogEvent::AppendContentNoCopy(StringView key, StringView val) {
     mContents.emplace_back(std::pair<StringView, StringView>(key, val), true);
     mIndex[key] = mContents.size() - 1;
 }

--- a/core/models/LogEvent.cpp
+++ b/core/models/LogEvent.cpp
@@ -21,7 +21,19 @@ namespace logtail {
 LogEvent::LogEvent(PipelineEventGroup* ptr) : PipelineEvent(Type::LOG, ptr) {
 }
 
-void LogEvent::SetContent(const StringView& key, const StringView& val) {
+StringView LogEvent::GetContent(StringView key) const {
+    auto it = mIndex.find(key);
+    if (it != mIndex.end()) {
+        return mContents[it->second].first.second;
+    }
+    return gEmptyStringView;
+}
+
+bool LogEvent::HasContent(StringView key) const {
+    return mIndex.find(key) != mIndex.end();
+}
+
+void LogEvent::SetContent(StringView key, StringView val) {
     SetContentNoCopy(GetSourceBuffer()->CopyString(key), GetSourceBuffer()->CopyString(val));
 }
 
@@ -29,7 +41,7 @@ void LogEvent::SetContent(const std::string& key, const std::string& val) {
     SetContentNoCopy(GetSourceBuffer()->CopyString(key), GetSourceBuffer()->CopyString(val));
 }
 
-void LogEvent::SetContent(const StringBuffer& key, const StringView& val) {
+void LogEvent::SetContent(const StringBuffer& key, StringView val) {
     SetContentNoCopy(key, GetSourceBuffer()->CopyString(val));
 }
 
@@ -37,24 +49,74 @@ void LogEvent::SetContentNoCopy(const StringBuffer& key, const StringBuffer& val
     SetContentNoCopy(StringView(key.data, key.size), StringView(val.data, val.size));
 }
 
-const StringView& LogEvent::GetContent(const StringView& key) const {
-    auto it = contents.find(key);
-    if (it != contents.end()) {
-        return it->second;
+void LogEvent::SetContentNoCopy(StringView key, StringView val) {
+    mContents.emplace_back(std::pair<StringView, StringView>(key, val), true);
+    auto it = mIndex.find(key);
+    if (it != mIndex.end()) {
+        mContents[it->second].second = false;
     }
-    return gEmptyStringView;
+    mIndex[key] = mContents.size() - 1;
 }
 
-bool LogEvent::HasContent(const StringView& key) const {
-    return contents.find(key) != contents.end();
+void LogEvent::DelContent(StringView key) {
+    auto it = mIndex.find(key);
+    if (it != mIndex.end()) {
+        mContents[it->second].second = false;
+        mIndex.erase(it);
+    }
 }
 
-void LogEvent::SetContentNoCopy(const StringView& key, const StringView& val) {
-    contents[key] = val;
+LogEvent::ContentIterator LogEvent::FindContent(StringView key) {
+    auto it = mIndex.find(key);
+    if (it != mIndex.end()) {
+        return ContentIterator(mContents.begin() + it->second, mContents);
+    }
+    return ContentIterator(mContents.end(), mContents);
 }
 
-void LogEvent::DelContent(const StringView& key) {
-    contents.erase(key);
+LogEvent::ConstContentIterator LogEvent::FindContent(StringView key) const {
+    auto it = mIndex.find(key);
+    if (it != mIndex.end()) {
+        return ConstContentIterator(mContents.begin() + it->second, mContents);
+    }
+    return ConstContentIterator(mContents.end(), mContents);
+}
+
+LogEvent::ContentIterator LogEvent::begin() {
+    auto it = mContents.begin();
+    while (it != mContents.end() && !it->second) {
+        ++it;
+    }
+    return ContentIterator(it, mContents);
+}
+
+LogEvent::ContentIterator LogEvent::end() {
+    return ContentIterator(mContents.end(), mContents);
+}
+
+LogEvent::ConstContentIterator LogEvent::begin() const {
+    return cbegin();
+}
+
+LogEvent::ConstContentIterator LogEvent::end() const {
+    return cend();
+}
+
+LogEvent::ConstContentIterator LogEvent::cbegin() const {
+    auto it = mContents.cbegin();
+    while (it != mContents.cend() && !it->second) {
+        ++it;
+    }
+    return ConstContentIterator(it, mContents);
+}
+
+LogEvent::ConstContentIterator LogEvent::cend() const {
+    return ConstContentIterator(mContents.cend(), mContents);
+}
+
+void LogEvent::AppendContent(StringView key, StringView val) {
+    mContents.emplace_back(std::pair<StringView, StringView>(key, val), true);
+    mIndex[key] = mContents.size() - 1;
 }
 
 uint64_t LogEvent::EventsSizeBytes() {
@@ -68,9 +130,9 @@ Json::Value LogEvent::ToJson() const {
     root["type"] = static_cast<int>(GetType());
     root["timestamp"] = GetTimestamp();
     root["timestampNanosecond"] = GetTimestampNanosecond();
-    if (!GetContents().empty()) {
+    if (!Empty()) {
         Json::Value contents;
-        for (const auto& content : this->GetContents()) {
+        for (const auto& content : *this) {
             contents[content.first.to_string()] = content.second.to_string();
         }
         root["contents"] = std::move(contents);

--- a/core/models/LogEvent.h
+++ b/core/models/LogEvent.h
@@ -102,7 +102,7 @@ private:
     // this is only used for ProcessorParseApsaraNative for backward compatability, since multiple keys are allowed.
     // We do not invalidate existing LogContent when the same key has arrived.
     friend class ProcessorParseApsaraNative;
-    void AppendContent(StringView key, StringView val);
+    void AppendContentNoCopy(StringView key, StringView val);
 
     // since log reduce in SLS server requires the original order of log contents, we have to maintain this sequential
     // information for backward compatability.

--- a/core/models/LogEvent.h
+++ b/core/models/LogEvent.h
@@ -20,23 +20,74 @@
 
 namespace logtail {
 
-using LogContents = std::map<StringView, StringView>;
+using LogContent = std::pair<StringView, StringView>;
+using ContentsContainer = std::vector<std::pair<LogContent, bool>>;
+
+template <class T, class F>
+class BaseContentIterator {
+    friend class LogEvent;
+
+public:
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = F;
+    using reference = F&;
+    using pointer = F*;
+
+    BaseContentIterator(const ContentsContainer& c) : container(c) {}
+
+    reference operator*() const { return ptr->first; }
+    pointer operator->() const { return &ptr->first; }
+    BaseContentIterator& operator++() {
+        Advance();
+        return *this;
+    }
+    BaseContentIterator operator++(int) {
+        BaseContentIterator it(ptr, container);
+        Advance();
+        return it;
+    }
+    bool operator==(const BaseContentIterator& rhs) const { return ptr == rhs.ptr; }
+    bool operator!=(const BaseContentIterator& rhs) const { return ptr != rhs.ptr; }
+
+private:
+    explicit BaseContentIterator(const T& p, const ContentsContainer& c) : ptr(p), container(c) {}
+    void Advance() {
+        while (ptr != container.end() && !((++ptr)->second))
+            ;
+    }
+
+    T ptr;
+    const ContentsContainer& container;
+};
 
 class LogEvent : public PipelineEvent {
     friend class PipelineEventGroup;
 
 public:
-    const LogContents& GetContents() const { return contents; }
-    LogContents& MutableContents() { return contents; }
-    void SetContent(const StringView& key, const StringView& val);
-    void SetContent(const std::string& key, const std::string& val);
-    void SetContent(const StringBuffer& key, const StringView& val);
+    using ConstContentIterator = BaseContentIterator<ContentsContainer::const_iterator, const LogContent>;
+    using ContentIterator = BaseContentIterator<ContentsContainer::iterator, LogContent>;
 
+    StringView GetContent(StringView key) const;
+    bool HasContent(StringView key) const;
+    ContentIterator FindContent(StringView key);
+    ConstContentIterator FindContent(StringView key) const;
+    void SetContent(StringView key, StringView val);
+    void SetContent(const std::string& key, const std::string& val);
+    void SetContent(const StringBuffer& key, StringView val);
     void SetContentNoCopy(const StringBuffer& key, const StringBuffer& val);
-    const StringView& GetContent(const StringView& key) const;
-    bool HasContent(const StringView& key) const;
-    void SetContentNoCopy(const StringView& key, const StringView& val);
-    void DelContent(const StringView& key);
+    void SetContentNoCopy(StringView key, StringView val);
+    void DelContent(StringView key);
+
+    bool Empty() const { return mIndex.empty(); }
+    size_t Size() const { return mIndex.size(); }
+
+    ContentIterator begin();
+    ContentIterator end();
+    ConstContentIterator begin() const;
+    ConstContentIterator end() const;
+    ConstContentIterator cbegin() const;
+    ConstContentIterator cend() const;
 
     uint64_t EventsSizeBytes() override;
 
@@ -48,7 +99,14 @@ public:
 private:
     LogEvent(PipelineEventGroup* ptr);
 
-    LogContents contents;
+    // this is only used for ProcessorParseApsaraNative for backward compatability, since multiple keys are allowed.
+    // We do not invalidate existing LogContent when the same key has arrived.
+    friend class ProcessorParseApsaraNative;
+    void AppendContent(StringView key, StringView val);
+
+    // since log reduce in SLS server requires the original order of log contents, we have to maintain this sequential information for backward compatability.
+    ContentsContainer mContents;
+    std::map<StringView, size_t> mIndex;
 };
 
 } // namespace logtail

--- a/core/models/LogEvent.h
+++ b/core/models/LogEvent.h
@@ -53,7 +53,7 @@ public:
 private:
     explicit BaseContentIterator(const T& p, const ContentsContainer& c) : ptr(p), container(c) {}
     void Advance() {
-        while (ptr != container.end() && !((++ptr)->second))
+        while ((++ptr != container.end()) && !(ptr->second))
             ;
     }
 
@@ -104,7 +104,8 @@ private:
     friend class ProcessorParseApsaraNative;
     void AppendContent(StringView key, StringView val);
 
-    // since log reduce in SLS server requires the original order of log contents, we have to maintain this sequential information for backward compatability.
+    // since log reduce in SLS server requires the original order of log contents, we have to maintain this sequential
+    // information for backward compatability.
     ContentsContainer mContents;
     std::map<StringView, size_t> mIndex;
 };

--- a/core/processor/CommonParserOptions.cpp
+++ b/core/processor/CommonParserOptions.cpp
@@ -96,12 +96,11 @@ bool CommonParserOptions::ShouldAddSourceContent(bool parseSuccess) {
 
 bool CommonParserOptions::ShouldEraseEvent(bool parseSuccess, const LogEvent& sourceEvent) {
     if (!parseSuccess && !mKeepingSourceWhenParseFail) {
-        const auto& contents = sourceEvent.GetContents();
-        if (contents.empty()) {
+        if (sourceEvent.Empty()) {
             return true;
         }
         // "__file_offset__"
-        if (contents.size() == 1 && (contents.begin()->first == LOG_RESERVED_KEY_FILE_OFFSET)) {
+        if (sourceEvent.Size() == 1 && (sourceEvent.cbegin()->first == LOG_RESERVED_KEY_FILE_OFFSET)) {
             return true;
         }
     }

--- a/core/processor/ProcessorDesensitizeNative.cpp
+++ b/core/processor/ProcessorDesensitizeNative.cpp
@@ -162,21 +162,20 @@ void ProcessorDesensitizeNative::ProcessEvent(PipelineEventPtr& e) {
     auto& sourceEvent = e.Cast<LogEvent>();
 
     // Traverse all fields and desensitize sensitive fields.
-    auto end = sourceEvent.end();
-    for (auto it = sourceEvent.begin(); it != end; ++it) {
+    for (auto& item : sourceEvent) {
         // Only perform desensitization processing on specified fields.
-        if (it->first != mSourceKey) {
+        if (item.first != mSourceKey) {
             continue;
         }
         // Only perform desensitization processing on non-empty fields.
-        if (it->second.empty()) {
+        if (item.second.empty()) {
             continue;
         }
-        std::string value = it->second.to_string();
+        std::string value = item.second.to_string();
         CastOneSensitiveWord(&value);
         mProcDesensitizeRecodesTotal->Add(1);
         StringBuffer valueBuffer = sourceEvent.GetSourceBuffer()->CopyString(value);
-        sourceEvent.SetContentNoCopy(it->first, StringView(valueBuffer.data, valueBuffer.size));
+        sourceEvent.SetContentNoCopy(item.first, StringView(valueBuffer.data, valueBuffer.size));
     }
 }
 

--- a/core/processor/ProcessorDesensitizeNative.cpp
+++ b/core/processor/ProcessorDesensitizeNative.cpp
@@ -161,23 +161,21 @@ void ProcessorDesensitizeNative::ProcessEvent(PipelineEventPtr& e) {
 
     auto& sourceEvent = e.Cast<LogEvent>();
 
-    const LogContents& contents = sourceEvent.GetContents();
-
     // Traverse all fields and desensitize sensitive fields.
-    for (auto it = contents.begin(); it != contents.end(); ++it) {
+    for (auto & item : sourceEvent) {
         // Only perform desensitization processing on specified fields.
-        if (it->first != mSourceKey) {
+        if (item.first != mSourceKey) {
             continue;
         }
         // Only perform desensitization processing on non-empty fields.
-        if (it->second.empty()) {
+        if (item.second.empty()) {
             continue;
         }
-        std::string value = it->second.to_string();
+        std::string value = item.second.to_string();
         CastOneSensitiveWord(&value);
         mProcDesensitizeRecodesTotal->Add(1);
         StringBuffer valueBuffer = sourceEvent.GetSourceBuffer()->CopyString(value);
-        sourceEvent.SetContentNoCopy(it->first, StringView(valueBuffer.data, valueBuffer.size));
+        sourceEvent.SetContentNoCopy(item.first, StringView(valueBuffer.data, valueBuffer.size));
     }
 }
 

--- a/core/processor/ProcessorDesensitizeNative.cpp
+++ b/core/processor/ProcessorDesensitizeNative.cpp
@@ -162,20 +162,21 @@ void ProcessorDesensitizeNative::ProcessEvent(PipelineEventPtr& e) {
     auto& sourceEvent = e.Cast<LogEvent>();
 
     // Traverse all fields and desensitize sensitive fields.
-    for (auto & item : sourceEvent) {
+    auto end = sourceEvent.end();
+    for (auto it = sourceEvent.begin(); it != end; ++it) {
         // Only perform desensitization processing on specified fields.
-        if (item.first != mSourceKey) {
+        if (it->first != mSourceKey) {
             continue;
         }
         // Only perform desensitization processing on non-empty fields.
-        if (item.second.empty()) {
+        if (it->second.empty()) {
             continue;
         }
-        std::string value = item.second.to_string();
+        std::string value = it->second.to_string();
         CastOneSensitiveWord(&value);
         mProcDesensitizeRecodesTotal->Add(1);
         StringBuffer valueBuffer = sourceEvent.GetSourceBuffer()->CopyString(value);
-        sourceEvent.SetContentNoCopy(item.first, StringView(valueBuffer.data, valueBuffer.size));
+        sourceEvent.SetContentNoCopy(it->first, StringView(valueBuffer.data, valueBuffer.size));
     }
 }
 

--- a/core/processor/ProcessorFilterNative.h
+++ b/core/processor/ProcessorFilterNative.h
@@ -37,7 +37,7 @@ public:
 
 public:
     virtual bool Match(const sls_logs::Log& log, const LogGroupContext& context) { return true; }
-    virtual bool Match(const LogContents& contents, const PipelineContext& mContext) { return true; }
+    virtual bool Match(const LogEvent& contents, const PipelineContext& mContext) { return true; }
 
 public:
     FilterNodeType GetNodeType() const { return nodeType; }
@@ -57,7 +57,7 @@ public:
 
 public:
     virtual bool Match(const sls_logs::Log& log, const LogGroupContext& context);
-    virtual bool Match(const LogContents& contents, const PipelineContext& mContext);
+    virtual bool Match(const LogEvent& contents, const PipelineContext& mContext);
 
 private:
     FilterOperator op;
@@ -76,7 +76,7 @@ public:
 public:
     virtual bool Match(const sls_logs::Log& log, const LogGroupContext& context);
 
-    virtual bool Match(const LogContents& contents, const PipelineContext& mContext);
+    virtual bool Match(const LogEvent& contents, const PipelineContext& mContext);
 
 private:
     std::string key;
@@ -94,7 +94,7 @@ public:
 public:
     virtual bool Match(const sls_logs::Log& log, const LogGroupContext& context);
 
-    virtual bool Match(const LogContents& contents, const PipelineContext& mContext);
+    virtual bool Match(const LogEvent& contents, const PipelineContext& mContext);
 
 private:
     BaseFilterNodePtr child;
@@ -136,7 +136,7 @@ private:
 
     // Filter logs through FilterRule
     bool FilterFilterRule(LogEvent& sourceEvent, const LogFilterRule* filterRule);
-    bool IsMatched(const LogContents& contents, const LogFilterRule& rule);
+    bool IsMatched(const LogEvent& contents, const LogFilterRule& rule);
 
     bool noneUtf8(StringView& strSrc, bool modify);
     bool CheckNoneUtf8(const StringView& strSrc);

--- a/core/processor/ProcessorParseApsaraNative.cpp
+++ b/core/processor/ProcessorParseApsaraNative.cpp
@@ -466,7 +466,7 @@ void ProcessorParseApsaraNative::AddLog(const StringView& key,
     if (!overwritten && targetEvent.HasContent(key)) {
         return;
     }
-    targetEvent.AppendContent(key, value);
+    targetEvent.AppendContentNoCopy(key, value);
     *mLogGroupSize += key.size() + value.size() + 5;
     mProcParseOutSizeBytes->Add(key.size() + value.size());
 }

--- a/core/processor/ProcessorParseApsaraNative.cpp
+++ b/core/processor/ProcessorParseApsaraNative.cpp
@@ -466,7 +466,7 @@ void ProcessorParseApsaraNative::AddLog(const StringView& key,
     if (!overwritten && targetEvent.HasContent(key)) {
         return;
     }
-    targetEvent.SetContentNoCopy(key, value);
+    targetEvent.AppendContent(key, value);
     *mLogGroupSize += key.size() + value.size() + 5;
     mProcParseOutSizeBytes->Add(key.size() + value.size());
 }

--- a/core/processor/ProcessorSplitLogStringNative.cpp
+++ b/core/processor/ProcessorSplitLogStringNative.cpp
@@ -125,8 +125,8 @@ void ProcessorSplitLogStringNative::ProcessEvent(PipelineEventGroup& logGroup,
             StringBuffer offsetStr = logGroup.GetSourceBuffer()->CopyString(std::to_string(offset));
             targetEvent->SetContentNoCopy(LOG_RESERVED_KEY_FILE_OFFSET, StringView(offsetStr.data, offsetStr.size));
         }
-        if (sourceEvent.GetContents().size() > 1) { // copy other fields
-            for (auto& kv : sourceEvent.GetContents()) {
+        if (sourceEvent.Size() > 1) { // copy other fields
+            for (const auto& kv : sourceEvent) {
                 if (kv.first != mSourceKey && kv.first != LOG_RESERVED_KEY_FILE_OFFSET) {
                     targetEvent->SetContentNoCopy(kv.first, kv.second);
                 }

--- a/core/processor/ProcessorSplitRegexNative.cpp
+++ b/core/processor/ProcessorSplitRegexNative.cpp
@@ -155,8 +155,8 @@ void ProcessorSplitRegexNative::ProcessEvent(PipelineEventGroup& logGroup,
             StringBuffer offsetStr = logGroup.GetSourceBuffer()->CopyString(std::to_string(offset));
             targetEvent->SetContentNoCopy(LOG_RESERVED_KEY_FILE_OFFSET, StringView(offsetStr.data, offsetStr.size));
         }
-        if (sourceEvent.GetContents().size() > 1) { // copy other fields
-            for (auto& kv : sourceEvent.GetContents()) {
+        if (sourceEvent.Size() > 1) { // copy other fields
+            for (const auto& kv : sourceEvent) {
                 if (kv.first != mSourceKey && kv.first != LOG_RESERVED_KEY_FILE_OFFSET) {
                     targetEvent->SetContentNoCopy(kv.first, kv.second);
                 }

--- a/core/processor/daemon/LogProcess.cpp
+++ b/core/processor/daemon/LogProcess.cpp
@@ -533,7 +533,7 @@ void LogProcess::FillLogGroupLogs(const PipelineEventGroup& eventGroup,
         } else {
             SetLogTime(log, logEvent.GetTimestamp());
         }
-        for (auto& kv : logEvent.GetContents()) {
+        for (const auto& kv : logEvent) {
             sls_logs::Log_Content* contPtr = log->add_contents();
             // need to rename EVENT_META_LOG_FILE_OFFSET
             contPtr->set_key(kv.first.to_string());

--- a/core/unittest/models/LogEventUnittest.cpp
+++ b/core/unittest/models/LogEventUnittest.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdlib>
-
 #include "common/JsonUtil.h"
 #include "models/LogEvent.h"
 #include "unittest/Unittest.h"
+
+using namespace std;
 
 namespace logtail {
 
@@ -25,7 +25,8 @@ public:
     void TestSetTimestamp();
     void TestSetContent();
     void TestDelContent();
-
+    void TestReadOp();
+    void TestIterate();
     void TestFromJsonToJson();
 
 protected:
@@ -36,65 +37,124 @@ protected:
     }
 
 private:
-    std::shared_ptr<SourceBuffer> mSourceBuffer;
-    std::unique_ptr<PipelineEventGroup> mEventGroup;
-    std::unique_ptr<LogEvent> mLogEvent;
+    shared_ptr<SourceBuffer> mSourceBuffer;
+    unique_ptr<PipelineEventGroup> mEventGroup;
+    unique_ptr<LogEvent> mLogEvent;
 };
-
-UNIT_TEST_CASE(LogEventUnittest, TestSetTimestamp)
-UNIT_TEST_CASE(LogEventUnittest, TestSetContent)
-UNIT_TEST_CASE(LogEventUnittest, TestDelContent)
-UNIT_TEST_CASE(LogEventUnittest, TestFromJsonToJson)
 
 void LogEventUnittest::TestSetTimestamp() {
     mLogEvent->SetTimestamp(13800000000);
-    APSARA_TEST_EQUAL_FATAL(13800000000, mLogEvent->GetTimestamp());
+    APSARA_TEST_EQUAL(13800000000, mLogEvent->GetTimestamp());
 }
 
 void LogEventUnittest::TestSetContent() {
     { // string copy, let kv out of scope
-        mLogEvent->SetContent(std::string("key1"), std::string("value1"));
+        mLogEvent->SetContent(string("key1"), string("value1"));
     }
     { // stringview copy, let kv out of scope
-        std::string key("key2");
-        std::string value("value2");
+        string key("key2");
+        string value("value2");
         mLogEvent->SetContent(StringView(key), StringView(value));
     }
     size_t beforeAlloc;
     { // StringBuffer nocopy
-        StringBuffer key = mLogEvent->GetSourceBuffer()->CopyString(std::string("key3"));
-        StringBuffer value = mLogEvent->GetSourceBuffer()->CopyString(std::string("value3"));
+        StringBuffer key = mLogEvent->GetSourceBuffer()->CopyString(string("key3"));
+        StringBuffer value = mLogEvent->GetSourceBuffer()->CopyString(string("value3"));
         beforeAlloc = mSourceBuffer->mAllocator.TotalAllocated();
         mLogEvent->SetContentNoCopy(key, value);
     }
-    std::string key("key4");
-    std::string value("value4");
+    string key("key4");
+    string value("value4");
     { // StringView nocopy
         mLogEvent->SetContentNoCopy(StringView(key), StringView(value));
     }
     size_t afterAlloc = mSourceBuffer->mAllocator.TotalAllocated();
-    APSARA_TEST_EQUAL_FATAL(beforeAlloc, afterAlloc);
-    std::vector<std::pair<std::string, std::string>> answers = {
+    APSARA_TEST_EQUAL(beforeAlloc, afterAlloc);
+    vector<pair<string, string>> answers = {
         {"key1", "value1"},
         {"key2", "value2"},
         {"key3", "value3"},
         {"key4", "value4"},
     };
     for (const auto kv : answers) {
-        APSARA_TEST_TRUE_FATAL(mLogEvent->HasContent(kv.first));
-        APSARA_TEST_STREQ_FATAL(kv.second.c_str(), mLogEvent->GetContent(kv.first).data());
+        APSARA_TEST_TRUE(mLogEvent->HasContent(kv.first));
+        APSARA_TEST_STREQ(kv.second.c_str(), mLogEvent->GetContent(kv.first).data());
     }
 }
 
 void LogEventUnittest::TestDelContent() {
-    mLogEvent->SetContent(std::string("key1"), std::string("value1"));
-    APSARA_TEST_TRUE_FATAL(mLogEvent->HasContent("key1"));
-    mLogEvent->DelContent(std::string("key1"));
-    APSARA_TEST_FALSE_FATAL(mLogEvent->HasContent("key1"));
+    mLogEvent->SetContent(string("key1"), string("value1"));
+    {
+        // key not exists
+        mLogEvent->DelContent(string("key2"));
+        APSARA_TEST_EQUAL(1, mLogEvent->Size());
+    }
+    {
+        // key exists
+        mLogEvent->DelContent(string("key1"));
+        APSARA_TEST_FALSE(mLogEvent->HasContent("key1"));
+        APSARA_TEST_TRUE(mLogEvent->Empty());
+    }
+}
+
+void LogEventUnittest::TestReadOp() {
+    mLogEvent->SetContent(string("key1"), string("value1"));
+    {
+        // key not exists
+        auto it = mLogEvent->FindContent("key2");
+        APSARA_TEST_TRUE(it == mLogEvent->end());
+        APSARA_TEST_FALSE(mLogEvent->HasContent("key2"));
+        APSARA_TEST_EQUAL(nullptr, mLogEvent->GetContent("key2").data());
+    }
+    {
+        // key exists
+        auto it = mLogEvent->FindContent("key1");
+        APSARA_TEST_TRUE(it != mLogEvent->end());
+        APSARA_TEST_STREQ("key1", it->first.data());
+        APSARA_TEST_STREQ("value1", it->second.data());
+        APSARA_TEST_TRUE(mLogEvent->HasContent("key1"));
+        APSARA_TEST_STREQ("value1", mLogEvent->GetContent("key1").data());
+    }
+}
+
+void LogEventUnittest::TestIterate() {
+    {
+        // first element is valid
+        mLogEvent->SetContent(string("key1"), string("value1"));
+        APSARA_TEST_STREQ("key1", mLogEvent->begin()->first.data());
+        APSARA_TEST_STREQ("value1", mLogEvent->begin()->second.data());
+    }
+    {
+        // first element is invalid, and no element is valid
+        mLogEvent->DelContent("key1");
+        APSARA_TEST_TRUE(mLogEvent->end() == mLogEvent->begin());
+    }
+    {
+        // first element is invalid, and at least one element is valid
+        mLogEvent->SetContent(string("key1"), string("value1"));
+        APSARA_TEST_STREQ("key1", mLogEvent->begin()->first.data());
+        APSARA_TEST_STREQ("value1", mLogEvent->begin()->second.data());
+    }
+
+    // 2 valid elements and 1 invalid element
+    mLogEvent->SetContent(string("key2"), string("value2"));
+    {
+        // suffix iteration
+        auto it = mLogEvent->begin()++;
+        APSARA_TEST_STREQ("key1", it->first.data());
+        APSARA_TEST_STREQ("value1", it->second.data());
+    }
+    {
+        // prefix iteration
+        auto it = ++mLogEvent->begin();
+        APSARA_TEST_STREQ("key2", it->first.data());
+        APSARA_TEST_STREQ("value2", it->second.data());
+        APSARA_TEST_TRUE(mLogEvent->end() == ++it);
+    }
 }
 
 void LogEventUnittest::TestFromJsonToJson() {
-    std::string inJson = R"({
+    string inJson = R"({
         "contents" :
         {
             "key1" : "value1",
@@ -104,16 +164,23 @@ void LogEventUnittest::TestFromJsonToJson() {
         "timestampNanosecond" : 0,
         "type" : 1
     })";
-    APSARA_TEST_TRUE_FATAL(mLogEvent->FromJsonString(inJson));
-    APSARA_TEST_EQUAL_FATAL(12345678901L, mLogEvent->GetTimestamp());
-    std::vector<std::pair<std::string, std::string>> answers = {{"key1", "value1"}, {"key2", "value2"}};
+    APSARA_TEST_TRUE(mLogEvent->FromJsonString(inJson));
+    APSARA_TEST_EQUAL(12345678901L, mLogEvent->GetTimestamp());
+    vector<pair<string, string>> answers = {{"key1", "value1"}, {"key2", "value2"}};
     for (const auto kv : answers) {
-        APSARA_TEST_TRUE_FATAL(mLogEvent->HasContent(kv.first));
-        APSARA_TEST_STREQ_FATAL(kv.second.c_str(), mLogEvent->GetContent(kv.first).data());
+        APSARA_TEST_TRUE(mLogEvent->HasContent(kv.first));
+        APSARA_TEST_STREQ(kv.second.c_str(), mLogEvent->GetContent(kv.first).data());
     }
-    std::string outJson = mLogEvent->ToJsonString();
-    APSARA_TEST_STREQ_FATAL(CompactJson(inJson).c_str(), CompactJson(outJson).c_str());
+    string outJson = mLogEvent->ToJsonString();
+    APSARA_TEST_STREQ(CompactJson(inJson).c_str(), CompactJson(outJson).c_str());
 }
+
+UNIT_TEST_CASE(LogEventUnittest, TestSetTimestamp)
+UNIT_TEST_CASE(LogEventUnittest, TestSetContent)
+UNIT_TEST_CASE(LogEventUnittest, TestDelContent)
+UNIT_TEST_CASE(LogEventUnittest, TestReadOp)
+UNIT_TEST_CASE(LogEventUnittest, TestIterate)
+UNIT_TEST_CASE(LogEventUnittest, TestFromJsonToJson)
 
 } // namespace logtail
 


### PR DESCRIPTION
1. 使用vector保存KV，然后新增一个map建立key的索引；
2. 删除某个key时，将其从索引中删除，但是vector中保留KV，仅标记其为无效
3. 遍历content时，实际遍历vector，但是需要跳过无效元素。