### PR TITLE
Add UseDecimal parameter to the service_canal plugin. When UseDecimal is set to true, the binlog parsing outputs the original DECIMAL format instead of scientific notation

### DIFF
--- a/docs/cn/plugins/input/service-canal.md
+++ b/docs/cn/plugins/input/service-canal.md
@@ -31,6 +31,7 @@
 | TextToString | Boolean，`false` | 是否将text类型的数据转换成字符串。不设置时，默认为false，表示不转换。|
 | PackValues | Boolean，`false` | 是否将事件数据打包成JSON格式。默认为false，表示不打包。如果设置为true，Logtail会将事件数据以JSON格式集中打包到data和old_data两个字段中，其中old_data仅在row_update事件中有意义。 示例：假设数据表有三列数据c1，c2，c3，设置为false，row_insert事件数据中会有c1，c2，c3三个字段，而设置为true时，c1，c2，c3会被统一打包为data字段，值为`{"c1":"...", "c2": "...", "c3": "..."}`。|
 | EnableEventMeta | Boolean，`false` | 是否采集事件的元数据，默认为false，表示不采集。 Binlog事件的元数据包括event_time、event_log_position、event_size和event_server_id。|
+| UseDecimal | Boolean，`false` | binlog解析DECIMAL时，是否输出原格式而非科学计数法。不设置时，默认为false，表示使用科学计数法。|
 
 ## 样例
 

--- a/docs/cn/plugins/input/service-canal.md
+++ b/docs/cn/plugins/input/service-canal.md
@@ -31,7 +31,7 @@
 | TextToString | Boolean，`false` | 是否将text类型的数据转换成字符串。不设置时，默认为false，表示不转换。|
 | PackValues | Boolean，`false` | 是否将事件数据打包成JSON格式。默认为false，表示不打包。如果设置为true，Logtail会将事件数据以JSON格式集中打包到data和old_data两个字段中，其中old_data仅在row_update事件中有意义。 示例：假设数据表有三列数据c1，c2，c3，设置为false，row_insert事件数据中会有c1，c2，c3三个字段，而设置为true时，c1，c2，c3会被统一打包为data字段，值为`{"c1":"...", "c2": "...", "c3": "..."}`。|
 | EnableEventMeta | Boolean，`false` | 是否采集事件的元数据，默认为false，表示不采集。 Binlog事件的元数据包括event_time、event_log_position、event_size和event_server_id。|
-| UseDecimal | Boolean，`false` | binlog解析DECIMAL时，是否输出原格式而非科学计数法。不设置时，默认为false，表示使用科学计数法。|
+| UseDecimal | Boolean，`false` | Binlog解析DECIMAL类型时，是否保持原格式输出，而不是使用科学计数法。如果未设置，系统默认为false，即默认使用科学计数法。|
 
 ## 样例
 

--- a/plugins/input/canal/input_canal.go
+++ b/plugins/input/canal/input_canal.go
@@ -141,6 +141,8 @@ type ServiceCanal struct {
 	Charset           string
 	// Pack values into two fields: new_data and old_data. False by default.
 	PackValues bool
+	// binlog解析输出原格式而非科学计数法
+	UseDecimal bool
 
 	shutdown  chan struct{}
 	waitGroup sync.WaitGroup
@@ -189,6 +191,7 @@ func (sc *ServiceCanal) Init(context pipeline.Context) (int, error) {
 	sc.config.DiscardNoMetaRowEvent = true
 	sc.config.IncludeTableRegex = sc.IncludeTables
 	sc.config.ExcludeTableRegex = sc.ExcludeTables
+	sc.config.UseDecimal = sc.UseDecimal
 
 	sc.lastErrorChan = make(chan error, 1)
 

--- a/plugins/input/canal/input_canal.go
+++ b/plugins/input/canal/input_canal.go
@@ -141,7 +141,7 @@ type ServiceCanal struct {
 	Charset           string
 	// Pack values into two fields: new_data and old_data. False by default.
 	PackValues bool
-	// binlog解析输出原格式而非科学计数法
+	// True时 binlog解析DECIMAL输出原格式而非科学计数法, like:https://github.com/go-mysql-org/go-mysql/blob/6c99b4bff931a5aced0978b78aadb5867afcdcd3/canal/dump.go#L85
 	UseDecimal bool
 
 	shutdown  chan struct{}


### PR DESCRIPTION
参考链接：https://github.com/go-mysql-org/go-mysql/blob/6c99b4bff931a5aced0978b78aadb5867afcdcd3/canal/dump.go#L85

https://github.com/go-mysql-org/go-mysql/issues/475


目前现状，UseDecimal默认为false，当DECIMAL类型数据大于等于100000时，会转成科学计数法 例如 1e6.
看了底层实现，UseDecimal为false时会用fmt.Sprint，所以变成了科学计数法