### PR TITLE
Improved container discovery mechanism for collecting logs from exited containers in a timely manner.

### DIFF
--- a/pkg/helper/docker_center.go
+++ b/pkg/helper/docker_center.go
@@ -1057,12 +1057,14 @@ func (dc *DockerCenter) fetchAll() error {
 			time.Sleep(time.Second * 5)
 		}
 		if err == nil {
-			finishedAt := containerDetail.State.FinishedAt
-			finishedAtTime, _ := time.Parse(time.RFC3339, finishedAt)
-			now := time.Now()
-			duration := now.Sub(finishedAtTime)
-			if !ContainerProcessAlive(containerDetail.State.Pid) && duration >= ContainerInfoDeletedTimeout {
-				continue
+			if !ContainerProcessAlive(containerDetail.State.Pid) {
+				finishedAt := containerDetail.State.FinishedAt
+				finishedAtTime, _ := time.Parse(time.RFC3339, finishedAt)
+				now := time.Now()
+				duration := now.Sub(finishedAtTime)
+				if duration >= ContainerInfoDeletedTimeout {
+					continue
+				}
 			}
 			containerMap[container.ID] = dc.CreateInfoDetail(containerDetail, envConfigPrefix, false)
 		} else {

--- a/pkg/helper/docker_center.go
+++ b/pkg/helper/docker_center.go
@@ -261,8 +261,8 @@ func (did *DockerInfoDetail) PodName() string {
 }
 
 func (did *DockerInfoDetail) FinishedAt() string {
-	if did.K8SInfo != nil {
-		return did.FinishedAt()
+	if did.ContainerInfo.State != nil {
+		return did.ContainerInfo.State.FinishedAt
 	}
 	return ""
 }

--- a/pkg/helper/docker_center.go
+++ b/pkg/helper/docker_center.go
@@ -1058,6 +1058,7 @@ func (dc *DockerCenter) fetchAll() error {
 		}
 		if err == nil {
 			if !ContainerProcessAlive(containerDetail.State.Pid) {
+				containerDetail.State.Status = ContainerStatusExited
 				finishedAt := containerDetail.State.FinishedAt
 				finishedAtTime, _ := time.Parse(time.RFC3339, finishedAt)
 				now := time.Now()

--- a/pkg/helper/docker_cri_adapter.go
+++ b/pkg/helper/docker_cri_adapter.go
@@ -403,12 +403,14 @@ func (cw *CRIRuntimeWrapper) fetchAll() error {
 			logger.Error(context.Background(), "CREATE_CONTAINERD_INFO_ALARM", "Create container info from cri-runtime error, Container Info:%+v", c)
 			continue
 		}
-		finishedAt := dockerContainer.FinishedAt()
-		finishedAtTime, _ := time.Parse(time.RFC3339, finishedAt)
-		now := time.Now()
-		duration := now.Sub(finishedAtTime)
-		if dockerContainer.Status() != ContainerStatusRunning && duration >= ContainerInfoDeletedTimeout {
-			continue
+		if dockerContainer.Status() != ContainerStatusRunning {
+			finishedAt := dockerContainer.FinishedAt()
+			finishedAtTime, _ := time.Parse(time.RFC3339, finishedAt)
+			now := time.Now()
+			duration := now.Sub(finishedAtTime)
+			if duration >= ContainerInfoDeletedTimeout {
+				continue
+			}
 		}
 		cw.containers[c.GetId()] = &innerContainerInfo{
 			State:  c.State,


### PR DESCRIPTION
问题背景：
在当前的容器发现机制中，尽管fetchone流程会暂时保留已经退出的容器信息一定时间（即ContainerInfoDeletedTimeout设定的时长），FetchAll流程却不会包含已经退出的容器，并且FetchAll会按定时计划执行。这种设计可能导致FetchAll提前清除已退出的容器，使得相关容器日志未能被有效采集。

修复措施：
我们对FetchAll流程做了改进，从现在起它会检查容器退出的时间是否没有超过ContainerInfoDeletedTimeout设定的阈值。只要没有超过这个时间限制，即便容器已退出，它仍会被FetchAll加以考虑。此外，我们提升了ContainerInfoDeletedTimeout的值至120秒，这一改进增加了日志采集的完成率和成功性。