### PR TITLE
Fix Go Plugin nanosecond

### DIFF
--- a/pkg/helper/local_collector.go
+++ b/pkg/helper/local_collector.go
@@ -48,7 +48,7 @@ func (p *LocalCollector) AddDataWithContext(tags map[string]string, fields map[s
 	} else {
 		logTime = t[0]
 	}
-	slsLog, _ := CreateLog(logTime, nil, tags, fields)
+	slsLog, _ := CreateLog(logTime, len(t) != 0, nil, tags, fields)
 	p.Logs = append(p.Logs, slsLog)
 }
 
@@ -63,7 +63,7 @@ func (p *LocalCollector) AddDataArrayWithContext(tags map[string]string,
 	} else {
 		logTime = t[0]
 	}
-	slsLog, _ := CreateLogByArray(logTime, nil, tags, columns, values)
+	slsLog, _ := CreateLogByArray(logTime, len(t) != 0, nil, tags, columns, values)
 	p.Logs = append(p.Logs, slsLog)
 }
 

--- a/pkg/helper/local_context.go
+++ b/pkg/helper/local_context.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/alibaba/ilogtail/pkg"
+	"github.com/alibaba/ilogtail/pkg/config"
 	"github.com/alibaba/ilogtail/pkg/logger"
 	"github.com/alibaba/ilogtail/pkg/pipeline"
 	"github.com/alibaba/ilogtail/pkg/protocol"
