### PR TITLE
wait for read flush timeout instead of flushing last line immediately on file deletion

### DIFF
--- a/core/event_handler/EventHandler.cpp
+++ b/core/event_handler/EventHandler.cpp
@@ -776,6 +776,7 @@ void ModifyHandler::Handle(const Event& event) {
                                  "config", mConfigName)("log reader queue name", reader->GetHostLogPath())(
                                  "file device", reader->GetDevInode().dev)("file inode", reader->GetDevInode().inode)(
                                  "file size", reader->GetFileSize()));
+                    reader->CloseFilePtr();
                 } else if (reader->IsContainerStopped()) {
                     // release fd as quick as possible
                     LOG_INFO(
@@ -786,8 +787,8 @@ void ModifyHandler::Handle(const Event& event) {
                                                                                reader->GetDevInode().dev)(
                             "file inode", reader->GetDevInode().inode)("file size", reader->GetFileSize()));
                     ForceReadLogAndPush(reader);
+                    reader->CloseFilePtr();
                 }
-                reader->CloseFilePtr();
                 break;
             }
             if (pushRetry >= 5 || GetCurrentTimeInMicroSeconds() - beginTime > mReadFileTimeSlice) {

--- a/core/reader/LogFileReader.cpp
+++ b/core/reader/LogFileReader.cpp
@@ -18,16 +18,15 @@
 #include <fcntl.h>
 #include <io.h>
 #endif
+#include <cityhash/city.h>
 #include <time.h>
 
 #include <algorithm>
+#include <boost/filesystem.hpp>
+#include <boost/regex.hpp>
 #include <limits>
 #include <numeric>
 #include <random>
-
-#include <boost/filesystem.hpp>
-#include <boost/regex.hpp>
-#include <cityhash/city.h>
 
 #include "GloablFileDescriptorManager.h"
 #include "app_config/AppConfig.h"
@@ -978,7 +977,8 @@ void LogFileReader::skipCheckpointRelayHole() {
 }
 
 bool LogFileReader::ReadLog(LogBuffer& logBuffer, const Event* event) {
-    if (mLogFileOp.IsOpen() == false) {
+    // when event is read timeout and the file cannot be opened, simply flush the cache.
+    if (!mLogFileOp.IsOpen() && (event == nullptr || !event->IsReaderFlushTimeout())) {
         if (!ShouldForceReleaseDeletedFileFd()) {
             // should never happen
             LOG_ERROR(sLogger, ("unknow error, log file not open", mHostLogPath));
@@ -988,7 +988,7 @@ bool LogFileReader::ReadLog(LogBuffer& logBuffer, const Event* event) {
     if (AppConfig::GetInstance()->IsInputFlowControl())
         LogInput::GetInstance()->FlowControl();
 
-    if (mFirstWatched && (mLastFilePos == 0))
+    if ((event == nullptr || !event->IsReaderFlushTimeout()) && mFirstWatched && (mLastFilePos == 0))
         CheckForFirstOpen();
 
     // Init checkpoint for this read, new if no checkpoint to replay.
@@ -1633,84 +1633,108 @@ void LogFileReader::setExactlyOnceCheckpointAfterRead(size_t readSize) {
 }
 
 void LogFileReader::ReadUTF8(LogBuffer& logBuffer, int64_t end, bool& moreData, bool allowRollback) {
-    logBuffer.readOffset = mLastFilePos;
-    bool fromCpt = false;
-    size_t READ_BYTE = getNextReadSize(end, fromCpt);
-    if (!READ_BYTE) {
-        return;
-    }
-    const size_t lastCacheSize = mCache.size();
-    if (READ_BYTE < lastCacheSize) {
-        READ_BYTE = lastCacheSize; // this should not happen, just avoid READ_BYTE >= 0 theoratically
-    }
-    StringBuffer stringMemory = logBuffer.AllocateStringBuffer(READ_BYTE); // allocate modifiable buffer
-    if (lastCacheSize) {
-        READ_BYTE -= lastCacheSize; // reserve space to copy from cache if needed
-    }
-    TruncateInfo* truncateInfo = nullptr;
-    int64_t lastReadPos = GetLastReadPos();
-    size_t nbytes = READ_BYTE
-        ? ReadFile(mLogFileOp, stringMemory.data + lastCacheSize, READ_BYTE, lastReadPos, &truncateInfo)
-        : 0UL;
-    char* stringBuffer = stringMemory.data;
-    if (nbytes == 0 && (!lastCacheSize || allowRollback)) { // read nothing, if no cached data or allow rollback the
-        // reader's state cannot be changed
-        return;
-    }
-    if (lastCacheSize) {
-        memcpy(stringBuffer, mCache.data(), lastCacheSize); // copy from cache
-        nbytes += lastCacheSize;
-    }
-    // Ignore \n if last is force read
-    if (stringBuffer[0] == '\n' && mLastForceRead) {
-        ++stringBuffer;
-        ++mLastFilePos;
-        logBuffer.readOffset = mLastFilePos;
-        --nbytes;
-    }
-    const size_t stringBufferLen = nbytes;
-    logBuffer.truncateInfo.reset(truncateInfo);
-    lastReadPos = mLastFilePos + nbytes; // this doesn't seem right when ulogfs is used and a hole is skipped
-    LOG_DEBUG(sLogger, ("read bytes", nbytes)("last read pos", lastReadPos));
-    moreData = (nbytes == BUFFER_SIZE);
-    auto alignedBytes = nbytes;
-    if (allowRollback) {
-        alignedBytes = AlignLastCharacter(stringBuffer, nbytes);
-    }
-    if (allowRollback || mReaderConfig.second->RequiringJsonReader()) {
-        int32_t rollbackLineFeedCount;
-        nbytes = LastMatchedLine(stringBuffer, alignedBytes, rollbackLineFeedCount, allowRollback);
-    }
+    char* stringBuffer = nullptr;
+    size_t nbytes = 0;
 
-    if (nbytes == 0) {
-        if (moreData) { // excessively long line without '\n' or multiline begin or valid wchar
-            nbytes = alignedBytes ? alignedBytes : BUFFER_SIZE;
-            if (mReaderConfig.second->RequiringJsonReader()) {
-                int32_t rollbackLineFeedCount;
-                nbytes = LastMatchedLine(stringBuffer, nbytes, rollbackLineFeedCount, false);
-            }
-            LOG_WARNING(
-                sLogger,
-                ("Log is too long and forced to be split at offset: ", mLastFilePos + nbytes)("file: ", mHostLogPath)(
-                    "inode: ", mDevInode.inode)("first 1024B log: ", logBuffer.rawBuffer.substr(0, 1024)));
-            std::ostringstream oss;
-            oss << "Log is too long and forced to be split at offset: " << ToString(mLastFilePos + nbytes)
-                << " file: " << mHostLogPath << " inode: " << ToString(mDevInode.inode)
-                << " first 1024B log: " << logBuffer.rawBuffer.substr(0, 1024) << std::endl;
-            LogtailAlarm::GetInstance()->SendAlarm(
-                SPLIT_LOG_FAIL_ALARM, oss.str(), GetProject(), GetLogstore(), GetRegion());
-        } else {
-            // line is not finished yet nor more data, put all data in cache
-            mCache.assign(stringBuffer, stringBufferLen);
+    logBuffer.readOffset = mLastFilePos;
+    if (!mLogFileOp.IsOpen()) {
+        // read flush timeout
+        nbytes = mCache.size();
+        StringBuffer stringMemory = logBuffer.AllocateStringBuffer(nbytes);
+        stringBuffer = stringMemory.data;
+        memcpy(stringBuffer, mCache.data(), nbytes);
+        // Ignore \n if last is force read
+        if (stringBuffer[0] == '\n' && mLastForceRead) {
+            ++stringBuffer;
+            ++mLastFilePos;
+            logBuffer.readOffset = mLastFilePos;
+            --nbytes;
+        }
+        mCache.clear();
+        moreData = false;
+    } else {
+        bool fromCpt = false;
+        size_t READ_BYTE = getNextReadSize(end, fromCpt);
+        if (!READ_BYTE) {
             return;
         }
+        const size_t lastCacheSize = mCache.size();
+        if (READ_BYTE < lastCacheSize) {
+            READ_BYTE = lastCacheSize; // this should not happen, just avoid READ_BYTE >= 0 theoratically
+        }
+        StringBuffer stringMemory = logBuffer.AllocateStringBuffer(READ_BYTE); // allocate modifiable buffer
+        if (lastCacheSize) {
+            READ_BYTE -= lastCacheSize; // reserve space to copy from cache if needed
+        }
+        TruncateInfo* truncateInfo = nullptr;
+        int64_t lastReadPos = GetLastReadPos();
+        nbytes = READ_BYTE
+            ? ReadFile(mLogFileOp, stringMemory.data + lastCacheSize, READ_BYTE, lastReadPos, &truncateInfo)
+            : 0UL;
+        stringBuffer = stringMemory.data;
+        if (nbytes == 0 && (!lastCacheSize || allowRollback)) { // read nothing, if no cached data or allow rollback the
+            // reader's state cannot be changed
+            return;
+        }
+        if (lastCacheSize) {
+            memcpy(stringBuffer, mCache.data(), lastCacheSize); // copy from cache
+            nbytes += lastCacheSize;
+        }
+        // Ignore \n if last is force read
+        if (stringBuffer[0] == '\n' && mLastForceRead) {
+            ++stringBuffer;
+            ++mLastFilePos;
+            logBuffer.readOffset = mLastFilePos;
+            --nbytes;
+        }
+        const size_t stringBufferLen = nbytes;
+        logBuffer.truncateInfo.reset(truncateInfo);
+        lastReadPos = mLastFilePos + nbytes; // this doesn't seem right when ulogfs is used and a hole is skipped
+        LOG_DEBUG(sLogger, ("read bytes", nbytes)("last read pos", lastReadPos));
+        moreData = (nbytes == BUFFER_SIZE);
+        auto alignedBytes = nbytes;
+        if (allowRollback) {
+            alignedBytes = AlignLastCharacter(stringBuffer, nbytes);
+        }
+        if (allowRollback || mReaderConfig.second->RequiringJsonReader()) {
+            int32_t rollbackLineFeedCount;
+            nbytes = LastMatchedLine(stringBuffer, alignedBytes, rollbackLineFeedCount, allowRollback);
+        }
+
+        if (nbytes == 0) {
+            if (moreData) { // excessively long line without '\n' or multiline begin or valid wchar
+                nbytes = alignedBytes ? alignedBytes : BUFFER_SIZE;
+                if (mReaderConfig.second->RequiringJsonReader()) {
+                    int32_t rollbackLineFeedCount;
+                    nbytes = LastMatchedLine(stringBuffer, nbytes, rollbackLineFeedCount, false);
+                }
+                LOG_WARNING(sLogger,
+                            ("Log is too long and forced to be split at offset: ",
+                             mLastFilePos + nbytes)("file: ", mHostLogPath)("inode: ", mDevInode.inode)(
+                                "first 1024B log: ", logBuffer.rawBuffer.substr(0, 1024)));
+                std::ostringstream oss;
+                oss << "Log is too long and forced to be split at offset: " << ToString(mLastFilePos + nbytes)
+                    << " file: " << mHostLogPath << " inode: " << ToString(mDevInode.inode)
+                    << " first 1024B log: " << logBuffer.rawBuffer.substr(0, 1024) << std::endl;
+                LogtailAlarm::GetInstance()->SendAlarm(
+                    SPLIT_LOG_FAIL_ALARM, oss.str(), GetProject(), GetLogstore(), GetRegion());
+            } else {
+                // line is not finished yet nor more data, put all data in cache
+                mCache.assign(stringBuffer, stringBufferLen);
+                return;
+            }
+        }
+        if (nbytes < stringBufferLen) {
+            // rollback happend, put rollbacked part in cache
+            mCache.assign(stringBuffer + nbytes, stringBufferLen - nbytes);
+        } else {
+            mCache.clear();
+        }
+        if (!moreData && fromCpt && lastReadPos < end) {
+            moreData = true;
+        }
     }
-    if (nbytes < stringBufferLen) {
-        // rollback happend, put rollbacked part in cache
-        mCache.assign(stringBuffer + nbytes, stringBufferLen - nbytes);
-    } else {
-        mCache.clear();
-    }
+
     // cache is sealed, nbytes should no change any more
     size_t stringLen = nbytes;
     if (stringBuffer[stringLen - 1] == '\n'
@@ -1720,9 +1744,6 @@ void LogFileReader::ReadUTF8(LogBuffer& logBuffer, int64_t end, bool& moreData, 
     }
     stringBuffer[stringLen] = '\0';
 
-    if (!moreData && fromCpt && lastReadPos < end) {
-        moreData = true;
-    }
     logBuffer.rawBuffer = StringView(stringBuffer, stringLen); // set readable buffer
     logBuffer.readLength = nbytes;
     setExactlyOnceCheckpointAfterRead(nbytes);
@@ -1733,56 +1754,75 @@ void LogFileReader::ReadUTF8(LogBuffer& logBuffer, int64_t end, bool& moreData, 
 }
 
 void LogFileReader::ReadGBK(LogBuffer& logBuffer, int64_t end, bool& moreData, bool allowRollback) {
+    char* gbkBuffer = nullptr;
+    size_t readCharCount = 0, originReadCount = 0;
+    int64_t lastReadPos = 0;
+    bool logTooLongSplitFlag = false, fromCpt = false;
+
     logBuffer.readOffset = mLastFilePos;
-    bool fromCpt = false;
-    size_t READ_BYTE = getNextReadSize(end, fromCpt);
-    const size_t lastCacheSize = mCache.size();
-    if (READ_BYTE < lastCacheSize) {
-        READ_BYTE = lastCacheSize; // this should not happen, just avoid READ_BYTE >= 0 theoratically
-    }
-    std::unique_ptr<char[]> gbkMemory(new char[READ_BYTE + 1]);
-    char* gbkBuffer = gbkMemory.get();
-    if (lastCacheSize) {
-        READ_BYTE -= lastCacheSize; // reserve space to copy from cache if needed
-    }
-    TruncateInfo* truncateInfo = nullptr;
-    int64_t lastReadPos = GetLastReadPos();
-    size_t readCharCount
-        = READ_BYTE ? ReadFile(mLogFileOp, gbkBuffer + lastCacheSize, READ_BYTE, lastReadPos, &truncateInfo) : 0UL;
-    if (readCharCount == 0 && (!lastCacheSize || allowRollback)) { // just keep last cache
-        return;
-    }
-    if (lastCacheSize) {
-        memcpy(gbkBuffer, mCache.data(), lastCacheSize); // copy from cache
-        readCharCount += lastCacheSize;
-    }
-    // Ignore \n if last is force read
-    if (gbkBuffer[0] == '\n' && mLastForceRead) {
-        ++gbkBuffer;
-        --readCharCount;
-        ++mLastFilePos;
-        logBuffer.readOffset = mLastFilePos;
-    }
-    logBuffer.truncateInfo.reset(truncateInfo);
-    lastReadPos = mLastFilePos + readCharCount;
-    const size_t originReadCount = readCharCount;
-    moreData = (readCharCount == BUFFER_SIZE);
-    bool logTooLongSplitFlag = false;
-    auto alignedBytes = readCharCount;
-    if (allowRollback) {
-        alignedBytes = AlignLastCharacter(gbkBuffer, readCharCount);
-    }
-    if (alignedBytes == 0) {
-        if (moreData) { // excessively long line without valid wchar
-            logTooLongSplitFlag = true;
-            alignedBytes = BUFFER_SIZE;
-        } else {
-            // line is not finished yet nor more data, put all data in cache
-            mCache.assign(gbkBuffer, originReadCount);
+    if (!mLogFileOp.IsOpen()) {
+        // read flush timeout
+        readCharCount = mCache.size();
+        memcpy(gbkBuffer, mCache.data(), readCharCount);
+        // Ignore \n if last is force read
+        if (gbkBuffer[0] == '\n' && mLastForceRead) {
+            ++gbkBuffer;
+            ++mLastFilePos;
+            logBuffer.readOffset = mLastFilePos;
+            --readCharCount;
+        }
+        lastReadPos = mLastFilePos + readCharCount;
+        originReadCount = readCharCount;
+        moreData = false;
+    } else {
+        size_t READ_BYTE = getNextReadSize(end, fromCpt);
+        const size_t lastCacheSize = mCache.size();
+        if (READ_BYTE < lastCacheSize) {
+            READ_BYTE = lastCacheSize; // this should not happen, just avoid READ_BYTE >= 0 theoratically
+        }
+        std::unique_ptr<char[]> gbkMemory(new char[READ_BYTE + 1]);
+        gbkBuffer = gbkMemory.get();
+        if (lastCacheSize) {
+            READ_BYTE -= lastCacheSize; // reserve space to copy from cache if needed
+        }
+        TruncateInfo* truncateInfo = nullptr;
+        lastReadPos = GetLastReadPos();
+        readCharCount
+            = READ_BYTE ? ReadFile(mLogFileOp, gbkBuffer + lastCacheSize, READ_BYTE, lastReadPos, &truncateInfo) : 0UL;
+        if (readCharCount == 0 && (!lastCacheSize || allowRollback)) { // just keep last cache
             return;
         }
+        if (lastCacheSize) {
+            memcpy(gbkBuffer, mCache.data(), lastCacheSize); // copy from cache
+            readCharCount += lastCacheSize;
+        }
+        // Ignore \n if last is force read
+        if (gbkBuffer[0] == '\n' && mLastForceRead) {
+            ++gbkBuffer;
+            --readCharCount;
+            ++mLastFilePos;
+            logBuffer.readOffset = mLastFilePos;
+        }
+        logBuffer.truncateInfo.reset(truncateInfo);
+        lastReadPos = mLastFilePos + readCharCount;
+        originReadCount = readCharCount;
+        moreData = (readCharCount == BUFFER_SIZE);
+        auto alignedBytes = readCharCount;
+        if (allowRollback) {
+            alignedBytes = AlignLastCharacter(gbkBuffer, readCharCount);
+        }
+        if (alignedBytes == 0) {
+            if (moreData) { // excessively long line without valid wchar
+                logTooLongSplitFlag = true;
+                alignedBytes = BUFFER_SIZE;
+            } else {
+                // line is not finished yet nor more data, put all data in cache
+                mCache.assign(gbkBuffer, originReadCount);
+                return;
+            }
+        }
+        readCharCount = alignedBytes;
     }
-    readCharCount = alignedBytes;
     gbkBuffer[readCharCount] = '\0';
 
     vector<long> lineFeedPos = {-1}; // elements point to the last char of each line
@@ -1850,7 +1890,7 @@ void LogFileReader::ReadGBK(LogBuffer& logBuffer, int64_t end, bool& moreData, b
         --stringLen;
     }
     stringBuffer[stringLen] = '\0';
-    if (!moreData && fromCpt && lastReadPos < end) {
+    if (mLogFileOp.IsOpen() && !moreData && fromCpt && lastReadPos < end) {
         moreData = true;
     }
     logBuffer.rawBuffer = StringView(stringBuffer, stringLen);

--- a/test/case/behavior/reader_deleted/ilogtail-e2e.yaml
+++ b/test/case/behavior/reader_deleted/ilogtail-e2e.yaml
@@ -23,7 +23,7 @@ ilogtail:
             - Type: input_file
               FilePaths: 
                 - /root/test/simple.log
-              FlushTimeoutSecs: 10000
+              FlushTimeoutSecs: 3
           flushers:
             - Type: flusher_stdout
               OnlyStdout: false

--- a/test/case/behavior/reader_deleted/run.sh
+++ b/test/case/behavior/reader_deleted/run.sh
@@ -15,5 +15,6 @@
 # limitations under the License.
 sleep 5
 echo -n "5=====" >> /root/volume/simple.log
-sleep 3
+sleep 1
 rm /root/volume/simple.log
+sleep 3

--- a/test/case/behavior/reader_log_rotate/ilogtail-e2e.yaml
+++ b/test/case/behavior/reader_log_rotate/ilogtail-e2e.yaml
@@ -23,7 +23,7 @@ ilogtail:
             - Type: input_file
               FilePaths: 
                 - /root/test/simple.log
-              FlushTimeoutSecs: 10000
+              FlushTimeoutSecs: 2
           flushers:
             - Type: flusher_stdout
               OnlyStdout: false

--- a/test/case/behavior/reader_log_rotate/run.sh
+++ b/test/case/behavior/reader_log_rotate/run.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 sleep 5
 echo -n "5=====" >> /root/volume/simple.log
-sleep 3
+sleep 1
 mv /root/volume/simple.log /root/volume/simple.log.1
 echo "6=====" >> /root/volume/simple.log
+sleep 3


### PR DESCRIPTION
- 问题：
reader队列只有一个reader的时候，如果delete flag为true且已经读到尾巴了，会强制将最后不完整的日志发送出去。因为delete flag只是个hint，所以可能导致日志被截断。
- 修复：
对于上述情况，等待超时事件发生才flush。