### PR TITLE
fix: normalize logpath to avoid crash during handler registration

### DIFF
--- a/core/common/FileSystemUtil.cpp
+++ b/core/common/FileSystemUtil.cpp
@@ -87,11 +87,19 @@ std::string AbsolutePath(const std::string& path, const std::string& basepath) {
 }
 
 std::string NormalizePath(const std::string& path) {
+    // for boost, if path ends with slash, then lexically_normal() will return /.
+    // otherwise, lexically_normal() returns without slash
     boost::filesystem::path abs(path);
-    if (abs.filename_is_dot() || abs.filename_is_dot_dot()) {
-        abs.remove_filename();
+    string res = abs.lexically_normal().string();
+    size_t len = res.size();
+    if (len >= 2 && res[len - 2] == PATH_SEPARATOR[0] && res[len - 1] == '.') {
+        if (len == 2) {
+            res.resize(1);
+        } else {
+            res.resize(len - 2);
+        }
     }
-    return abs.string();
+    return res;
 }
 
 int FSeek(FILE* stream, int64_t offset, int origin) {

--- a/core/config_manager/ConfigManagerBase.cpp
+++ b/core/config_manager/ConfigManagerBase.cpp
@@ -598,8 +598,9 @@ void ConfigManagerBase::LoadSingleUserConfig(const std::string& logName, const J
                         logPath = tmpLogPath;
                 }
                 if (IsRelativePath(logPath)) {
-                    logPath = NormalizePath(AbsolutePath(logPath, AppConfig::GetInstance()->GetProcessExecutionDir()));
+                    logPath = AbsolutePath(logPath, AppConfig::GetInstance()->GetProcessExecutionDir());
                 }
+                logPath = NormalizePath(logPath);
 
                 // one may still make mistakes, teminate logPath by '/'
                 size_t size = logPath.size();

--- a/core/unittest/common/FileSystemUtilUnittest.h
+++ b/core/unittest/common/FileSystemUtilUnittest.h
@@ -451,4 +451,42 @@ TEST_F(FileSystemUtilUnittest, TestGetFdPath) {
     fclose(file);
 }
 
+TEST_F(FileSystemUtilUnittest, TestNormalizePath) {
+    std::string path;
+
+    path = "/";
+    EXPECT_STREQ(NormalizePath(path).c_str(), "/");
+
+    path = "/.";
+    EXPECT_STREQ(NormalizePath(path).c_str(), "/");
+
+    path = "/a";
+    EXPECT_STREQ(NormalizePath(path).c_str(), "/a");
+
+    path = "/a/";
+    EXPECT_STREQ(NormalizePath(path).c_str(), "/a");
+
+    path = "/a/.";
+    EXPECT_STREQ(NormalizePath(path).c_str(), "/a");
+
+    path = "/a/./";
+    EXPECT_STREQ(NormalizePath(path).c_str(), "/a");
+
+    path = "/a/..";
+    EXPECT_STREQ(NormalizePath(path).c_str(), "/");
+
+    path = "/a/../";
+    EXPECT_STREQ(NormalizePath(path).c_str(), "/");
+
+    // '//x' is considered root name in windows
+    path = "//a//**//b*//c?";
+    EXPECT_STREQ(NormalizePath(path).c_str(), "//a/**/b*/c?");
+
+    path = ".";
+    EXPECT_STREQ(NormalizePath(path).c_str(), ".");
+
+    path = "./";
+    EXPECT_STREQ(NormalizePath(path).c_str(), ".");
+}
+
 } // namespace logtail


### PR DESCRIPTION
The precondition of ConfigManagerBase::RegisterWildcardPath is that the input path is normalized. Otherwise the index out of range may raise at runtime.