@@ -47,6 +48,10 @@ func (p *LocalContext) GetProject() string {
 }
 func (p *LocalContext) GetLogstore() string {
 	return p.common.GetLogStore()
+}
+
+func (p *LocalContext) GetGlobalConfig() *config.GlobalConfig {
+	return &config.GlobalConfig{}
 }
 
 func (p *LocalContext) AddPlugin(name string) {

--- a/pkg/helper/local_context.go
+++ b/pkg/helper/local_context.go
@@ -50,7 +50,7 @@ func (p *LocalContext) GetLogstore() string {
 	return p.common.GetLogStore()
 }
 
-func (p *LocalContext) GetGlobalConfig() *config.GlobalConfig {
+func (p *LocalContext) GetPipelineScopeConfig() *config.GlobalConfig {
 	return &config.GlobalConfig{}
 }
 

--- a/pkg/helper/log_helper.go
+++ b/pkg/helper/log_helper.go
@@ -37,7 +37,7 @@ const (
 	SlsMetricstoreInvalidReplaceCharacter        = '_'
 )
 
-func CreateLog(t time.Time, configTag map[string]string, logTags map[string]string, fields map[string]string) (*protocol.Log, error) {
+func CreateLog(t time.Time, enableTimestampNano bool, configTag map[string]string, logTags map[string]string, fields map[string]string) (*protocol.Log, error) {
 	var slsLog protocol.Log
 	slsLog.Contents = make([]*protocol.Log_Content, 0, len(configTag)+len(logTags)+len(fields))
 	for key, val := range configTag {
@@ -63,11 +63,15 @@ func CreateLog(t time.Time, configTag map[string]string, logTags map[string]stri
 		}
 		slsLog.Contents = append(slsLog.Contents, cont)
 	}
-	protocol.SetLogTimeWithNano(&slsLog, uint32(t.Unix()), uint32(t.Nanosecond()))
+	if enableTimestampNano {
+		protocol.SetLogTimeWithNano(&slsLog, uint32(t.Unix()), uint32(t.Nanosecond()))
+	} else {
+		protocol.SetLogTime(&slsLog, uint32(t.Unix()))
+	}
 	return &slsLog, nil
 }
 
-func CreateLogByArray(t time.Time, configTag map[string]string, logTags map[string]string, columns []string, values []string) (*protocol.Log, error) {
+func CreateLogByArray(t time.Time, enableTimestampNano bool, configTag map[string]string, logTags map[string]string, columns []string, values []string) (*protocol.Log, error) {
 	var slsLog protocol.Log
 	slsLog.Contents = make([]*protocol.Log_Content, 0, len(configTag)+len(logTags)+len(columns))
 
@@ -98,7 +102,11 @@ func CreateLogByArray(t time.Time, configTag map[string]string, logTags map[stri
 		}
 		slsLog.Contents = append(slsLog.Contents, cont)
 	}
-	protocol.SetLogTimeWithNano(&slsLog, uint32(t.Unix()), uint32(t.Nanosecond()))
+	if enableTimestampNano {
+		protocol.SetLogTimeWithNano(&slsLog, uint32(t.Unix()), uint32(t.Nanosecond()))
+	} else {
+		protocol.SetLogTime(&slsLog, uint32(t.Unix()))
+	}
 	return &slsLog, nil
 }
 

--- a/pkg/pipeline/context.go
+++ b/pkg/pipeline/context.go
@@ -35,7 +35,7 @@ type Context interface {
 	GetProject() string
 	GetLogstore() string
 	GetRuntimeContext() context.Context
-	GetGlobalConfig() *config.GlobalConfig
+	GetPipelineScopeConfig() *config.GlobalConfig
 	GetExtension(name string, cfg any) (Extension, error)
 	RegisterCounterMetric(metric CounterMetric)
 	RegisterStringMetric(metric StringMetric)

--- a/pkg/pipeline/context.go
+++ b/pkg/pipeline/context.go
@@ -15,6 +15,7 @@
 package pipeline
 
 import (
+	"github.com/alibaba/ilogtail/pkg/config"
 	"github.com/alibaba/ilogtail/pkg/protocol"
 
 	"context"
@@ -34,6 +35,7 @@ type Context interface {
 	GetProject() string
 	GetLogstore() string
 	GetRuntimeContext() context.Context
+	GetGlobalConfig() *config.GlobalConfig
 	GetExtension(name string, cfg any) (Extension, error)
 	RegisterCounterMetric(metric CounterMetric)
 	RegisterStringMetric(metric StringMetric)

--- a/pkg/protocol/converter/converter.go
+++ b/pkg/protocol/converter/converter.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/alibaba/ilogtail/pkg/config"
 	"github.com/alibaba/ilogtail/pkg/flags"
 	"github.com/alibaba/ilogtail/pkg/models"
 	"github.com/alibaba/ilogtail/pkg/protocol"
@@ -127,10 +128,11 @@ type Converter struct {
 	OnlyContents         bool
 	TagKeyRenameMap      map[string]string
 	ProtocolKeyRenameMap map[string]string
+	GlobalConfig         *config.GlobalConfig
 }
 
-func NewConverterWithSep(protocol, encoding, sep string, ignoreUnExpectedData bool, tagKeyRenameMap, protocolKeyRenameMap map[string]string) (*Converter, error) {
-	converter, err := NewConverter(protocol, encoding, tagKeyRenameMap, protocolKeyRenameMap)
+func NewConverterWithSep(protocol, encoding, sep string, ignoreUnExpectedData bool, tagKeyRenameMap, protocolKeyRenameMap map[string]string, globalConfig *config.GlobalConfig) (*Converter, error) {
+	converter, err := NewConverter(protocol, encoding, tagKeyRenameMap, protocolKeyRenameMap, globalConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +141,7 @@ func NewConverterWithSep(protocol, encoding, sep string, ignoreUnExpectedData bo
 	return converter, nil
 }
 
-func NewConverter(protocol, encoding string, tagKeyRenameMap, protocolKeyRenameMap map[string]string) (*Converter, error) {
+func NewConverter(protocol, encoding string, tagKeyRenameMap, protocolKeyRenameMap map[string]string, globalConfig *config.GlobalConfig) (*Converter, error) {
 	enc, ok := supportedEncodingMap[protocol]
 	if !ok {
 		return nil, fmt.Errorf("unsupported protocol: %s", protocol)
@@ -152,6 +154,7 @@ func NewConverter(protocol, encoding string, tagKeyRenameMap, protocolKeyRenameM
 		Encoding:             encoding,
 		TagKeyRenameMap:      tagKeyRenameMap,
 		ProtocolKeyRenameMap: protocolKeyRenameMap,
+		GlobalConfig:         globalConfig,
 	}, nil
 }
 

--- a/pkg/protocol/converter/converter_single_log_flatten_test.go
+++ b/pkg/protocol/converter/converter_single_log_flatten_test.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
+	"github.com/alibaba/ilogtail/pkg/config"
 	"github.com/alibaba/ilogtail/pkg/flags"
 	"github.com/alibaba/ilogtail/pkg/protocol"
 )
@@ -36,7 +37,7 @@ func TestConvertToSimpleFlat(t *testing.T) {
 		protocolKeyRenameMap := map[string]string{
 			"time": "@timestamp",
 		}
-		c, err := NewConverter("custom_single_flatten", "json", keyRenameMap, protocolKeyRenameMap)
+		c, err := NewConverter("custom_single_flatten", "json", keyRenameMap, protocolKeyRenameMap, &config.GlobalConfig{})
 		So(err, ShouldBeNil)
 
 		Convey("When the logGroup is generated from files and from k8s daemonset environment", func() {
@@ -134,7 +135,7 @@ func TestConvertToSimpleFlat(t *testing.T) {
 			"label":       "",
 			"env":         "",
 		}
-		c, err := NewConverter("custom_single_flatten", "json", keyRenameMap, nil)
+		c, err := NewConverter("custom_single_flatten", "json", keyRenameMap, nil, &config.GlobalConfig{})
 		So(err, ShouldBeNil)
 
 		Convey("When the logGroup is generated from files and from k8s daemonset environment", func() {

--- a/pkg/protocol/converter/converter_test.go
+++ b/pkg/protocol/converter/converter_test.go
@@ -19,12 +19,13 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
+	"github.com/alibaba/ilogtail/pkg/config"
 	"github.com/alibaba/ilogtail/pkg/protocol"
 )
 
 func TestInvalidProtocol(t *testing.T) {
 	Convey("When constructing converter with invalid protocol", t, func() {
-		_, err := NewConverter("xml", "pb", nil, nil)
+		_, err := NewConverter("xml", "pb", nil, nil, &config.GlobalConfig{})
 
 		Convey("Then error should be returned", func() {
 			So(err, ShouldNotBeNil)

--- a/pkg/protocol/converter/custom_single_log_test.go
+++ b/pkg/protocol/converter/custom_single_log_test.go
@@ -21,13 +21,14 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
+	"github.com/alibaba/ilogtail/pkg/config"
 	"github.com/alibaba/ilogtail/pkg/flags"
 	"github.com/alibaba/ilogtail/pkg/protocol"
 )
 
 func TestConvertToSimple(t *testing.T) {
 	Convey("Given a converter with protocol: single, encoding: json, with no tag rename or protocol key rename", t, func() {
-		c, err := NewConverter("custom_single", "json", nil, nil)
+		c, err := NewConverter("custom_single", "json", nil, nil, &config.GlobalConfig{})
 		So(err, ShouldBeNil)
 
 		Convey("When the logGroup is generated from files and from host environment", func() {
@@ -590,7 +591,7 @@ func TestConvertToSimple(t *testing.T) {
 			"contents": "values",
 			"tags":     "annos",
 		}
-		c, err := NewConverter("custom_single", "json", keyRenameMap, protocolKeyRenameMap)
+		c, err := NewConverter("custom_single", "json", keyRenameMap, protocolKeyRenameMap, &config.GlobalConfig{})
 		So(err, ShouldBeNil)
 
 		Convey("When the logGroup is generated from files and from k8s daemonset environment", func() {
@@ -694,7 +695,7 @@ func TestConvertToSimple(t *testing.T) {
 			"label":       "",
 			"env":         "",
 		}
-		c, err := NewConverter("custom_single", "json", keyRenameMap, nil)
+		c, err := NewConverter("custom_single", "json", keyRenameMap, nil, &config.GlobalConfig{})
 		So(err, ShouldBeNil)
 
 		Convey("When the logGroup is generated from files and from k8s daemonset environment", func() {
@@ -837,7 +838,7 @@ func TestConvertToSimple(t *testing.T) {
 	})
 
 	Convey("When constructing converter with unsupported encoding", t, func() {
-		_, err := NewConverter("custom_single", "pb", nil, nil)
+		_, err := NewConverter("custom_single", "pb", nil, nil, &config.GlobalConfig{})
 
 		Convey("Then error should be returned", func() {
 			So(err, ShouldNotBeNil)

--- a/pkg/protocol/converter/influxdb_metric_test.go
+++ b/pkg/protocol/converter/influxdb_metric_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/smartystreets/goconvey/convey"
 
+	"github.com/alibaba/ilogtail/pkg/config"
 	"github.com/alibaba/ilogtail/pkg/models"
 	"github.com/alibaba/ilogtail/pkg/protocol"
 )
@@ -64,7 +65,7 @@ func TestConvertToInfluxdbProtocolStream(t *testing.T) {
 			},
 		}
 
-		converter, err := NewConverter("influxdb", "custom", nil, nil)
+		converter, err := NewConverter("influxdb", "custom", nil, nil, &config.GlobalConfig{})
 		convey.So(err, convey.ShouldBeNil)
 
 		for _, test := range cases {
@@ -141,7 +142,7 @@ func TestConverter_ConvertToInfluxdbProtocolStreamV2(t *testing.T) {
 			},
 		}
 
-		converter, err := NewConverter("influxdb", "custom", nil, nil)
+		converter, err := NewConverter("influxdb", "custom", nil, nil, &config.GlobalConfig{})
 		convey.So(err, convey.ShouldBeNil)
 
 		for _, test := range cases {

--- a/pkg/protocol/converter/jsonline_test.go
+++ b/pkg/protocol/converter/jsonline_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestNewConvertToJsonlineLogs(t *testing.T) {
 	Convey("When constructing converter with unsupported encoding", t, func() {
-		_, err := NewConverter(ProtocolJsonline, EncodingNone, nil, nil)
+		_, err := NewConverter(ProtocolJsonline, EncodingNone, nil, nil, &config.GlobalConfig{})
 		So(err, ShouldNotBeNil)
 	})
 

--- a/pkg/protocol/converter/jsonline_test.go
+++ b/pkg/protocol/converter/jsonline_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
+	"github.com/alibaba/ilogtail/pkg/config"
 	"github.com/alibaba/ilogtail/pkg/flags"
 	"github.com/alibaba/ilogtail/pkg/protocol"
 )
@@ -27,7 +28,7 @@ func TestNewConvertToJsonlineLogs(t *testing.T) {
 		protocolKeyRenameMap := map[string]string{
 			"time": "@timestamp",
 		}
-		c, err := NewConverter(ProtocolJsonline, EncodingJSON, keyRenameMap, protocolKeyRenameMap)
+		c, err := NewConverter(ProtocolJsonline, EncodingJSON, keyRenameMap, protocolKeyRenameMap, &config.GlobalConfig{})
 		So(err, ShouldBeNil)
 
 		Convey("When the logGroup is generated from files and from k8s daemonset environment", func() {
@@ -112,7 +113,7 @@ func TestNewConvertToJsonlineLogs(t *testing.T) {
 			"label":       "",
 			"env":         "",
 		}
-		c, err := NewConverter(ProtocolJsonline, EncodingJSON, keyRenameMap, nil)
+		c, err := NewConverter(ProtocolJsonline, EncodingJSON, keyRenameMap, nil, &config.GlobalConfig{})
 		So(err, ShouldBeNil)
 
 		Convey("When the logGroup is generated from files and from k8s daemonset environment", func() {

--- a/pkg/protocol/converter/otlp.go
+++ b/pkg/protocol/converter/otlp.go
@@ -26,7 +26,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
-	"github.com/alibaba/ilogtail/pkg/config"
 	"github.com/alibaba/ilogtail/pkg/models"
 	"github.com/alibaba/ilogtail/pkg/protocol"
 	"github.com/alibaba/ilogtail/pkg/protocol/otlp"
@@ -83,7 +82,7 @@ func (c *Converter) ConvertToOtlpResourseLogs(logGroup *protocol.LogGroup, targe
 		}
 
 		logRecord.SetObservedTimestamp(pcommon.Timestamp(time.Now().UnixNano()))
-		if config.LogtailGlobalConfig.EnableTimestampNanosecond {
+		if c.GlobalConfig.EnableTimestampNanosecond {
 			logRecord.SetTimestamp(pcommon.Timestamp(uint64(log.Time)*uint64(time.Second)) + pcommon.Timestamp(uint64(*log.TimeNs)*uint64(time.Nanosecond)))
 		} else {
 			logRecord.SetTimestamp(pcommon.Timestamp(uint64(log.Time) * uint64(time.Second)))

--- a/pkg/protocol/converter/otlp_test.go
+++ b/pkg/protocol/converter/otlp_test.go
@@ -17,12 +17,12 @@ import (
 
 func TestNewConvertToOtlpLogs(t *testing.T) {
 	convey.Convey("When constructing converter with unsupported encoding", t, func() {
-		_, err := NewConverter(ProtocolOtlpV1, EncodingJSON, nil, nil)
+		_, err := NewConverter(ProtocolOtlpV1, EncodingJSON, nil, nil, &config.GlobalConfig{})
 		convey.So(err, convey.ShouldNotBeNil)
 	})
 
 	convey.Convey("When constructing converter with supported encoding", t, func() {
-		c, err := NewConverter(ProtocolOtlpV1, EncodingNone, nil, nil)
+		c, err := NewConverter(ProtocolOtlpV1, EncodingNone, nil, nil, &config.GlobalConfig{})
 		convey.So(err, convey.ShouldBeNil)
 
 		convey.Convey("When the logGroup is generated from files", func() {
@@ -81,9 +81,8 @@ func TestNewConvertToOtlpLogs(t *testing.T) {
 		})
 	})
 
-	config.LogtailGlobalConfig.EnableTimestampNanosecond = true
 	convey.Convey("When constructing converter with supported encoding", t, func() {
-		c, err := NewConverter(ProtocolOtlpV1, EncodingNone, nil, nil)
+		c, err := NewConverter(ProtocolOtlpV1, EncodingNone, nil, nil, &config.GlobalConfig{EnableTimestampNanosecond: true})
 		convey.So(err, convey.ShouldBeNil)
 
 		convey.Convey("When the logGroup is generated from files", func() {
@@ -148,7 +147,7 @@ func TestNewConvertToOtlpLogs(t *testing.T) {
 
 func TestConvertPipelineGroupEventsToOtlpLogs(t *testing.T) {
 	convey.Convey("When constructing converter with supported encoding", t, func() {
-		c, err := NewConverter(ProtocolOtlpV1, EncodingNone, nil, nil)
+		c, err := NewConverter(ProtocolOtlpV1, EncodingNone, nil, nil, &config.GlobalConfig{})
 		convey.So(err, convey.ShouldBeNil)
 
 		convey.Convey("When the logGroup is generated from files", func() {
@@ -224,7 +223,7 @@ func TestConvertPipelineGroupEventsToOtlpLogs(t *testing.T) {
 
 func TestConvertPipelineGroupEventsToOtlpMetrics(t *testing.T) {
 	convey.Convey("When constructing converter with supported encoding", t, func() {
-		c, err := NewConverter(ProtocolOtlpV1, EncodingNone, nil, nil)
+		c, err := NewConverter(ProtocolOtlpV1, EncodingNone, nil, nil, &config.GlobalConfig{})
 		convey.So(err, convey.ShouldBeNil)
 
 		convey.Convey("When the logGroup is generated from files", func() {
@@ -296,7 +295,7 @@ func TestConvertPipelineGroupEventsToOtlpMetrics(t *testing.T) {
 
 func TestConvertPipelineGroupEventsToOtlpTraces(t *testing.T) {
 	convey.Convey("When constructing converter with supported encoding", t, func() {
-		c, err := NewConverter(ProtocolOtlpV1, EncodingNone, nil, nil)
+		c, err := NewConverter(ProtocolOtlpV1, EncodingNone, nil, nil, &config.GlobalConfig{})
 		convey.So(err, convey.ShouldBeNil)
 
 		convey.Convey("When the logGroup is generated from files", func() {

--- a/pkg/protocol/decoder/opentelemetry/otlpDataToSLSProto.go
+++ b/pkg/protocol/decoder/opentelemetry/otlpDataToSLSProto.go
@@ -411,7 +411,8 @@ func ConvertOtlpMetricV1(otlpMetrics pmetric.Metrics) (logs []*protocol.Log, err
 							},
 						},
 					}
-					protocol.SetLogTimeWithNano(log, uint32(nowTime.Unix()), uint32(nowTime.Nanosecond()))
+					// Not support for nanosecond of system time
+					protocol.SetLogTime(log, uint32(nowTime.Unix()))
 					logs = append(logs, log)
 				}
 			}

--- a/pluginmanager/context_imp.go
+++ b/pluginmanager/context_imp.go
@@ -85,7 +85,7 @@ func (p *ContextImp) GetLogstore() string {
 	return p.common.GetLogStore()
 }
 
-func (p *ContextImp) GetGlobalConfig() *config.GlobalConfig {
+func (p *ContextImp) GetPipelineScopeConfig() *config.GlobalConfig {
 	return p.logstoreC.GlobalConfig
 }
 

--- a/pluginmanager/context_imp.go
+++ b/pluginmanager/context_imp.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/alibaba/ilogtail/pkg"
+	"github.com/alibaba/ilogtail/pkg/config"
 	"github.com/alibaba/ilogtail/pkg/logger"
 	"github.com/alibaba/ilogtail/pkg/pipeline"
 	"github.com/alibaba/ilogtail/pkg/protocol"
@@ -82,6 +83,10 @@ func (p *ContextImp) GetProject() string {
 }
 func (p *ContextImp) GetLogstore() string {
 	return p.common.GetLogStore()
+}
+
+func (p *ContextImp) GetGlobalConfig() *config.GlobalConfig {
+	return p.logstoreC.GlobalConfig
 }
 
 func (p *ContextImp) AddPlugin(name string) {

--- a/pluginmanager/metric_wrapper.go
+++ b/pluginmanager/metric_wrapper.go
@@ -73,7 +73,7 @@ func (p *MetricWrapper) AddDataWithContext(tags map[string]string, fields map[st
 	} else {
 		logTime = t[0]
 	}
-	slsLog, _ := helper.CreateLog(logTime, p.Tags, tags, fields)
+	slsLog, _ := helper.CreateLog(logTime, len(t) != 0, p.Tags, tags, fields)
 	p.LogsChan <- &pipeline.LogWithContext{Log: slsLog, Context: ctx}
 }
 
@@ -88,7 +88,7 @@ func (p *MetricWrapper) AddDataArrayWithContext(tags map[string]string,
 	} else {
 		logTime = t[0]
 	}
-	slsLog, _ := helper.CreateLogByArray(logTime, p.Tags, tags, columns, values)
+	slsLog, _ := helper.CreateLogByArray(logTime, len(t) != 0, p.Tags, tags, columns, values)
 	p.LogsChan <- &pipeline.LogWithContext{Log: slsLog, Context: ctx}
 }
 

--- a/pluginmanager/plugin_runner_v1.go
+++ b/pluginmanager/plugin_runner_v1.go
@@ -255,7 +255,7 @@ func (p *pluginv1Runner) runProcessorInternal(cc *pipeline.AsyncControl) {
 							continue
 						}
 						if l.Time == uint32(0) {
-							protocol.SetLogTimeWithNano(l, uint32(nowTime.Unix()), uint32(nowTime.Nanosecond()))
+							protocol.SetLogTime(l, uint32(nowTime.Unix()))
 						}
 						if !p.LogstoreConfig.GlobalConfig.EnableTimestampNanosecond {
 							l.TimeNs = nil

--- a/pluginmanager/service_wrapper.go
+++ b/pluginmanager/service_wrapper.go
@@ -76,7 +76,7 @@ func (p *ServiceWrapper) AddDataWithContext(tags map[string]string, fields map[s
 	} else {
 		logTime = t[0]
 	}
-	slsLog, _ := helper.CreateLog(logTime, p.Tags, tags, fields)
+	slsLog, _ := helper.CreateLog(logTime, len(t) != 0, p.Tags, tags, fields)
 	p.LogsChan <- &pipeline.LogWithContext{Log: slsLog, Context: ctx}
 }
 
@@ -91,7 +91,7 @@ func (p *ServiceWrapper) AddDataArrayWithContext(tags map[string]string,
 	} else {
 		logTime = t[0]
 	}
-	slsLog, _ := helper.CreateLogByArray(logTime, p.Tags, tags, columns, values)
+	slsLog, _ := helper.CreateLogByArray(logTime, len(t) != 0, p.Tags, tags, columns, values)
 	p.LogsChan <- &pipeline.LogWithContext{Log: slsLog, Context: ctx}
 }
 

--- a/plugins/flusher/clickhouse/flusher_clickhouse.go
+++ b/plugins/flusher/clickhouse/flusher_clickhouse.go
@@ -174,7 +174,7 @@ func (f *FlusherClickHouse) Validate() error {
 func (f *FlusherClickHouse) getConverter() (*converter.Converter, error) {
 	logger.Debug(f.context.GetRuntimeContext(), "[ilogtail data convert config] Protocol", f.Convert.Protocol,
 		"Encoding", f.Convert.Encoding, "TagFieldsRename", f.Convert.TagFieldsRename, "ProtocolFieldsRename", f.Convert.ProtocolFieldsRename)
-	return converter.NewConverter(f.Convert.Protocol, f.Convert.Encoding, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename, f.context.GetGlobalConfig())
+	return converter.NewConverter(f.Convert.Protocol, f.Convert.Encoding, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename, f.context.GetPipelineScopeConfig())
 }
 
 func (f *FlusherClickHouse) Flush(projectName string, logstoreName string, configName string, logGroupList []*protocol.LogGroup) error {

--- a/plugins/flusher/clickhouse/flusher_clickhouse.go
+++ b/plugins/flusher/clickhouse/flusher_clickhouse.go
@@ -174,7 +174,7 @@ func (f *FlusherClickHouse) Validate() error {
 func (f *FlusherClickHouse) getConverter() (*converter.Converter, error) {
 	logger.Debug(f.context.GetRuntimeContext(), "[ilogtail data convert config] Protocol", f.Convert.Protocol,
 		"Encoding", f.Convert.Encoding, "TagFieldsRename", f.Convert.TagFieldsRename, "ProtocolFieldsRename", f.Convert.ProtocolFieldsRename)
-	return converter.NewConverter(f.Convert.Protocol, f.Convert.Encoding, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename)
+	return converter.NewConverter(f.Convert.Protocol, f.Convert.Encoding, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename, f.context.GetGlobalConfig())
 }
 
 func (f *FlusherClickHouse) Flush(projectName string, logstoreName string, configName string, logGroupList []*protocol.LogGroup) error {

--- a/plugins/flusher/elasticsearch/flusher_elasticsearch.go
+++ b/plugins/flusher/elasticsearch/flusher_elasticsearch.go
@@ -149,7 +149,7 @@ func (f *FlusherElasticSearch) Validate() error {
 func (f *FlusherElasticSearch) getConverter() (*converter.Converter, error) {
 	logger.Debug(f.context.GetRuntimeContext(), "[ilogtail data convert config] Protocol", f.Convert.Protocol,
 		"Encoding", f.Convert.Encoding, "TagFieldsRename", f.Convert.TagFieldsRename, "ProtocolFieldsRename", f.Convert.ProtocolFieldsRename)
-	return converter.NewConverter(f.Convert.Protocol, f.Convert.Encoding, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename, f.context.GetGlobalConfig())
+	return converter.NewConverter(f.Convert.Protocol, f.Convert.Encoding, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename, f.context.GetPipelineScopeConfig())
 }
 
 func (f *FlusherElasticSearch) getIndexKeys() ([]string, bool, error) {

--- a/plugins/flusher/elasticsearch/flusher_elasticsearch.go
+++ b/plugins/flusher/elasticsearch/flusher_elasticsearch.go
@@ -149,7 +149,7 @@ func (f *FlusherElasticSearch) Validate() error {
 func (f *FlusherElasticSearch) getConverter() (*converter.Converter, error) {
 	logger.Debug(f.context.GetRuntimeContext(), "[ilogtail data convert config] Protocol", f.Convert.Protocol,
 		"Encoding", f.Convert.Encoding, "TagFieldsRename", f.Convert.TagFieldsRename, "ProtocolFieldsRename", f.Convert.ProtocolFieldsRename)
-	return converter.NewConverter(f.Convert.Protocol, f.Convert.Encoding, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename)
+	return converter.NewConverter(f.Convert.Protocol, f.Convert.Encoding, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename, f.context.GetGlobalConfig())
 }
 
 func (f *FlusherElasticSearch) getIndexKeys() ([]string, bool, error) {

--- a/plugins/flusher/http/flusher_http.go
+++ b/plugins/flusher/http/flusher_http.go
@@ -246,7 +246,7 @@ func (f *FlusherHTTP) initRequestInterceptors(transport http.RoundTripper) (http
 }
 
 func (f *FlusherHTTP) getConverter() (*converter.Converter, error) {
-	return converter.NewConverterWithSep(f.Convert.Protocol, f.Convert.Encoding, f.Convert.Separator, f.Convert.IgnoreUnExpectedData, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename)
+	return converter.NewConverterWithSep(f.Convert.Protocol, f.Convert.Encoding, f.Convert.Separator, f.Convert.IgnoreUnExpectedData, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename, f.context.GetGlobalConfig())
 }
 
 func (f *FlusherHTTP) addTask(log interface{}) {

--- a/plugins/flusher/http/flusher_http.go
+++ b/plugins/flusher/http/flusher_http.go
@@ -246,7 +246,7 @@ func (f *FlusherHTTP) initRequestInterceptors(transport http.RoundTripper) (http
 }
 
 func (f *FlusherHTTP) getConverter() (*converter.Converter, error) {
-	return converter.NewConverterWithSep(f.Convert.Protocol, f.Convert.Encoding, f.Convert.Separator, f.Convert.IgnoreUnExpectedData, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename, f.context.GetGlobalConfig())
+	return converter.NewConverterWithSep(f.Convert.Protocol, f.Convert.Encoding, f.Convert.Separator, f.Convert.IgnoreUnExpectedData, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename, f.context.GetPipelineScopeConfig())
 }
 
 func (f *FlusherHTTP) addTask(log interface{}) {

--- a/plugins/flusher/http/flusher_http_test.go
+++ b/plugins/flusher/http/flusher_http_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/alibaba/ilogtail/pkg/config"
 	"github.com/alibaba/ilogtail/pkg/helper"
 	"github.com/alibaba/ilogtail/pkg/logger"
 	"github.com/alibaba/ilogtail/pkg/models"
@@ -757,6 +758,10 @@ func (c mockContext) GetConfigName() string {
 
 func (c mockContext) GetRuntimeContext() context.Context {
 	return context.Background()
+}
+
+func (c mockContext) GetGlobalConfig() *config.GlobalConfig {
+	return &config.GlobalConfig{}
 }
 
 func init() {

--- a/plugins/flusher/http/flusher_http_test.go
+++ b/plugins/flusher/http/flusher_http_test.go
@@ -760,7 +760,7 @@ func (c mockContext) GetRuntimeContext() context.Context {
 	return context.Background()
 }
 
-func (c mockContext) GetGlobalConfig() *config.GlobalConfig {
+func (c mockContext) GetPipelineScopeConfig() *config.GlobalConfig {
 	return &config.GlobalConfig{}
 }
 

--- a/plugins/flusher/kafkav2/flusher_kafka_v2.go
+++ b/plugins/flusher/kafkav2/flusher_kafka_v2.go
@@ -565,7 +565,7 @@ func (k *FlusherKafka) makeHeaders() []sarama.RecordHeader {
 
 func (k *FlusherKafka) getConverter() (*converter.Converter, error) {
 	logger.Debug(k.context.GetRuntimeContext(), "[ilogtail data convert config] Protocol", k.Convert.Protocol, "Encoding", k.Convert.Encoding, "TagFieldsRename", k.Convert.TagFieldsRename, "ProtocolFieldsRename", k.Convert.ProtocolFieldsRename)
-	return converter.NewConverter(k.Convert.Protocol, k.Convert.Encoding, k.Convert.TagFieldsRename, k.Convert.ProtocolFieldsRename, k.context.GetGlobalConfig())
+	return converter.NewConverter(k.Convert.Protocol, k.Convert.Encoding, k.Convert.TagFieldsRename, k.Convert.ProtocolFieldsRename, k.context.GetPipelineScopeConfig())
 }
 
 func init() {

--- a/plugins/flusher/kafkav2/flusher_kafka_v2.go
+++ b/plugins/flusher/kafkav2/flusher_kafka_v2.go
@@ -565,7 +565,7 @@ func (k *FlusherKafka) makeHeaders() []sarama.RecordHeader {
 
 func (k *FlusherKafka) getConverter() (*converter.Converter, error) {
 	logger.Debug(k.context.GetRuntimeContext(), "[ilogtail data convert config] Protocol", k.Convert.Protocol, "Encoding", k.Convert.Encoding, "TagFieldsRename", k.Convert.TagFieldsRename, "ProtocolFieldsRename", k.Convert.ProtocolFieldsRename)
-	return converter.NewConverter(k.Convert.Protocol, k.Convert.Encoding, k.Convert.TagFieldsRename, k.Convert.ProtocolFieldsRename)
+	return converter.NewConverter(k.Convert.Protocol, k.Convert.Encoding, k.Convert.TagFieldsRename, k.Convert.ProtocolFieldsRename, k.context.GetGlobalConfig())
 }
 
 func init() {

--- a/plugins/flusher/loki/flusher_loki.go
+++ b/plugins/flusher/loki/flusher_loki.go
@@ -180,7 +180,7 @@ func (f *FlusherLoki) Stop() error {
 func (f *FlusherLoki) getConverter() (*converter.Converter, error) {
 	logger.Debug(f.context.GetRuntimeContext(), "[ilogtail data convert config] Protocol", f.Convert.Protocol,
 		"Encoding", f.Convert.Encoding, "TagFieldsRename", f.Convert.TagFieldsRename, "ProtocolFieldsRename", f.Convert.ProtocolFieldsRename)
-	cvt, err := converter.NewConverter(f.Convert.Protocol, f.Convert.Encoding, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename, f.context.GetGlobalConfig())
+	cvt, err := converter.NewConverter(f.Convert.Protocol, f.Convert.Encoding, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename, f.context.GetPipelineScopeConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/flusher/loki/flusher_loki.go
+++ b/plugins/flusher/loki/flusher_loki.go
@@ -180,7 +180,7 @@ func (f *FlusherLoki) Stop() error {
 func (f *FlusherLoki) getConverter() (*converter.Converter, error) {
 	logger.Debug(f.context.GetRuntimeContext(), "[ilogtail data convert config] Protocol", f.Convert.Protocol,
 		"Encoding", f.Convert.Encoding, "TagFieldsRename", f.Convert.TagFieldsRename, "ProtocolFieldsRename", f.Convert.ProtocolFieldsRename)
-	cvt, err := converter.NewConverter(f.Convert.Protocol, f.Convert.Encoding, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename)
+	cvt, err := converter.NewConverter(f.Convert.Protocol, f.Convert.Encoding, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename, f.context.GetGlobalConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/flusher/opentelemetry/flusher_otlp.go
+++ b/plugins/flusher/opentelemetry/flusher_otlp.go
@@ -115,7 +115,7 @@ func (f *FlusherOTLP) Init(ctx pipeline.Context) error {
 func (f *FlusherOTLP) getConverter() (*converter.Converter, error) {
 	switch f.Version {
 	case v1:
-		return converter.NewConverter(converter.ProtocolOtlpV1, converter.EncodingNone, nil, nil, f.context.GetGlobalConfig())
+		return converter.NewConverter(converter.ProtocolOtlpV1, converter.EncodingNone, nil, nil, f.context.GetPipelineScopeConfig())
 	default:
 		return nil, fmt.Errorf("unsupported otlp log protocol version : %s", f.Version)
 	}

--- a/plugins/flusher/opentelemetry/flusher_otlp.go
+++ b/plugins/flusher/opentelemetry/flusher_otlp.go
@@ -115,7 +115,7 @@ func (f *FlusherOTLP) Init(ctx pipeline.Context) error {
 func (f *FlusherOTLP) getConverter() (*converter.Converter, error) {
 	switch f.Version {
 	case v1:
-		return converter.NewConverter(converter.ProtocolOtlpV1, converter.EncodingNone, nil, nil)
+		return converter.NewConverter(converter.ProtocolOtlpV1, converter.EncodingNone, nil, nil, f.context.GetGlobalConfig())
 	default:
 		return nil, fmt.Errorf("unsupported otlp log protocol version : %s", f.Version)
 	}

--- a/plugins/flusher/opentelemetry/flusher_otlp_test.go
+++ b/plugins/flusher/opentelemetry/flusher_otlp_test.go
@@ -450,15 +450,18 @@ func Test_Flusher_Flush_Timeout(t *testing.T) {
 func Test_Flusher_GetConverter(t *testing.T) {
 	convey.Convey("When get Converter", t, func() {
 
+		logCtx := mock.NewEmptyContext("p", "l", "c")
 		convey.Convey("When get Converter", func() {
-			f := &FlusherOTLP{Version: v1}
+			f := &FlusherOTLP{Version: v1, context: logCtx}
+
 			c, err := f.getConverter()
 			convey.So(c, convey.ShouldNotBeNil)
 			convey.So(err, convey.ShouldBeNil)
 		})
 
 		convey.Convey("When get Converter fail", func() {
-			f := &FlusherOTLP{}
+			f := &FlusherOTLP{context: logCtx}
+
 			_, err := f.getConverter()
 			convey.So(err, convey.ShouldBeError)
 		})

--- a/plugins/flusher/pulsar/flusher_pulsar.go
+++ b/plugins/flusher/pulsar/flusher_pulsar.go
@@ -247,7 +247,7 @@ func (f *FlusherPulsar) Stop() error {
 func (f *FlusherPulsar) getConverter() (*converter.Converter, error) {
 	logger.Debug(f.context.GetRuntimeContext(), "[ilogtail data convert config] Protocol", f.Convert.Protocol,
 		"Encoding", f.Convert.Encoding, "TagFieldsRename", f.Convert.TagFieldsRename, "ProtocolFieldsRename", f.Convert.ProtocolFieldsRename)
-	return converter.NewConverter(f.Convert.Protocol, f.Convert.Encoding, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename)
+	return converter.NewConverter(f.Convert.Protocol, f.Convert.Encoding, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename, f.context.GetGlobalConfig())
 }
 
 func (f *FlusherPulsar) initClientOptions() pulsar.ClientOptions {

--- a/plugins/flusher/pulsar/flusher_pulsar.go
+++ b/plugins/flusher/pulsar/flusher_pulsar.go
@@ -247,7 +247,7 @@ func (f *FlusherPulsar) Stop() error {
 func (f *FlusherPulsar) getConverter() (*converter.Converter, error) {
 	logger.Debug(f.context.GetRuntimeContext(), "[ilogtail data convert config] Protocol", f.Convert.Protocol,
 		"Encoding", f.Convert.Encoding, "TagFieldsRename", f.Convert.TagFieldsRename, "ProtocolFieldsRename", f.Convert.ProtocolFieldsRename)
-	return converter.NewConverter(f.Convert.Protocol, f.Convert.Encoding, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename, f.context.GetGlobalConfig())
+	return converter.NewConverter(f.Convert.Protocol, f.Convert.Encoding, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename, f.context.GetPipelineScopeConfig())
 }
 
 func (f *FlusherPulsar) initClientOptions() pulsar.ClientOptions {

--- a/plugins/input/docker/stdout/docker_stdout_processor.go
+++ b/plugins/input/docker/stdout/docker_stdout_processor.go
@@ -285,7 +285,7 @@ func (p *DockerStdoutProcessor) newRawLogBySingleLine(msg *LogMessage) *protocol
 	log := &protocol.Log{
 		Contents: make([]*protocol.Log_Content, 0, p.fieldNum),
 	}
-	protocol.SetLogTimeWithNano(log, uint32(nowTime.Unix()), uint32(nowTime.Nanosecond()))
+	protocol.SetLogTime(log, uint32(nowTime.Unix()))
 	if len(msg.Content) > 0 && msg.Content[len(msg.Content)-1] == '\n' {
 		msg.Content = msg.Content[0 : len(msg.Content)-1]
 	}
@@ -331,7 +331,7 @@ func (p *DockerStdoutProcessor) newRawLogByMultiLine() *protocol.Log {
 	log := &protocol.Log{
 		Contents: make([]*protocol.Log_Content, 0, p.fieldNum),
 	}
-	protocol.SetLogTimeWithNano(log, uint32(nowTime.Unix()), uint32(nowTime.Nanosecond()))
+	protocol.SetLogTime(log, uint32(nowTime.Unix()))
 	log.Contents = append(log.Contents, &protocol.Log_Content{
 		Key:   "content",
 		Value: multiLine.String(),

--- a/plugins/input/skywalkingv3/ot_trace.go
+++ b/plugins/input/skywalkingv3/ot_trace.go
@@ -72,7 +72,7 @@ func (ot *OtSpan) ToLog() (*protocol.Log, error) {
 		protocol.SetLogTimeWithNano(log, uint32(ot.End/int64(1000000)), uint32((ot.End*1000)%1e9))
 	} else {
 		nowTime := time.Now()
-		protocol.SetLogTimeWithNano(log, uint32(nowTime.Unix()), uint32(nowTime.Nanosecond()))
+		protocol.SetLogTime(log, uint32(nowTime.Unix()))
 	}
 	log.Contents = make([]*protocol.Log_Content, 0)
 	linksJSON, err := json.Marshal(ot.Links)

--- a/plugins/processor/gotime/processor_gotime.go
+++ b/plugins/processor/gotime/processor_gotime.go
@@ -132,7 +132,7 @@ func (p *ProcessorGotime) processLog(log *protocol.Log) {
 				parsedTime = parsedStringTime
 			}
 			if p.SetTime {
-				if p.context.GetGlobalConfig().EnableTimestampNanosecond {
+				if p.context.GetPipelineScopeConfig().EnableTimestampNanosecond {
 					protocol.SetLogTimeWithNano(log, uint32(parsedTime.Unix()), uint32(parsedTime.Nanosecond()))
 				} else {
 					protocol.SetLogTime(log, uint32(parsedTime.Unix()))

--- a/plugins/processor/gotime/processor_gotime.go
+++ b/plugins/processor/gotime/processor_gotime.go
@@ -132,7 +132,11 @@ func (p *ProcessorGotime) processLog(log *protocol.Log) {
 				parsedTime = parsedStringTime
 			}
 			if p.SetTime {
-				protocol.SetLogTimeWithNano(log, uint32(parsedTime.Unix()), uint32(parsedTime.Nanosecond()))
+				if p.context.GetGlobalConfig().EnableTimestampNanosecond {
+					protocol.SetLogTimeWithNano(log, uint32(parsedTime.Unix()), uint32(parsedTime.Nanosecond()))
+				} else {
+					protocol.SetLogTime(log, uint32(parsedTime.Unix()))
+				}
 			}
 			if !p.KeepSource {
 				log.Contents = append(log.Contents[:idx], log.Contents[idx+1:]...)

--- a/plugins/processor/split/logregex/split_log_regex.go
+++ b/plugins/processor/split/logregex/split_log_regex.go
@@ -119,7 +119,7 @@ func (p *ProcessorSplitRegex) ProcessLogs(logArray []*protocol.Log) []*protocol.
 			}
 		} else {
 			nowTime := time.Now()
-			protocol.SetLogTimeWithNano(newLog, uint32(nowTime.Unix()), uint32(nowTime.Nanosecond()))
+			protocol.SetLogTime(newLog, uint32(nowTime.Unix()))
 		}
 		if destCont != nil {
 			destArray = p.SplitLog(destArray, newLog, destCont)

--- a/plugins/processor/split/logstring/split_log_string.go
+++ b/plugins/processor/split/logstring/split_log_string.go
@@ -70,7 +70,7 @@ func (p *ProcessorSplit) ProcessLogs(logArray []*protocol.Log) []*protocol.Log {
 			}
 		} else {
 			nowTime := time.Now()
-			protocol.SetLogTimeWithNano(newLog, uint32(nowTime.Unix()), uint32(nowTime.Nanosecond()))
+			protocol.SetLogTime(newLog, uint32(nowTime.Unix()))
 		}
 
 		if destCont != nil {

--- a/plugins/processor/strptime/strptime.go
+++ b/plugins/processor/strptime/strptime.go
@@ -145,7 +145,11 @@ func (s *Strptime) processLog(log *protocol.Log) {
 			logTime = logTime.In(s.location).Add(time.Second * time.Duration(-s.UTCOffset))
 		}
 
-		protocol.SetLogTimeWithNano(log, uint32(logTime.Unix()), uint32(logTime.Nanosecond()))
+		if s.context.GetGlobalConfig().EnableTimestampNanosecond {
+			protocol.SetLogTimeWithNano(log, uint32(logTime.Unix()), uint32(logTime.Nanosecond()))
+		} else {
+			protocol.SetLogTime(log, uint32(logTime.Unix()))
+		}
 		if !s.KeepSource {
 			log.Contents = append(log.Contents[:idx], log.Contents[idx+1:]...)
 		}

--- a/plugins/processor/strptime/strptime.go
+++ b/plugins/processor/strptime/strptime.go
@@ -145,7 +145,7 @@ func (s *Strptime) processLog(log *protocol.Log) {
 			logTime = logTime.In(s.location).Add(time.Second * time.Duration(-s.UTCOffset))
 		}
 
-		if s.context.GetGlobalConfig().EnableTimestampNanosecond {
+		if s.context.GetPipelineScopeConfig().EnableTimestampNanosecond {
 			protocol.SetLogTimeWithNano(log, uint32(logTime.Unix()), uint32(logTime.Nanosecond()))
 		} else {
 			protocol.SetLogTime(log, uint32(logTime.Unix()))

--- a/plugins/test/common.go
+++ b/plugins/test/common.go
@@ -158,7 +158,7 @@ func (m *MockMetricCollector) AddDataWithContext(tags map[string]string, fields 
 	} else {
 		logTime = t[0]
 	}
-	slsLog, _ := helper.CreateLog(logTime, m.Tags, tags, fields)
+	slsLog, _ := helper.CreateLog(logTime, len(t) != 0, m.Tags, tags, fields)
 	m.Logs = append(m.Logs, slsLog)
 }
 
@@ -172,7 +172,7 @@ func (m *MockMetricCollector) AddDataArrayWithContext(tags map[string]string, co
 	} else {
 		logTime = t[0]
 	}
-	slsLog, _ := helper.CreateLogByArray(logTime, m.Tags, tags, columns, values)
+	slsLog, _ := helper.CreateLogByArray(logTime, len(t) != 0, m.Tags, tags, columns, values)
 	m.Logs = append(m.Logs, slsLog)
 }
 

--- a/plugins/test/mock/context.go
+++ b/plugins/test/mock/context.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/alibaba/ilogtail/pkg"
+	"github.com/alibaba/ilogtail/pkg/config"
 	"github.com/alibaba/ilogtail/pkg/logger"
 	"github.com/alibaba/ilogtail/pkg/pipeline"
 	"github.com/alibaba/ilogtail/pkg/protocol"
@@ -60,6 +61,10 @@ func (p *EmptyContext) GetProject() string {
 }
 func (p *EmptyContext) GetLogstore() string {
 	return p.common.GetLogStore()
+}
+
+func (p *EmptyContext) GetGlobalConfig() *config.GlobalConfig {
+	return &config.GlobalConfig{}
 }
 
 func (p *EmptyContext) AddPlugin(name string) {

--- a/plugins/test/mock/context.go
+++ b/plugins/test/mock/context.go
@@ -63,7 +63,7 @@ func (p *EmptyContext) GetLogstore() string {
 	return p.common.GetLogStore()
 }
 
-func (p *EmptyContext) GetGlobalConfig() *config.GlobalConfig {
+func (p *EmptyContext) GetPipelineScopeConfig() *config.GlobalConfig {
 	return &config.GlobalConfig{}
 }
 


### PR DESCRIPTION
## 问题
1. service stdout 系统时间一直会采集纳秒
2. 在流水线改造过后，Go的全局配置已经变为了流水线级的。原有的全局变量废弃了，不会被更新。但目前还是从原有的全局变量获取纳秒开关

## C++ Go统一纳秒行为定义
1. 系统时间不支持纳秒
2. 通过时间解析插件并且开启纳秒开关，才支持纳秒

