### PR TITLE
fix: disable nanosecond timestamp when only EnableTimestampNanosecond is enabled

### DIFF
--- a/core/common/TimeUtil.cpp
+++ b/core/common/TimeUtil.cpp
@@ -302,10 +302,11 @@ void SetLogTime(sls_logs::Log* log, time_t second) {
     log->set_time(second);
 }
 
-void SetLogTimeWithNano(sls_logs::Log* log, time_t second, long nanosecond) {
-    // Usage: set nanosecond first, and then discard at LogProcess@ProcessBufferLegacy
+void SetLogTimeWithNano(sls_logs::Log* log, time_t second, std::optional<uint32_t> nanosecond) {
     log->set_time(second);
-    log->set_time_ns(nanosecond);
+    if (nanosecond) {
+        log->set_time_ns(nanosecond.value());
+    }
 }
 
 LogtailTime GetCurrentLogtailTime() {

--- a/core/common/TimeUtil.h
+++ b/core/common/TimeUtil.h
@@ -16,6 +16,7 @@
 
 #pragma once
 #include <ctime>
+#include <optional>
 #include <string>
 #include <thread>
 
@@ -83,7 +84,7 @@ uint64_t GetPreciseTimestampFromLogtailTime(LogtailTime logTime, const PreciseTi
 
 void SetLogTime(sls_logs::Log* log, time_t second);
 
-void SetLogTimeWithNano(sls_logs::Log* log, time_t second, long nanosecond);
+void SetLogTimeWithNano(sls_logs::Log* log, time_t second, std::optional<uint32_t> nanosecond);
 
 LogtailTime GetCurrentLogtailTime();
 

--- a/core/models/LogEvent.cpp
+++ b/core/models/LogEvent.cpp
@@ -138,7 +138,9 @@ Json::Value LogEvent::ToJson(bool enableEventMeta) const {
     Json::Value root;
     root["type"] = static_cast<int>(GetType());
     root["timestamp"] = GetTimestamp();
-    root["timestampNanosecond"] = GetTimestampNanosecond();
+    if (IsTimestampNanosecondEnabled()) {
+        root["timestampNanosecond"] = static_cast<int32_t>(GetTimestampNanosecond().value());
+    }
     if (enableEventMeta) {
         root["fileOffset"] = GetPosition().first;
         root["rawSize"] = GetPosition().second;

--- a/core/models/LogEvent.cpp
+++ b/core/models/LogEvent.cpp
@@ -138,7 +138,7 @@ Json::Value LogEvent::ToJson(bool enableEventMeta) const {
     Json::Value root;
     root["type"] = static_cast<int>(GetType());
     root["timestamp"] = GetTimestamp();
-    if (IsTimestampNanosecondEnabled()) {
+    if (GetTimestampNanosecond()) {
         root["timestampNanosecond"] = static_cast<int32_t>(GetTimestampNanosecond().value());
     }
     if (enableEventMeta) {

--- a/core/models/MetricEvent.cpp
+++ b/core/models/MetricEvent.cpp
@@ -69,7 +69,9 @@ Json::Value MetricEvent::ToJson(bool enableEventMeta) const {
     Json::Value root;
     root["type"] = static_cast<int>(GetType());
     root["timestamp"] = GetTimestamp();
-    root["timestampNanosecond"] = GetTimestampNanosecond();
+    if (IsTimestampNanosecondEnabled()) {
+        root["timestampNanosecond"] = static_cast<int32_t>(GetTimestampNanosecond().value());
+    }
     root["name"] = mName.to_string();
     root["value"] = MetricValueToJson(mValue);
     if (!mTags.mInner.empty()) {

--- a/core/models/MetricEvent.cpp
+++ b/core/models/MetricEvent.cpp
@@ -69,7 +69,7 @@ Json::Value MetricEvent::ToJson(bool enableEventMeta) const {
     Json::Value root;
     root["type"] = static_cast<int>(GetType());
     root["timestamp"] = GetTimestamp();
-    if (IsTimestampNanosecondEnabled()) {
+    if (GetTimestampNanosecond()) {
         root["timestampNanosecond"] = static_cast<int32_t>(GetTimestampNanosecond().value());
     }
     root["name"] = mName.to_string();

--- a/core/models/PipelineEvent.h
+++ b/core/models/PipelineEvent.h
@@ -20,6 +20,7 @@
 #include <ctime>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "common/memory/SourceBuffer.h"
@@ -41,12 +42,17 @@ public:
 
     Type GetType() const { return mType; }
     time_t GetTimestamp() const { return mTimestamp; }
-    long GetTimestampNanosecond() const { return mTimestampNanosecond; }
+    std::optional<uint32_t> GetTimestampNanosecond() const { return mTimestampNanosecond; }
     void SetTimestamp(time_t t) { mTimestamp = t; }
-    void SetTimestamp(time_t t, long ns) {
+    void SetTimestamp(time_t t, uint32_t ns) {
         mTimestamp = t;
         mTimestampNanosecond = ns; // Only nanosecond part
     }
+    void SetTimestamp(time_t t, std::optional<uint32_t> ns) {
+        mTimestamp = t;
+        mTimestampNanosecond = ns; // Only nanosecond part
+    }
+    bool IsTimestampNanosecondEnabled() const { return mTimestampNanosecond.has_value(); }
     void ResetPipelineEventGroup(PipelineEventGroup* ptr) { mPipelineEventGroupPtr = ptr; }
     std::shared_ptr<SourceBuffer>& GetSourceBuffer();
 
@@ -64,7 +70,7 @@ protected:
 
     Type mType = Type::NONE;
     time_t mTimestamp = 0;
-    long mTimestampNanosecond = 0;
+    std::optional<uint32_t> mTimestampNanosecond;
     PipelineEventGroup* mPipelineEventGroupPtr = nullptr;
 };
 

--- a/core/models/PipelineEvent.h
+++ b/core/models/PipelineEvent.h
@@ -52,7 +52,6 @@ public:
         mTimestamp = t;
         mTimestampNanosecond = ns; // Only nanosecond part
     }
-    bool IsTimestampNanosecondEnabled() const { return mTimestampNanosecond.has_value(); }
     void ResetPipelineEventGroup(PipelineEventGroup* ptr) { mPipelineEventGroupPtr = ptr; }
     std::shared_ptr<SourceBuffer>& GetSourceBuffer();
 

--- a/core/models/SpanEvent.cpp
+++ b/core/models/SpanEvent.cpp
@@ -309,7 +309,7 @@ Json::Value SpanEvent::ToJson(bool enableEventMeta) const {
     Json::Value root;
     root["type"] = static_cast<int>(GetType());
     root["timestamp"] = GetTimestamp();
-    if (IsTimestampNanosecondEnabled()) {
+    if (GetTimestampNanosecond()) {
         root["timestampNanosecond"] = static_cast<int32_t>(GetTimestampNanosecond().value());
     }
     root["traceId"] = mTraceId.to_string();

--- a/core/models/SpanEvent.cpp
+++ b/core/models/SpanEvent.cpp
@@ -299,9 +299,9 @@ size_t SpanEvent::DataSize() const {
         linksSize += item.DataSize();
     }
     // TODO: for enum, it seems more reasonable to use actual string size instead of size of enum
-    return PipelineEvent::DataSize() + mTraceId.size() + mSpanId.size() + mTraceState.size() + mParentSpanId.size() + mName.size()
-        + sizeof(decltype(mKind)) + sizeof(decltype(mStartTimeNs)) + sizeof(decltype(mEndTimeNs)) + mTags.DataSize()
-        + eventsSize + linksSize + sizeof(decltype(mStatus)) + mScopeTags.DataSize();
+    return PipelineEvent::DataSize() + mTraceId.size() + mSpanId.size() + mTraceState.size() + mParentSpanId.size()
+        + mName.size() + sizeof(decltype(mKind)) + sizeof(decltype(mStartTimeNs)) + sizeof(decltype(mEndTimeNs))
+        + mTags.DataSize() + eventsSize + linksSize + sizeof(decltype(mStatus)) + mScopeTags.DataSize();
 }
 
 #ifdef APSARA_UNIT_TEST_MAIN
@@ -309,7 +309,9 @@ Json::Value SpanEvent::ToJson(bool enableEventMeta) const {
     Json::Value root;
     root["type"] = static_cast<int>(GetType());
     root["timestamp"] = GetTimestamp();
-    root["timestampNanosecond"] = GetTimestampNanosecond();
+    if (IsTimestampNanosecondEnabled()) {
+        root["timestampNanosecond"] = static_cast<int32_t>(GetTimestampNanosecond().value());
+    }
     root["traceId"] = mTraceId.to_string();
     root["spanId"] = mSpanId.to_string();
     if (!mTraceState.empty()) {

--- a/core/processor/daemon/LogProcess.cpp
+++ b/core/processor/daemon/LogProcess.cpp
@@ -408,8 +408,8 @@ void LogProcess::FillLogGroupLogs(const PipelineEventGroup& eventGroup,
         }
         sls_logs::Log* log = resultGroup.add_logs();
         auto& logEvent = event.Cast<LogEvent>();
-        if (enableTimestampNanosecond && logEvent.IsTimestampNanosecondEnabled()) {
-            SetLogTimeWithNano(log, logEvent.GetTimestamp(), logEvent.GetTimestampNanosecond().value());
+        if (enableTimestampNanosecond) {
+            SetLogTimeWithNano(log, logEvent.GetTimestamp(), logEvent.GetTimestampNanosecond());
         } else {
             SetLogTime(log, logEvent.GetTimestamp());
         }

--- a/core/processor/daemon/LogProcess.cpp
+++ b/core/processor/daemon/LogProcess.cpp
@@ -231,7 +231,7 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
 
         {
             ReadLock lock(mAccessProcessThreadRWL);
-            
+
             std::unique_ptr<ProcessQueueItem> item;
             std::string configName;
             if (!ProcessQueueManager::GetInstance()->PopItem(threadNo, item, configName)) {
@@ -408,8 +408,8 @@ void LogProcess::FillLogGroupLogs(const PipelineEventGroup& eventGroup,
         }
         sls_logs::Log* log = resultGroup.add_logs();
         auto& logEvent = event.Cast<LogEvent>();
-        if (enableTimestampNanosecond) {
-            SetLogTimeWithNano(log, logEvent.GetTimestamp(), logEvent.GetTimestampNanosecond());
+        if (enableTimestampNanosecond && logEvent.IsTimestampNanosecondEnabled()) {
+            SetLogTimeWithNano(log, logEvent.GetTimestamp(), logEvent.GetTimestampNanosecond().value());
         } else {
             SetLogTime(log, logEvent.GetTimestamp());
         }

--- a/core/spl/PipelineEventGroupInput.cpp
+++ b/core/spl/PipelineEventGroupInput.cpp
@@ -56,7 +56,7 @@ void PipelineEventGroupInput::getTimeColumns(std::vector<uint32_t>& times,
     for (const auto &event : mLogGroup->GetEvents()) {
         const LogEvent& sourceEvent = event.Cast<LogEvent>();
         times.emplace_back(sourceEvent.GetTimestamp());
-        timeNanos.emplace_back(sourceEvent.GetTimestampNanosecond());
+        timeNanos.emplace_back(sourceEvent.GetTimestampNanosecond() ? sourceEvent.GetTimestampNanosecond().value() : 0);
     }
 }
 

--- a/core/unittest/models/MetricEventUnittest.cpp
+++ b/core/unittest/models/MetricEventUnittest.cpp
@@ -125,7 +125,7 @@ void MetricEventUnittest::TestSize() {
 }
 
 void MetricEventUnittest::TestToJson() {
-    mMetricEvent->SetTimestamp(12345678901);
+    mMetricEvent->SetTimestamp(12345678901, 0);
     mMetricEvent->SetName("test");
     mMetricEvent->SetValue(UntypedSingleValue{10.0});
     mMetricEvent->SetTag(string("key1"), string("value1"));
@@ -170,7 +170,7 @@ void MetricEventUnittest::TestFromJson() {
     mMetricEvent->FromJson(eventJson);
 
     APSARA_TEST_EQUAL(12345678901, mMetricEvent->GetTimestamp());
-    APSARA_TEST_EQUAL(0L, mMetricEvent->GetTimestampNanosecond());
+    APSARA_TEST_EQUAL(0L, mMetricEvent->GetTimestampNanosecond().value());
     APSARA_TEST_EQUAL("test", mMetricEvent->GetName());
     APSARA_TEST_TRUE(mMetricEvent->Is<UntypedSingleValue>());
     APSARA_TEST_EQUAL(10.0, mMetricEvent->GetValue<UntypedSingleValue>()->mValue);

--- a/core/unittest/models/SpanEventUnittest.cpp
+++ b/core/unittest/models/SpanEventUnittest.cpp
@@ -247,7 +247,7 @@ void SpanEventUnittest::TestSize() {
 }
 
 void SpanEventUnittest::TestToJson() {
-    mSpanEvent->SetTimestamp(12345678901);
+    mSpanEvent->SetTimestamp(12345678901, 0);
     mSpanEvent->SetTraceId("test_trace_id");
     mSpanEvent->SetSpanId("test_span_id");
     mSpanEvent->SetTraceState("normal");
@@ -343,6 +343,8 @@ void SpanEventUnittest::TestFromJson() {
     ParseJsonTable(eventStr, eventJson, errorMsg);
     mSpanEvent->FromJson(eventJson);
 
+    APSARA_TEST_EQUAL(12345678901, mSpanEvent->GetTimestamp());
+    APSARA_TEST_EQUAL(0L, mSpanEvent->GetTimestampNanosecond().value());
     APSARA_TEST_EQUAL("test_trace_id", mSpanEvent->GetTraceId().to_string());
     APSARA_TEST_EQUAL("test_span_id", mSpanEvent->GetSpanId().to_string());
     APSARA_TEST_EQUAL("normal", mSpanEvent->GetTraceState().to_string());

--- a/core/unittest/processor/ProcessorMergeMultilineLogNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorMergeMultilineLogNativeUnittest.cpp
@@ -365,7 +365,6 @@ void ProcessorMergeMultilineLogNativeUnittest::TestProcess() {
                     {
                         "name": "",
                         "timestamp": 0,
-                        "timestampNanosecond": 0,
                         "type": 2,
                         "value": {
                             "type": "unknown"
@@ -469,7 +468,6 @@ void ProcessorMergeMultilineLogNativeUnittest::TestProcess() {
                     {
                         "name": "",
                         "timestamp": 0,
-                        "timestampNanosecond": 0,
                         "type": 2,
                         "value": {
                             "type": "unknown"
@@ -526,7 +524,6 @@ void ProcessorMergeMultilineLogNativeUnittest::TestProcess() {
                     {
                         "name": "",
                         "timestamp": 0,
-                        "timestampNanosecond": 0,
                         "type": 2,
                         "value": {
                             "type": "unknown"
@@ -1412,7 +1409,6 @@ void ProcessEventsWithPartLogUnittest::TestProcess() {
                     {
                         "name": "",
                         "timestamp": 0,
-                        "timestampNanosecond": 0,
                         "type": 2,
                         "value": {
                             "type": "unknown"
@@ -1556,7 +1552,6 @@ void ProcessEventsWithPartLogUnittest::TestProcess() {
                     {
                         "name": "",
                         "timestamp": 0,
-                        "timestampNanosecond": 0,
                         "type": 2,
                         "value": {
                             "type": "unknown"
@@ -1697,7 +1692,6 @@ void ProcessEventsWithPartLogUnittest::TestProcess() {
                     {
                         "name": "",
                         "timestamp": 0,
-                        "timestampNanosecond": 0,
                         "type": 2,
                         "value": {
                             "type": "unknown"
@@ -1827,7 +1821,6 @@ void ProcessEventsWithPartLogUnittest::TestProcess() {
                     {
                         "name": "",
                         "timestamp": 0,
-                        "timestampNanosecond": 0,
                         "type": 2,
                         "value": {
                             "type": "unknown"

--- a/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
@@ -491,7 +491,6 @@ void ProcessorParseApsaraNativeUnittest::TestMultipleLines() {
                     "__raw__": "[2023-09-04 13:15"
                 },
                 "timestamp": 12345678901,
-                "timestampNanosecond": 0,
                 "type": 1
             },
             {
@@ -499,7 +498,6 @@ void ProcessorParseApsaraNativeUnittest::TestMultipleLines() {
                     "__raw__": ":50.1]\t[ERROR]\t[1]\t/ilogtail/AppConfigBase.cpp:1\t\tAppConfigBase AppConfigBase:1"
                 },
                 "timestamp": 12345678901,
-                "timestampNanosecond": 0,
                 "type": 1
             },
             {
@@ -863,7 +861,6 @@ void ProcessorParseApsaraNativeUnittest::TestProcessKeyOverwritten() {
                     "rawLog": "value1"
                 },
                 "timestamp": 12345678901,
-                "timestampNanosecond": 0,
                 "type": 1
             }
         ]
@@ -939,7 +936,6 @@ void ProcessorParseApsaraNativeUnittest::TestUploadRawLog() {
                     "rawLog": "value1"
                 },
                 "timestamp": 12345678901,
-                "timestampNanosecond": 0,
                 "type": 1
             }
         ]
@@ -1050,7 +1046,6 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventKeepUnmatch() {
                     "rawLog" : "value1"
                 },
                 "timestamp" : 12345678901,
-                "timestampNanosecond": 0,
                 "type" : 1
             },
             {
@@ -1059,7 +1054,6 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventKeepUnmatch() {
                     "rawLog" : "value1"
                 },
                 "timestamp" : 12345678901,
-                "timestampNanosecond": 0,
                 "type" : 1
             },
             {
@@ -1068,7 +1062,6 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventKeepUnmatch() {
                     "rawLog" : "value1"
                 },
                 "timestamp" : 12345678901,
-                "timestampNanosecond": 0,
                 "type" : 1
             },
             {
@@ -1077,7 +1070,6 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventKeepUnmatch() {
                     "rawLog" : "value1"
                 },
                 "timestamp" : 12345678901,
-                "timestampNanosecond": 0,
                 "type" : 1
             },
             {
@@ -1086,7 +1078,6 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventKeepUnmatch() {
                     "rawLog" : "value1"
                 },
                 "timestamp" : 12345678901,
-                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]
@@ -1292,7 +1283,6 @@ void ProcessorParseApsaraNativeUnittest::TestProcessEventMicrosecondUnmatch() {
                     "rawLog": "[2023-09-04 13:18:04"
                 },
                 "timestamp": 12345678901,
-                "timestampNanosecond": 0,
                 "type": 1
             }
         ]

--- a/core/unittest/processor/ProcessorParseDelimiterNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseDelimiterNativeUnittest.cpp
@@ -89,6 +89,7 @@ void ProcessorParseDelimiterNativeUnittest::TestAllowingShortenedFields() {
                     "content" : "2013-10-31 21:03:49,POST,'PutData?Category=YunOsAccountOpLog',0.024"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             },
             {
@@ -97,6 +98,7 @@ void ProcessorParseDelimiterNativeUnittest::TestAllowingShortenedFields() {
                     "content" : "value1"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]
@@ -148,6 +150,7 @@ void ProcessorParseDelimiterNativeUnittest::TestAllowingShortenedFields() {
 012@@34"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]
@@ -271,6 +274,7 @@ void ProcessorParseDelimiterNativeUnittest::TestAllowingShortenedFields() {
 012@@34"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]
@@ -417,6 +421,7 @@ void ProcessorParseDelimiterNativeUnittest::TestExtend() {
 012@@345@@1@@2@@3"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]
@@ -544,6 +549,7 @@ void ProcessorParseDelimiterNativeUnittest::TestExtend() {
 012@@345@@1@@2@@3"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]
@@ -674,6 +680,7 @@ void ProcessorParseDelimiterNativeUnittest::TestMultipleLines() {
 012@@345"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]
@@ -797,6 +804,7 @@ void ProcessorParseDelimiterNativeUnittest::TestMultipleLines() {
 012@@345@@678"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]
@@ -919,6 +927,7 @@ void ProcessorParseDelimiterNativeUnittest::TestMultipleLines() {
 012@@345@@678"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]
@@ -1048,6 +1057,7 @@ void ProcessorParseDelimiterNativeUnittest::TestMultipleLinesWithProcessorMergeM
 012@@345"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]
@@ -1178,6 +1188,7 @@ void ProcessorParseDelimiterNativeUnittest::TestMultipleLinesWithProcessorMergeM
 012@@345@@678"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]
@@ -1307,6 +1318,7 @@ void ProcessorParseDelimiterNativeUnittest::TestMultipleLinesWithProcessorMergeM
 012@@345@@678"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]
@@ -1456,6 +1468,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessWholeLine() {
                     "content" : "2013-10-31 21:03:49,POST,PutData?Category=YunOsAccountOpLog,0.024"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             },
             {
@@ -1464,6 +1477,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessWholeLine() {
                     "content" : "2013-10-31 21:04:49,POST,PutData?Category=YunOsAccountOpLog,0.024"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]
@@ -1523,6 +1537,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessQuote() {
         2023-12-25 1|zdfvzdfv zfdv|zfdvzdfv zfd|fzdvzdfvzdfvz|zfvzfdzv zfdb|zfdvzdfbvzb|zdfvzdfbvzdb|'advfawevaevb|dvzdfvzdbfazdb|zdfvbzdfb '|zdfbvzbszfbsfb"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]
@@ -1675,6 +1690,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessQuote() {
                         "content" : "2013-10-31 21:03:49,POST,'PutData?Category=YunOsAccountOpLog',0.024"
                     },
                     "timestamp" : 12345678901,
+                    "timestampNanosecond": 0,
                     "type" : 1
                 },
                 {
@@ -1683,6 +1699,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessQuote() {
                         "content" : "2013-10-31 21:03:49,POST,'PutData?Category=YunOsAccountOpLog,0.024"
                     },
                     "timestamp" : 12345678901,
+                    "timestampNanosecond": 0,
                     "type" : 1
                 },
                 {
@@ -1691,6 +1708,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessQuote() {
                         "content" : "2013-10-31 21:03:49,POST,'PutData?Category=YunOs'AccountOpLog',0.024"
                     },
                     "timestamp" : 12345678901,
+                    "timestampNanosecond": 0,
                     "type" : 1
                 }
             ]
@@ -1771,6 +1789,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessKeyOverwritten() {
                     "content" : "2013-10-31 21:03:49,POST,'PutData?Category=YunOsAccountOpLog',0.024"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             },
             {
@@ -1779,6 +1798,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessKeyOverwritten() {
                     "content" : "value1"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]
@@ -1850,6 +1870,7 @@ void ProcessorParseDelimiterNativeUnittest::TestUploadRawLog() {
                     "content" : "2013-10-31 21:03:49,POST,'PutData?Category=YunOsAccountOpLog',0.024"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             },
             {
@@ -1858,6 +1879,7 @@ void ProcessorParseDelimiterNativeUnittest::TestUploadRawLog() {
                     "content" : "value1"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]
@@ -1955,6 +1977,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessEventKeepUnmatch() {
                     "content" : "value1"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             },
             {
@@ -1963,6 +1986,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessEventKeepUnmatch() {
                     "content" : "value1"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             },
             {
@@ -1971,6 +1995,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessEventKeepUnmatch() {
                     "content" : "value1"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             },
             {
@@ -1979,6 +2004,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessEventKeepUnmatch() {
                     "content" : "value1"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             },
             {
@@ -1987,6 +2013,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessEventKeepUnmatch() {
                     "content" : "value1"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]
@@ -2095,6 +2122,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessEventDiscardUnmatch() {
                     "content" : "value1"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             },
             {
@@ -2103,6 +2131,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessEventDiscardUnmatch() {
                     "content" : "value1"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             },
             {
@@ -2111,6 +2140,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessEventDiscardUnmatch() {
                     "content" : "value1"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             },
             {
@@ -2119,6 +2149,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessEventDiscardUnmatch() {
                     "content" : "value1"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             },
             {
@@ -2127,6 +2158,7 @@ void ProcessorParseDelimiterNativeUnittest::TestProcessEventDiscardUnmatch() {
                     "content" : "value1"
                 },
                 "timestamp" : 12345678901,
+                "timestampNanosecond": 0,
                 "type" : 1
             }
         ]

--- a/core/unittest/processor/ProcessorParseRegexNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseRegexNativeUnittest.cpp
@@ -210,7 +210,6 @@ void ProcessorParseRegexNativeUnittest::TestProcessRegex() {
                     "rawLog" : "value1\tvalue2"
                 },
                 "timestamp" : 12345678901,
-                "timestampNanosecond" : 0,
                 "type" : 1
             },
             {
@@ -221,7 +220,6 @@ void ProcessorParseRegexNativeUnittest::TestProcessRegex() {
                     "rawLog" : "value3\tvalue4"
                 },
                 "timestamp" : 12345678901,
-                "timestampNanosecond" : 0,
                 "type" : 1
             }
         ]
@@ -288,7 +286,6 @@ void ProcessorParseRegexNativeUnittest::TestProcessRegexRaw() {
                     "rawLog" : "value1"
                 },
                 "timestamp" : 12345678901,
-                "timestampNanosecond" : 0,
                 "type" : 1
             },
             {
@@ -298,7 +295,6 @@ void ProcessorParseRegexNativeUnittest::TestProcessRegexRaw() {
                     "rawLog" : "value3"
                 },
                 "timestamp" : 12345678901,
-                "timestampNanosecond" : 0,
                 "type" : 1
             }
         ]
@@ -366,7 +362,6 @@ void ProcessorParseRegexNativeUnittest::TestProcessRegexContent() {
                     "rawLog" : "value1\tvalue2"
                 },
                 "timestamp" : 12345678901,
-                "timestampNanosecond" : 0,
                 "type" : 1
             },
             {
@@ -377,7 +372,6 @@ void ProcessorParseRegexNativeUnittest::TestProcessRegexContent() {
                     "rawLog" : "value3\tvalue4"
                 },
                 "timestamp" : 12345678901,
-                "timestampNanosecond" : 0,
                 "type" : 1
             }
         ]


### PR DESCRIPTION
- 问题：启用EnableTimestampNanosecond但使用系统时间时，logGroup的time_ns仍然会被赋值0，前端展示会多9个0，后端认为开启纳秒功能进而降低查询性能。

注：本PR只解决C++部分的问题，Golang部分待 @Abingcbc 确认。