### PR TITLE
fix: make LOGTAIL_LOG_LEVEL env variable effective for ilogtail.LOG

### DIFF
--- a/core/logger/Logger.cpp
+++ b/core/logger/Logger.cpp
@@ -322,11 +322,12 @@ void Logger::LoadConfig(const std::string& filePath) {
         }
 
         spdlog::register_logger(logger);
-        logger->set_level(loggerCfg.level);
         logger->set_pattern(DEFAULT_PATTERN);
         if (name == "/apsara/sls/ilogtail" && !aliyun_logtail_log_level.empty()) {
+            logger->set_level(envLogLevel);
             logger->flush_on(envLogLevel);
         } else {
+            logger->set_level(loggerCfg.level);
             logger->flush_on(loggerCfg.level);
         }
         LogMsg(std::string("logger named ") + name + " created.");


### PR DESCRIPTION
https://github.com/alibaba/ilogtail/pull/1096/files introduced a feature to adjust log level easily through env variable. This fix ensures that the log level for ilogtail.LOG is now properly set in accordance with the LOGTAIL_LOG_LEVEL value.