### PR TITLE
fix go checkpoint deletion problem caused by always online config mistaken for deleted

### DIFF
--- a/pluginmanager/always_online_manager.go
+++ b/pluginmanager/always_online_manager.go
@@ -60,7 +60,7 @@ func (aom *AlwaysOnlineManager) AddCachedConfig(config *LogstoreConfig, timeout 
 		addedTime: time.Now(),
 		timeout:   timeout,
 	}
-	aom.configMap[config.ConfigName] = alwaysOnlineItem
+	aom.configMap[config.ConfigNameWithSuffix] = alwaysOnlineItem
 }
 
 // GetCachedConfig get cached config from manager and delete this item, so manager will not close this config

--- a/pluginmanager/logstore_config.go
+++ b/pluginmanager/logstore_config.go
@@ -89,11 +89,12 @@ var (
 
 type LogstoreConfig struct {
 	// common fields
-	ProjectName  string
-	LogstoreName string
-	ConfigName   string
-	LogstoreKey  int64
-	FlushOutFlag bool
+	ProjectName          string
+	LogstoreName         string
+	ConfigName           string
+	ConfigNameWithSuffix string
+	LogstoreKey          int64
+	FlushOutFlag         bool
 	// Each LogstoreConfig can have its independent GlobalConfig if the "global" field
 	//   is offered in configuration, see build-in StatisticsConfig and AlarmConfig.
 	GlobalConfig *config.GlobalConfig
@@ -380,12 +381,13 @@ func createLogstoreConfig(project string, logstore string, configName string, lo
 	contextImp := &ContextImp{}
 	contextImp.InitContext(project, logstore, configName)
 	logstoreC := &LogstoreConfig{
-		ProjectName:      project,
-		LogstoreName:     logstore,
-		ConfigName:       config.GetRealConfigName(configName),
-		LogstoreKey:      logstoreKey,
-		Context:          contextImp,
-		configDetailHash: fmt.Sprintf("%x", md5.Sum([]byte(jsonStr))), //nolint:gosec
+		ProjectName:          project,
+		LogstoreName:         logstore,
+		ConfigName:           config.GetRealConfigName(configName),
+		ConfigNameWithSuffix: configName,
+		LogstoreKey:          logstoreKey,
+		Context:              contextImp,
+		configDetailHash:     fmt.Sprintf("%x", md5.Sum([]byte(jsonStr))), //nolint:gosec
 	}
 	contextImp.logstoreC = logstoreC
 

--- a/pluginmanager/plugin_manager.go
+++ b/pluginmanager/plugin_manager.go
@@ -153,11 +153,11 @@ func timeoutStop(config *LogstoreConfig, flag bool) bool {
 
 		// The config is valid but stop slowly, allow it to load again.
 		DisabledLogtailConfigLock.Lock()
-		if _, exists := DisabledLogtailConfig[config.ConfigName]; !exists {
+		if _, exists := DisabledLogtailConfig[config.ConfigNameWithSuffix]; !exists {
 			DisabledLogtailConfigLock.Unlock()
 			return
 		}
-		delete(DisabledLogtailConfig, config.ConfigName)
+		delete(DisabledLogtailConfig, config.ConfigNameWithSuffix)
 		DisabledLogtailConfigLock.Unlock()
 		logger.Info(config.Context.GetRuntimeContext(), "Valid but slow stop config, enable it again", config.ConfigName)
 	}()
@@ -181,7 +181,7 @@ func HoldOn(exitFlag bool) error {
 			logger.Error(logstoreConfig.Context.GetRuntimeContext(), "CONFIG_STOP_TIMEOUT_ALARM",
 				"timeout when stop config, goroutine might leak")
 			DisabledLogtailConfigLock.Lock()
-			DisabledLogtailConfig[logstoreConfig.ConfigName] = logstoreConfig
+			DisabledLogtailConfig[logstoreConfig.ConfigNameWithSuffix] = logstoreConfig
 			DisabledLogtailConfigLock.Unlock()
 		}
 	}


### PR DESCRIPTION
- 问题：配置变更依然会导致stdout重复采集
- 原因：之前调整Go的真假配置名仍然存在疏漏，只关注了LogtailConfig这个全局结构，忽略了LastLogtailConfig、DisabledLogtailConfig和AlwaysOnlineManager里的配置名也应该是带后缀的。
- 修复：在logstoreConfig里保留带后缀的配置名，在timeoutstop的时候需要使用。