### PR TITLE
fix: Ensure alarms raised during collection for profile projects are reported

### DIFF
--- a/core/application/Application.cpp
+++ b/core/application/Application.cpp
@@ -210,6 +210,9 @@ void Application::Start() {
     CommonConfigProvider::GetInstance()->Init("common");
 #endif
 
+    LogtailAlarm::GetInstance()->Init();
+    LogtailMonitor::GetInstance()->Init();
+
     PluginRegistry::GetInstance()->LoadPlugins();
 
 #if defined(__ENTERPRISE__) && defined(__linux__) && !defined(__ANDROID__)

--- a/core/application/Application.cpp
+++ b/core/application/Application.cpp
@@ -188,9 +188,6 @@ void Application::Start() {
     // flusher_sls should always be loaded, since profiling will rely on this.
     Sender::Instance()->Init();
 
-    LogtailAlarm::GetInstance()->Init();
-    LogtailMonitor::GetInstance()->Init();
-
     // add local config dir
     filesystem::path localConfigPath
         = filesystem::path(AppConfig::GetInstance()->GetLogtailSysConfDir()) / "config" / "local";

--- a/core/monitor/LogtailAlarm.cpp
+++ b/core/monitor/LogtailAlarm.cpp
@@ -294,7 +294,7 @@ void LogtailAlarm::SendAlarm(const LogtailAlarmType alarmType,
         return;
     }
 
-    // ignore logtail self alarm
+    // ignore alarm for profile data
     if (Sender::IsProfileData(region, projectName, category)) {
         return;
     }

--- a/core/monitor/LogtailAlarm.cpp
+++ b/core/monitor/LogtailAlarm.cpp
@@ -295,8 +295,7 @@ void LogtailAlarm::SendAlarm(const LogtailAlarmType alarmType,
     }
 
     // ignore logtail self alarm
-    string profileProject = ProfileSender::GetInstance()->GetProfileProjectName(region);
-    if (!profileProject.empty() && profileProject == projectName) {
+    if (Sender::IsProfileData(region, projectName, category)) {
         return;
     }
     // LOG_DEBUG(sLogger, ("Add Alarm", region)("projectName", projectName)("alarm index",

--- a/core/sender/Sender.h
+++ b/core/sender/Sender.h
@@ -353,7 +353,6 @@ private:
     void CleanTimeoutSendStatistic();
 
     // bool CheckBatchMapFull(int64_t key);
-    static bool IsProfileData(const std::string& region, const std::string& project, const std::string& logstore);
 
     std::string GetRegionCurrentEndpoint(const std::string& region);
     std::string GetRegionFromEndpoint(const std::string& endpoint);
@@ -362,6 +361,7 @@ private:
 
 public:
     static Sender* Instance();
+    static bool IsProfileData(const std::string& region, const std::string& project, const std::string& logstore);
     // void ResetProfileSender();
     bool Init(); // Backward compatible
     // from collector to batchmap


### PR DESCRIPTION
Alarms generated by the collector during the data collection process for profile 
projects were previously not reported due to a rule designed to prevent circular 
reporting of alarms. This rule intended to avoid alarms raised as a result 
of attempting to send alarms to the profile project. However, it inadvertently 
blocked genuine alarms that occurred during the direct collection to the profile 
project itself. This fix adjusts the rule to differentiate between circular 
alarms and legitimate collection errors, allowing the latter to be reported 
as expected.