### PR TITLE
[backport] fix dockershim cause containerd invalid

### DIFF
--- a/pkg/helper/docker_cri_adapter.go
+++ b/pkg/helper/docker_cri_adapter.go
@@ -46,9 +46,7 @@ const (
 	maxMsgSize            = 1024 * 1024 * 16
 )
 
-var (
-	containerdUnixSocket  = "/run/containerd/containerd.sock"
-)
+var containerdUnixSocket = "/run/containerd/containerd.sock"
 
 var criRuntimeWrapper *CRIRuntimeWrapper
 

--- a/pkg/helper/docker_cri_adapter.go
+++ b/pkg/helper/docker_cri_adapter.go
@@ -48,8 +48,6 @@ const (
 
 var (
 	containerdUnixSocket  = "/run/containerd/containerd.sock"
-	dockerShimUnixSocket1 = "/var/run/dockershim.sock"
-	dockerShimUnixSocket2 = "/run/dockershim.sock"
 )
 
 var criRuntimeWrapper *CRIRuntimeWrapper

--- a/pkg/helper/docker_cri_adapter.go
+++ b/pkg/helper/docker_cri_adapter.go
@@ -84,14 +84,6 @@ func IsCRIRuntimeValid(criRuntimeEndpoint string) bool {
 		return true
 	}
 
-	// Verify dockershim.sock existence.
-	for _, sock := range []string{dockerShimUnixSocket1, dockerShimUnixSocket2} {
-		if fi, err := os.Stat(sock); err == nil && !fi.IsDir() {
-			// Having dockershim.sock means k8s + docker cri
-			return false
-		}
-	}
-
 	// Verify containerd.sock cri valid.
 	if fi, err := os.Stat(criRuntimeEndpoint); err == nil && !fi.IsDir() {
 		if IsCRIStatusValid(criRuntimeEndpoint) {


### PR DESCRIPTION
Docker and containerd may co-exist in some cases. So if dockershim.sock exist, the CRI runtime may still valid.