### PR TITLE
refactory: enable move for SourceBuffer

### DIFF
--- a/core/common/CMakeLists.txt
+++ b/core/common/CMakeLists.txt
@@ -16,6 +16,7 @@ cmake_minimum_required(VERSION 3.22)
 project(common)
 
 file(GLOB LIB_SOURCE_FILES *.cpp *.h)
+list(APPEND LIB_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/memory/SourceBuffer.h)
 list(REMOVE_ITEM LIB_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/BoostRegexValidator.cpp)
 list(REMOVE_ITEM LIB_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/GetUUID.cpp)
 if (MSVC)

--- a/core/common/EncodingConverter.h
+++ b/core/common/EncodingConverter.h
@@ -20,7 +20,7 @@
 #include <vector>
 #include <string>
 #include <cstddef>
-#include "reader/SourceBuffer.h"
+#include "common/memory/SourceBuffer.h"
 
 namespace logtail {
 enum FileEncoding { ENCODING_UTF8, ENCODING_GBK };

--- a/core/common/memory/SourceBuffer.h
+++ b/core/common/memory/SourceBuffer.h
@@ -41,12 +41,12 @@ private:
 // only movable
 class BufferAllocator {
 private:
-    static const int32_t kAlignSize = sizeof(void*);
-    static const int32_t kPageSize = 4096; // in bytes
+    static const uint32_t kAlignSize = sizeof(void*);
+    static const uint32_t kPageSize = 4096; // in bytes
 
 public:
-    explicit BufferAllocator(int32_t firstChunkSize = 4096, int32_t chunkSizeLimit = 1024 * 128)
-        : mFirstChunkSize(firstChunkSize), mChunkSize(firstChunkSize), mChunkSizeLimit(chunkSizeLimit) {
+    explicit BufferAllocator(uint32_t firstChunkSize = 4096, uint32_t chunkSizeLimit = 1024 * 128)
+        : mFirstChunkSize(firstChunkSize), mChunkSizeLimit(chunkSizeLimit), mChunkSize(firstChunkSize) {
         mAllocPtr = new uint8_t[mChunkSize];
         mAllocatedChunks.push_back(mAllocPtr);
         mFreeBytesInChunk = mChunkSize;
@@ -77,7 +77,7 @@ public:
         mUsed = 0;
     }
 
-    void* Allocate(int32_t bytes) {
+    void* Allocate(uint32_t bytes) {
         // Align the alloc size
         int32_t aligned = (bytes + kAlignSize - 1) & ~(kAlignSize - 1);
         return Alloc(aligned);
@@ -92,7 +92,7 @@ public:
 private:
     // Please do not make it public, user should always use Allocate() to get a better performance.
     // If you have a strong reason to do it, please drop a email to me: shiquan.yangsq@aliyun-inc.com
-    uint8_t* Alloc(int32_t bytes) {
+    uint8_t* Alloc(uint32_t bytes) {
         uint8_t* mem = NULL;
 
         if (bytes <= mFreeBytesInChunk) {

--- a/core/models/PipelineEvent.h
+++ b/core/models/PipelineEvent.h
@@ -25,7 +25,7 @@
 #include <string>
 
 #include "models/StringView.h"
-#include "reader/SourceBuffer.h"
+#include "common/memory/SourceBuffer.h"
 
 namespace logtail {
 

--- a/core/models/PipelineEventGroup.h
+++ b/core/models/PipelineEventGroup.h
@@ -21,7 +21,7 @@
 
 #include "common/Constants.h"
 #include "models/PipelineEventPtr.h"
-#include "reader/SourceBuffer.h"
+#include "common/memory/SourceBuffer.h"
 
 namespace logtail {
 

--- a/core/monitor/LogIntegrity.h
+++ b/core/monitor/LogIntegrity.h
@@ -23,7 +23,6 @@
 
 namespace logtail {
 // forward declaration
-struct LogBuffer;
 struct LoggroupTimeValue;
 struct MergeItem;
 

--- a/core/processor/daemon/LogProcess.cpp
+++ b/core/processor/daemon/LogProcess.cpp
@@ -456,7 +456,7 @@ int LogProcess::ProcessBuffer(std::shared_ptr<LogBuffer>& logBuffer,
     std::vector<PipelineEventGroup> eventGroupList;
     {
         // construct a logGroup, it should be moved into input later
-        PipelineEventGroup eventGroup{std::shared_ptr<SourceBuffer>(logBuffer->sourcebuffer)};
+        PipelineEventGroup eventGroup{std::shared_ptr<SourceBuffer>(std::move(logBuffer->sourcebuffer))};
         // TODO: metadata should be set in reader
         FillEventGroupMetadata(*logBuffer, eventGroup);
 

--- a/core/processor/daemon/LogProcess.cpp
+++ b/core/processor/daemon/LogProcess.cpp
@@ -456,7 +456,7 @@ int LogProcess::ProcessBuffer(std::shared_ptr<LogBuffer>& logBuffer,
     std::vector<PipelineEventGroup> eventGroupList;
     {
         // construct a logGroup, it should be moved into input later
-        PipelineEventGroup eventGroup(logBuffer);
+        PipelineEventGroup eventGroup{std::shared_ptr<SourceBuffer>(logBuffer->sourcebuffer)};
         // TODO: metadata should be set in reader
         FillEventGroupMetadata(*logBuffer, eventGroup);
 

--- a/core/reader/LogFileReader.cpp
+++ b/core/reader/LogFileReader.cpp
@@ -1640,7 +1640,7 @@ void LogFileReader::ReadUTF8(LogBuffer& logBuffer, int64_t end, bool& moreData, 
     if (!mLogFileOp.IsOpen()) {
         // read flush timeout
         nbytes = mCache.size();
-        StringBuffer stringMemory = logBuffer.AllocateStringBuffer(nbytes);
+        StringBuffer stringMemory = logBuffer.sourcebuffer->AllocateStringBuffer(nbytes);
         stringBuffer = stringMemory.data;
         memcpy(stringBuffer, mCache.data(), nbytes);
         // Ignore \n if last is force read
@@ -1662,7 +1662,7 @@ void LogFileReader::ReadUTF8(LogBuffer& logBuffer, int64_t end, bool& moreData, 
         if (READ_BYTE < lastCacheSize) {
             READ_BYTE = lastCacheSize; // this should not happen, just avoid READ_BYTE >= 0 theoratically
         }
-        StringBuffer stringMemory = logBuffer.AllocateStringBuffer(READ_BYTE); // allocate modifiable buffer
+        StringBuffer stringMemory = logBuffer.sourcebuffer->AllocateStringBuffer(READ_BYTE); // allocate modifiable buffer
         if (lastCacheSize) {
             READ_BYTE -= lastCacheSize; // reserve space to copy from cache if needed
         }
@@ -1838,7 +1838,7 @@ void LogFileReader::ReadGBK(LogBuffer& logBuffer, int64_t end, bool& moreData, b
     size_t srcLength = readCharCount;
     size_t requiredLen
         = EncodingConverter::GetInstance()->ConvertGbk2Utf8(gbkBuffer, &srcLength, nullptr, 0, lineFeedPos);
-    StringBuffer stringMemory = logBuffer.AllocateStringBuffer(requiredLen + 1);
+    StringBuffer stringMemory = logBuffer.sourcebuffer->AllocateStringBuffer(requiredLen + 1);
     size_t resultCharCount = EncodingConverter::GetInstance()->ConvertGbk2Utf8(
         gbkBuffer, &srcLength, stringMemory.data, stringMemory.capacity, lineFeedPos);
     char* stringBuffer = stringMemory.data; // utf8 buffer

--- a/core/reader/LogFileReader.h
+++ b/core/reader/LogFileReader.h
@@ -30,13 +30,13 @@
 #include "common/LogFileOperator.h"
 #include "common/StringTools.h"
 #include "common/TimeUtil.h"
+#include "common/memory/SourceBuffer.h"
 #include "event/Event.h"
 #include "file_server/FileDiscoveryOptions.h"
 #include "file_server/MultilineOptions.h"
 #include "log_pb/sls_logs.pb.h"
 #include "logger/Logger.h"
 #include "reader/FileReaderOptions.h"
-#include "reader/SourceBuffer.h"
 
 namespace logtail {
 
@@ -597,7 +597,7 @@ protected:
 #endif
 };
 
-struct LogBuffer : public SourceBuffer {
+struct LogBuffer {
     StringView rawBuffer;
     LogFileReaderPtr logFileReader;
     FileInfoPtr fileInfo;
@@ -607,9 +607,9 @@ struct LogBuffer : public SourceBuffer {
     // Current buffer's offset in file, for log position meta feature.
     uint64_t readOffset = 0;
     uint64_t readLength = 0;
+    SourceBuffer* sourcebuffer = nullptr;
 
-    LogBuffer() {}
-    void SetDependecy(const LogFileReaderPtr& reader) { logFileReader = reader; }
+    LogBuffer() : sourcebuffer(new SourceBuffer()) {}
 };
 
 } // namespace logtail

--- a/core/reader/LogFileReader.h
+++ b/core/reader/LogFileReader.h
@@ -610,6 +610,7 @@ struct LogBuffer {
     SourceBuffer* sourcebuffer = nullptr;
 
     LogBuffer() : sourcebuffer(new SourceBuffer()) {}
+    void SetDependecy(const LogFileReaderPtr& reader) { logFileReader = reader; }
 };
 
 } // namespace logtail

--- a/core/reader/LogFileReader.h
+++ b/core/reader/LogFileReader.h
@@ -607,7 +607,7 @@ struct LogBuffer {
     // Current buffer's offset in file, for log position meta feature.
     uint64_t readOffset = 0;
     uint64_t readLength = 0;
-    SourceBuffer* sourcebuffer = nullptr;
+    std::unique_ptr<SourceBuffer> sourcebuffer;
 
     LogBuffer() : sourcebuffer(new SourceBuffer()) {}
     void SetDependecy(const LogFileReaderPtr& reader) { logFileReader = reader; }

--- a/core/unittest/reader/LogFileReaderUnittest.cpp
+++ b/core/unittest/reader/LogFileReaderUnittest.cpp
@@ -17,7 +17,7 @@
 #include <fstream>
 #include "checkpoint/CheckPointManager.h"
 #include "reader/LogFileReader.h"
-#include "reader/SourceBuffer.h"
+#include "common/memory/SourceBuffer.h"
 #include "common/RuntimeUtil.h"
 #include "common/FileSystemUtil.h"
 #include "log_pb/sls_logs.pb.h"

--- a/core/unittest/reader/RemoveLastIncompleteLogUnittest.cpp
+++ b/core/unittest/reader/RemoveLastIncompleteLogUnittest.cpp
@@ -14,7 +14,7 @@
 
 #include "common/FileSystemUtil.h"
 #include "reader/LogFileReader.h"
-#include "reader/SourceBuffer.h"
+#include "common/memory/SourceBuffer.h"
 #include "unittest/Unittest.h"
 
 namespace logtail {


### PR DESCRIPTION
1. 允许SourceBuffer被移动
2. 调整SourceBuffer.h文件位置
3. LogBuffer与SourceBuffer的关系从继承改成组合，主要便于组装PipelineEventGroup（只需要SourceBuffer，不需要LogBuffer）