### PR TITLE
make inner processors input-dependent resources instead of pipeline-dependent ones

### DIFF
--- a/core/config/Config.h
+++ b/core/config/Config.h
@@ -64,11 +64,11 @@ struct Config {
         return mHasGoFlusher || ShouldNativeFlusherConnectedByGoPipeline();
     }
 
-    bool IsProcessRunnerInvolved() const {
-        // 长期过渡使用，待C++部分的时序聚合能力与Go持平后恢复下面的正式版
-        return !(mHasGoInput && !mHasNativeProcessor);
-        // return !(mHasGoInput && !mHasNativeProcessor && (mHasGoProcessor || (mHasGoFlusher && !mHasNativeFlusher)));
-    }
+    // bool IsProcessRunnerInvolved() const {
+    //     // 长期过渡使用，待C++部分的时序聚合能力与Go持平后恢复下面的正式版
+    //     return !(mHasGoInput && !mHasNativeProcessor);
+    //     // return !(mHasGoInput && !mHasNativeProcessor && (mHasGoProcessor || (mHasGoFlusher && !mHasNativeFlusher)));
+    // }
 
     bool HasGoPlugin() const { return mHasGoFlusher || mHasGoProcessor || mHasGoInput; }
 

--- a/core/file_server/FileDiscoveryOptions.cpp
+++ b/core/file_server/FileDiscoveryOptions.cpp
@@ -659,7 +659,7 @@ bool FileDiscoveryOptions::IsSameContainerInfo(const Json::Value& paramsJSON, co
 
     if (!paramsJSON.isMember("AllCmd")) {
         ContainerInfo containerInfo;
-        std::string errorMsg;
+        string errorMsg;
         if (!ContainerInfo::ParseByJSONObj(paramsJSON, containerInfo, errorMsg)) {
             LOG_ERROR(sLogger, ("invalid container info update param", errorMsg)("action", "ignore current cmd"));
             return true;
@@ -678,7 +678,7 @@ bool FileDiscoveryOptions::IsSameContainerInfo(const Json::Value& paramsJSON, co
 
     // check all
     unordered_map<string, ContainerInfo> allPathMap;
-    std::string errorMsg;
+    string errorMsg;
     if (!ContainerInfo::ParseAllByJSONObj(paramsJSON["AllCmd"], allPathMap, errorMsg)) {
         LOG_ERROR(sLogger, ("invalid container info update param", errorMsg)("action", "ignore current cmd"));
         return true;
@@ -713,7 +713,7 @@ bool FileDiscoveryOptions::UpdateContainerInfo(const Json::Value& paramsJSON, co
 
     if (!paramsJSON.isMember("AllCmd")) {
         ContainerInfo containerInfo;
-        std::string errorMsg;
+        string errorMsg;
         if (!ContainerInfo::ParseByJSONObj(paramsJSON, containerInfo, errorMsg)) {
             LOG_ERROR(sLogger, ("invalid container info update param", errorMsg)("action", "ignore current cmd"));
             return false;
@@ -735,7 +735,7 @@ bool FileDiscoveryOptions::UpdateContainerInfo(const Json::Value& paramsJSON, co
     }
 
     unordered_map<string, ContainerInfo> allPathMap;
-    std::string errorMsg;
+    string errorMsg;
     if (!ContainerInfo::ParseAllByJSONObj(paramsJSON["AllCmd"], allPathMap, errorMsg)) {
         LOG_ERROR(sLogger,
                   ("invalid all docker container params",
@@ -758,7 +758,7 @@ bool FileDiscoveryOptions::DeleteContainerInfo(const Json::Value& paramsJSON) {
         return false;
 
     ContainerInfo containerInfo;
-    std::string errorMsg;
+    string errorMsg;
     if (!ContainerInfo::ParseByJSONObj(paramsJSON, containerInfo, errorMsg)) {
         LOG_ERROR(sLogger, ("invalid container info update param", errorMsg)("action", "ignore current cmd"));
         return false;

--- a/core/file_server/MultilineOptions.cpp
+++ b/core/file_server/MultilineOptions.cpp
@@ -218,17 +218,16 @@ bool MultilineOptions::ParseRegex(const string& pattern, shared_ptr<boost::regex
     return true;
 }
 
-const std::string&
-UnmatchedContentTreatmentToString(MultilineOptions::UnmatchedContentTreatment unmatchedContentTreatment) {
+const string& UnmatchedContentTreatmentToString(MultilineOptions::UnmatchedContentTreatment unmatchedContentTreatment) {
     switch (unmatchedContentTreatment) {
         case MultilineOptions::UnmatchedContentTreatment::DISCARD:
-            static std::string discardStr = "discard";
+            static string discardStr = "discard";
             return discardStr;
         case MultilineOptions::UnmatchedContentTreatment::SINGLE_LINE:
-            static std::string singleLine = "single line";
+            static string singleLine = "single line";
             return singleLine;
         default:
-            static std::string unkonwn = "";
+            static string unkonwn = "";
             return unkonwn;
     }
 }

--- a/core/input/InputContainerStdio.cpp
+++ b/core/input/InputContainerStdio.cpp
@@ -20,6 +20,11 @@
 #include "common/ParamExtractor.h"
 #include "file_server/FileServer.h"
 #include "pipeline/Pipeline.h"
+#include "plugin/PluginRegistry.h"
+#include "processor/inner/ProcessorMergeMultilineLogNative.h"
+#include "processor/inner/ProcessorParseContainerLogNative.h"
+#include "processor/inner/ProcessorSplitLogStringNative.h"
+#include "processor/inner/ProcessorTagNative.h"
 
 using namespace std;
 
@@ -27,7 +32,7 @@ namespace logtail {
 
 const string InputContainerStdio::sName = "input_container_stdio";
 
-bool InputContainerStdio::Init(const Json::Value& config, Json::Value& optionalGoPipeline) {
+bool InputContainerStdio::Init(const Json::Value& config, uint32_t& pluginIdx, Json::Value& optionalGoPipeline) {
     string errorMsg;
     if (!AppConfig::GetInstance()->IsPurageContainerMode()) {
         PARAM_ERROR_RETURN(mContext->GetLogger(),
@@ -153,7 +158,7 @@ bool InputContainerStdio::Init(const Json::Value& config, Json::Value& optionalG
                                        GetContext().GetRegion());
     }
 
-    return true;
+    return CreateInnerProcessors(pluginIdx);
 }
 
 std::string InputContainerStdio::TryGetRealPath(const std::string& path) {
@@ -207,8 +212,8 @@ std::string InputContainerStdio::TryGetRealPath(const std::string& path) {
 }
 
 bool InputContainerStdio::DeduceAndSetContainerBaseDir(ContainerInfo& containerInfo,
-                                                     const PipelineContext* ctx,
-                                                     const FileDiscoveryOptions*) {
+                                                       const PipelineContext* ctx,
+                                                       const FileDiscoveryOptions*) {
     if (!containerInfo.mRealBaseDir.empty()) {
         return true;
     }
@@ -257,6 +262,84 @@ bool InputContainerStdio::Stop(bool isPipelineRemoving) {
     FileServer::GetInstance()->RemoveFileDiscoveryConfig(mContext->GetConfigName());
     FileServer::GetInstance()->RemoveFileReaderConfig(mContext->GetConfigName());
     FileServer::GetInstance()->RemoveMultilineConfig(mContext->GetConfigName());
+    return true;
+}
+
+bool InputContainerStdio::CreateInnerProcessors(uint32_t& pluginIdx) {
+    unique_ptr<ProcessorInstance> processor;
+    // ProcessorSplitLogStringNative
+    {
+        Json::Value detail;
+        processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorSplitLogStringNative::sName,
+                                                                   to_string(++pluginIdx));
+        detail["SplitChar"] = Json::Value('\n');
+        if (!processor->Init(detail, *mContext)) {
+            return false;
+        }
+        mInnerProcessors.emplace_back(std::move(processor));
+    }
+    // ProcessorParseContainerLogNative
+    {
+        Json::Value detail;
+        processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorParseContainerLogNative::sName,
+                                                                   to_string(++pluginIdx));
+        detail["IgnoringStdout"] = Json::Value(mIgnoringStdout);
+        detail["IgnoringStderr"] = Json::Value(mIgnoringStderr);
+        detail["KeepingSourceWhenParseFail"] = Json::Value(mKeepingSourceWhenParseFail);
+        detail["IgnoreParseWarning"] = Json::Value(mIgnoreParseWarning);
+        if (!processor->Init(detail, *mContext)) {
+            return false;
+        }
+        mInnerProcessors.emplace_back(std::move(processor));
+    }
+    // ProcessorMergeMultilineLogNative
+    {
+        Json::Value detail;
+        processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorMergeMultilineLogNative::sName,
+                                                                   to_string(++pluginIdx));
+        detail["MergeType"] = Json::Value("flag");
+        if (!processor->Init(detail, *mContext)) {
+            return false;
+        }
+        mInnerProcessors.emplace_back(std::move(processor));
+    }
+    if (mMultiline.IsMultiline()) {
+        Json::Value detail;
+        if (mContext->IsFirstProcessorJson() || mMultiline.mMode == MultilineOptions::Mode::JSON) {
+            mContext->SetRequiringJsonReaderFlag(true);
+            processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorSplitLogStringNative::sName,
+                                                                       to_string(++pluginIdx));
+            detail["SplitChar"] = Json::Value('\0');
+        } else {
+            processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorMergeMultilineLogNative::sName,
+                                                                       to_string(++pluginIdx));
+            detail["Mode"] = Json::Value("custom");
+            detail["MergeType"] = Json::Value("regex");
+            detail["StartPattern"] = Json::Value(mMultiline.mStartPattern);
+            detail["ContinuePattern"] = Json::Value(mMultiline.mContinuePattern);
+            detail["EndPattern"] = Json::Value(mMultiline.mEndPattern);
+            detail["IgnoringUnmatchWarning"] = Json::Value(mMultiline.mIgnoringUnmatchWarning);
+            if (mMultiline.mUnmatchedContentTreatment == MultilineOptions::UnmatchedContentTreatment::DISCARD) {
+                detail["UnmatchedContentTreatment"] = Json::Value("discard");
+            } else if (mMultiline.mUnmatchedContentTreatment
+                       == MultilineOptions::UnmatchedContentTreatment::SINGLE_LINE) {
+                detail["UnmatchedContentTreatment"] = Json::Value("single_line");
+            }
+        }
+        if (!processor->Init(detail, *mContext)) {
+            return false;
+        }
+        mInnerProcessors.emplace_back(std::move(processor));
+    }
+    {
+        Json::Value detail;
+        processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorTagNative::sName, to_string(++pluginIdx));
+        if (!processor->Init(detail, *mContext)) {
+            // should not happen
+            return false;
+        }
+        mInnerProcessors.emplace_back(std::move(processor));
+    }
     return true;
 }
 

--- a/core/input/InputContainerStdio.h
+++ b/core/input/InputContainerStdio.h
@@ -35,7 +35,7 @@ public:
     DeduceAndSetContainerBaseDir(ContainerInfo& containerInfo, const PipelineContext*, const FileDiscoveryOptions*);
 
     const std::string& Name() const override { return sName; }
-    bool Init(const Json::Value& config, Json::Value& optionalGoPipeline) override;
+    bool Init(const Json::Value& config, uint32_t& pluginIdx, Json::Value& optionalGoPipeline) override;
     bool Start() override;
     bool Stop(bool isPipelineRemoving) override;
 
@@ -49,6 +49,8 @@ public:
 
 private:
     FileDiscoveryOptions mFileDiscovery;
+
+    bool CreateInnerProcessors(uint32_t& pluginIdx);
 
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class InputContainerStdioUnittest;

--- a/core/input/InputFile.cpp
+++ b/core/input/InputFile.cpp
@@ -25,6 +25,10 @@
 #include "file_server/FileServer.h"
 #include "pipeline/Pipeline.h"
 #include "pipeline/PipelineManager.h"
+#include "plugin/PluginRegistry.h"
+#include "processor/inner/ProcessorSplitLogStringNative.h"
+#include "processor/inner/ProcessorSplitMultilineLogStringNative.h"
+#include "processor/inner/ProcessorTagNative.h"
 
 using namespace std;
 
@@ -35,11 +39,18 @@ namespace logtail {
 
 const string InputFile::sName = "input_file";
 
+bool InputFile::DeduceAndSetContainerBaseDir(ContainerInfo& containerInfo,
+                                             const PipelineContext*,
+                                             const FileDiscoveryOptions* fileDiscovery) {
+    std::string logPath = GetLogPath(fileDiscovery);
+    return SetContainerBaseDir(containerInfo, logPath);
+}
+
 InputFile::InputFile()
     : mMaxCheckpointDirSearchDepth(static_cast<uint32_t>(INT32_FLAG(search_checkpoint_default_dir_depth))) {
 }
 
-bool InputFile::Init(const Json::Value& config, Json::Value& optionalGoPipeline) {
+bool InputFile::Init(const Json::Value& config, uint32_t& pluginIdx, Json::Value& optionalGoPipeline) {
     string errorMsg;
 
     if (!mFileDiscovery.Init(config, *mContext, sName)) {
@@ -67,12 +78,12 @@ bool InputFile::Init(const Json::Value& config, Json::Value& optionalGoPipeline)
                            mContext->GetLogstoreName(),
                            mContext->GetRegion());
     }
-
     if (mEnableContainerDiscovery) {
-        mFileDiscovery.SetEnableContainerDiscoveryFlag(true);
         if (!mContainerDiscovery.Init(config, *mContext, sName)) {
             return false;
         }
+        mFileDiscovery.SetEnableContainerDiscoveryFlag(true);
+        mFileDiscovery.SetDeduceAndSetContainerBaseDirFunc(DeduceAndSetContainerBaseDir);
         mContainerDiscovery.GenerateContainerMetaFetchingGoPipeline(optionalGoPipeline, &mFileDiscovery);
     }
 
@@ -83,7 +94,6 @@ bool InputFile::Init(const Json::Value& config, Json::Value& optionalGoPipeline)
 
     // 过渡使用
     mFileDiscovery.SetTailingAllMatchedFiles(mFileReader.mTailingAllMatchedFiles);
-    mFileDiscovery.SetDeduceAndSetContainerBaseDirFunc(DeduceAndSetContainerBaseDir);
 
     // Multiline
     const char* key = "Multiline";
@@ -144,6 +154,77 @@ bool InputFile::Init(const Json::Value& config, Json::Value& optionalGoPipeline)
         mExactlyOnceConcurrency = exactlyOnceConcurrency;
     }
 
+    return CreateInnerProcessors(pluginIdx);
+}
+
+bool InputFile::Start() {
+    if (mEnableContainerDiscovery) {
+        mFileDiscovery.SetContainerInfo(
+            FileServer::GetInstance()->GetAndRemoveContainerInfo(mContext->GetPipeline().Name()));
+    }
+    FileServer::GetInstance()->AddFileDiscoveryConfig(mContext->GetConfigName(), &mFileDiscovery, mContext);
+    FileServer::GetInstance()->AddFileReaderConfig(mContext->GetConfigName(), &mFileReader, mContext);
+    FileServer::GetInstance()->AddMultilineConfig(mContext->GetConfigName(), &mMultiline, mContext);
+    FileServer::GetInstance()->AddExactlyOnceConcurrency(mContext->GetConfigName(), mExactlyOnceConcurrency);
+    return true;
+}
+
+bool InputFile::Stop(bool isPipelineRemoving) {
+    if (!isPipelineRemoving && mEnableContainerDiscovery) {
+        FileServer::GetInstance()->SaveContainerInfo(mContext->GetPipeline().Name(), mFileDiscovery.GetContainerInfo());
+    }
+    FileServer::GetInstance()->RemoveFileDiscoveryConfig(mContext->GetConfigName());
+    FileServer::GetInstance()->RemoveFileReaderConfig(mContext->GetConfigName());
+    FileServer::GetInstance()->RemoveMultilineConfig(mContext->GetConfigName());
+    FileServer::GetInstance()->RemoveExactlyOnceConcurrency(mContext->GetConfigName());
+    return true;
+}
+
+bool InputFile::CreateInnerProcessors(uint32_t& pluginIdx) {
+    unique_ptr<ProcessorInstance> processor;
+    {
+        Json::Value detail;
+        if (mContext->IsFirstProcessorJson() || mMultiline.mMode == MultilineOptions::Mode::JSON) {
+            mContext->SetRequiringJsonReaderFlag(true);
+            processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorSplitLogStringNative::sName,
+                                                                       to_string(++pluginIdx));
+            detail["SplitChar"] = Json::Value('\0');
+            detail["AppendingLogPositionMeta"] = Json::Value(mFileReader.mAppendingLogPositionMeta);
+        } else if (mMultiline.IsMultiline()) {
+            processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorSplitMultilineLogStringNative::sName,
+                                                                       to_string(++pluginIdx));
+            detail["Mode"] = Json::Value("custom");
+            detail["StartPattern"] = Json::Value(mMultiline.mStartPattern);
+            detail["ContinuePattern"] = Json::Value(mMultiline.mContinuePattern);
+            detail["EndPattern"] = Json::Value(mMultiline.mEndPattern);
+            detail["AppendingLogPositionMeta"] = Json::Value(mFileReader.mAppendingLogPositionMeta);
+            detail["IgnoringUnmatchWarning"] = Json::Value(mMultiline.mIgnoringUnmatchWarning);
+            if (mMultiline.mUnmatchedContentTreatment == MultilineOptions::UnmatchedContentTreatment::DISCARD) {
+                detail["UnmatchedContentTreatment"] = Json::Value("discard");
+            } else if (mMultiline.mUnmatchedContentTreatment
+                       == MultilineOptions::UnmatchedContentTreatment::SINGLE_LINE) {
+                detail["UnmatchedContentTreatment"] = Json::Value("single_line");
+            }
+        } else {
+            processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorSplitLogStringNative::sName,
+                                                                       to_string(++pluginIdx));
+            detail["AppendingLogPositionMeta"] = Json::Value(mFileReader.mAppendingLogPositionMeta);
+        }
+        if (!processor->Init(detail, *mContext)) {
+            // should not happen
+            return false;
+        }
+        mInnerProcessors.emplace_back(std::move(processor));
+    }
+    {
+        Json::Value detail;
+        processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorTagNative::sName, to_string(++pluginIdx));
+        if (!processor->Init(detail, *mContext)) {
+            // should not happen
+            return false;
+        }
+        mInnerProcessors.emplace_back(std::move(processor));
+    }
     return true;
 }
 
@@ -189,36 +270,6 @@ bool InputFile::SetContainerBaseDir(ContainerInfo& containerInfo, const std::str
         containerInfo.mRealBaseDir = STRING_FLAG(default_container_host_path) + containerInfo.mUpperDir + logPath;
     }
     LOG_INFO(sLogger, ("set container base dir", containerInfo.mRealBaseDir)("container id", containerInfo.mID));
-    return true;
-}
-
-bool InputFile::DeduceAndSetContainerBaseDir(ContainerInfo& containerInfo,
-                                             const PipelineContext*,
-                                             const FileDiscoveryOptions* fileDiscovery) {
-    std::string logPath = GetLogPath(fileDiscovery);
-    return SetContainerBaseDir(containerInfo, logPath);
-}
-
-bool InputFile::Start() {
-    if (mEnableContainerDiscovery) {
-        mFileDiscovery.SetContainerInfo(
-            FileServer::GetInstance()->GetAndRemoveContainerInfo(mContext->GetPipeline().Name()));
-    }
-    FileServer::GetInstance()->AddFileDiscoveryConfig(mContext->GetConfigName(), &mFileDiscovery, mContext);
-    FileServer::GetInstance()->AddFileReaderConfig(mContext->GetConfigName(), &mFileReader, mContext);
-    FileServer::GetInstance()->AddMultilineConfig(mContext->GetConfigName(), &mMultiline, mContext);
-    FileServer::GetInstance()->AddExactlyOnceConcurrency(mContext->GetConfigName(), mExactlyOnceConcurrency);
-    return true;
-}
-
-bool InputFile::Stop(bool isPipelineRemoving) {
-    if (!isPipelineRemoving && mEnableContainerDiscovery) {
-        FileServer::GetInstance()->SaveContainerInfo(mContext->GetPipeline().Name(), mFileDiscovery.GetContainerInfo());
-    }
-    FileServer::GetInstance()->RemoveFileDiscoveryConfig(mContext->GetConfigName());
-    FileServer::GetInstance()->RemoveFileReaderConfig(mContext->GetConfigName());
-    FileServer::GetInstance()->RemoveMultilineConfig(mContext->GetConfigName());
-    FileServer::GetInstance()->RemoveExactlyOnceConcurrency(mContext->GetConfigName());
     return true;
 }
 

--- a/core/input/InputFile.cpp
+++ b/core/input/InputFile.cpp
@@ -42,7 +42,7 @@ const string InputFile::sName = "input_file";
 bool InputFile::DeduceAndSetContainerBaseDir(ContainerInfo& containerInfo,
                                              const PipelineContext*,
                                              const FileDiscoveryOptions* fileDiscovery) {
-    std::string logPath = GetLogPath(fileDiscovery);
+    string logPath = GetLogPath(fileDiscovery);
     return SetContainerBaseDir(containerInfo, logPath);
 }
 
@@ -228,8 +228,8 @@ bool InputFile::CreateInnerProcessors(uint32_t& pluginIdx) {
     return true;
 }
 
-std::string InputFile::GetLogPath(const FileDiscoveryOptions* fileDiscovery) {
-    std::string logPath;
+string InputFile::GetLogPath(const FileDiscoveryOptions* fileDiscovery) {
+    string logPath;
     if (!fileDiscovery->GetWildcardPaths().empty()) {
         logPath = fileDiscovery->GetWildcardPaths()[0];
     } else {
@@ -238,7 +238,7 @@ std::string InputFile::GetLogPath(const FileDiscoveryOptions* fileDiscovery) {
     return logPath;
 }
 
-bool InputFile::SetContainerBaseDir(ContainerInfo& containerInfo, const std::string& logPath) {
+bool InputFile::SetContainerBaseDir(ContainerInfo& containerInfo, const string& logPath) {
     if (!containerInfo.mRealBaseDir.empty()) {
         return true;
     }

--- a/core/input/InputFile.h
+++ b/core/input/InputFile.h
@@ -30,15 +30,13 @@ class InputFile : public Input {
 public:
     static const std::string sName;
 
-    static bool SetContainerBaseDir(ContainerInfo& containerInfo, const std::string& logPath);
-    static std::string GetLogPath(const FileDiscoveryOptions* fileDiscovery);
     static bool
     DeduceAndSetContainerBaseDir(ContainerInfo& containerInfo, const PipelineContext*, const FileDiscoveryOptions*);
 
     InputFile();
 
     const std::string& Name() const override { return sName; }
-    bool Init(const Json::Value& config, Json::Value& optionalGoPipeline) override;
+    bool Init(const Json::Value& config, uint32_t& pluginIdx, Json::Value& optionalGoPipeline) override;
     bool Start() override;
     bool Stop(bool isPipelineRemoving) override;
 
@@ -52,6 +50,13 @@ public:
     uint32_t mExactlyOnceConcurrency = 0;
 
 private:
+    bool CreateInnerProcessors(uint32_t& pluginIdx);
+    static bool SetContainerBaseDir(ContainerInfo& containerInfo, const std::string& logPath);
+    static std::string GetLogPath(const FileDiscoveryOptions* fileDiscovery);
+
+#ifdef APSARA_UNIT_TEST_MAIN
+    friend class InputFileUnittest;
+#endif
 };
 
 } // namespace logtail

--- a/core/input/InputObserverNetwork.cpp
+++ b/core/input/InputObserverNetwork.cpp
@@ -22,7 +22,7 @@ namespace logtail {
 
 const std::string InputObserverNetwork::sName = "input_observer_network";
 
-bool InputObserverNetwork::Init(const Json::Value& config, Json::Value& optionalGoPipeline) {
+bool InputObserverNetwork::Init(const Json::Value& config, uint32_t& pluginIdx, Json::Value& optionalGoPipeline) {
     mDetail = config.toStyledString();
     return true;
 }

--- a/core/input/InputObserverNetwork.h
+++ b/core/input/InputObserverNetwork.h
@@ -27,7 +27,7 @@ public:
     static const std::string sName;
 
     const std::string& Name() const override { return sName; }
-    bool Init(const Json::Value& config, Json::Value& optionalGoPipeline) override;
+    bool Init(const Json::Value& config, uint32_t& pluginIdx, Json::Value& optionalGoPipeline) override;
     bool Start() override;
     bool Stop(bool isPipelineRemoving) override;
 

--- a/core/pipeline/Pipeline.cpp
+++ b/core/pipeline/Pipeline.cpp
@@ -25,17 +25,9 @@
 #include "go_pipeline/LogtailPlugin.h"
 #include "input/InputFeedbackInterfaceRegistry.h"
 #include "plugin/PluginRegistry.h"
-#include "processor/inner/ProcessorMergeMultilineLogNative.h"
 #include "processor/ProcessorParseApsaraNative.h"
-#include "processor/inner/ProcessorParseContainerLogNative.h"
-#include "processor/inner/ProcessorSplitLogStringNative.h"
-#include "processor/inner/ProcessorSplitMultilineLogStringNative.h"
-#include "processor/inner/ProcessorTagNative.h"
 #include "queue/ProcessQueueManager.h"
 #include "queue/QueueKeyManager.h"
-
-// for special treatment
-#include "file_server/MultilineOptions.h"
 
 DECLARE_FLAG_INT32(default_plugin_log_queue_size);
 
@@ -52,129 +44,19 @@ void AddExtendedGlobalParamToGoPipeline(const Json::Value& extendedParams, Json:
     }
 }
 
-bool Pipeline::handleInputFileProcessor(const logtail::InputFile* inputFile,
-                                        int16_t& pluginIndex,
-                                        const Config& config) {
-    unique_ptr<ProcessorInstance> processor;
-    Json::Value detail;
-    if (config.mIsFirstProcessorJson || inputFile->mMultiline.mMode == MultilineOptions::Mode::JSON) {
-        mContext.SetRequiringJsonReaderFlag(true);
-        processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorSplitLogStringNative::sName,
-                                                                   to_string(++pluginIndex));
-        detail["SplitChar"] = Json::Value('\0');
-        detail["AppendingLogPositionMeta"] = Json::Value(inputFile->mFileReader.mAppendingLogPositionMeta);
-    } else if (inputFile->mMultiline.IsMultiline()) {
-        processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorSplitMultilineLogStringNative::sName,
-                                                                   to_string(++pluginIndex));
-        detail["Mode"] = Json::Value("custom");
-        detail["StartPattern"] = Json::Value(inputFile->mMultiline.mStartPattern);
-        detail["ContinuePattern"] = Json::Value(inputFile->mMultiline.mContinuePattern);
-        detail["EndPattern"] = Json::Value(inputFile->mMultiline.mEndPattern);
-        detail["AppendingLogPositionMeta"] = Json::Value(inputFile->mFileReader.mAppendingLogPositionMeta);
-        detail["IgnoringUnmatchWarning"] = Json::Value(inputFile->mMultiline.mIgnoringUnmatchWarning);
-        if (inputFile->mMultiline.mUnmatchedContentTreatment == MultilineOptions::UnmatchedContentTreatment::DISCARD) {
-            detail["UnmatchedContentTreatment"] = Json::Value("discard");
-        } else if (inputFile->mMultiline.mUnmatchedContentTreatment
-                   == MultilineOptions::UnmatchedContentTreatment::SINGLE_LINE) {
-            detail["UnmatchedContentTreatment"] = Json::Value("single_line");
-        }
-    } else {
-        processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorSplitLogStringNative::sName,
-                                                                   to_string(++pluginIndex));
-        detail["AppendingLogPositionMeta"] = Json::Value(inputFile->mFileReader.mAppendingLogPositionMeta);
-    }
-    if (!processor->Init(detail, mContext)) {
-        // should not happen
-        return false;
-    }
-    mProcessorLine.emplace_back(std::move(processor));
-    return true;
-}
-
-bool Pipeline::handleInputContainerStdioProcessor(const logtail::InputContainerStdio* inputContainerStdio,
-                                                int16_t& pluginIndex,
-                                                const Config& config) {
-    unique_ptr<ProcessorInstance> processor;
-    // ProcessorSplitLogStringNative
-    {
-        Json::Value detail;
-        processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorSplitLogStringNative::sName,
-                                                                   to_string(++pluginIndex));
-        detail["SplitChar"] = Json::Value('\n');
-        if (!processor->Init(detail, mContext)) {
-            return false;
-        }
-        mProcessorLine.emplace_back(std::move(processor));
-    }
-    // ProcessorParseContainerLogNative
-    {
-        Json::Value detail;
-        processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorParseContainerLogNative::sName,
-                                                                   to_string(++pluginIndex));
-        detail["IgnoringStdout"] = Json::Value(inputContainerStdio->mIgnoringStdout);
-        detail["IgnoringStderr"] = Json::Value(inputContainerStdio->mIgnoringStderr);
-        detail["KeepingSourceWhenParseFail"] = Json::Value(inputContainerStdio->mKeepingSourceWhenParseFail);
-        detail["IgnoreParseWarning"] = Json::Value(inputContainerStdio->mIgnoreParseWarning);
-        if (!processor->Init(detail, mContext)) {
-            return false;
-        }
-        mProcessorLine.emplace_back(std::move(processor));
-    }
-    // ProcessorMergeMultilineLogNative
-    {
-        Json::Value detail;
-        processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorMergeMultilineLogNative::sName,
-                                                                   to_string(++pluginIndex));
-        detail["MergeType"] = Json::Value("flag");
-        if (!processor->Init(detail, mContext)) {
-            return false;
-        }
-        mProcessorLine.emplace_back(std::move(processor));
-    }
-    if (inputContainerStdio->mMultiline.IsMultiline()) {
-        Json::Value detail;
-        if (config.mIsFirstProcessorJson || inputContainerStdio->mMultiline.mMode == MultilineOptions::Mode::JSON) {
-            mContext.SetRequiringJsonReaderFlag(true);
-            processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorSplitLogStringNative::sName,
-                                                                       to_string(++pluginIndex));
-            detail["SplitChar"] = Json::Value('\0');
-        } else {
-            processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorMergeMultilineLogNative::sName,
-                                                                       to_string(++pluginIndex));
-            detail["Mode"] = Json::Value("custom");
-            detail["MergeType"] = Json::Value("regex");
-            detail["StartPattern"] = Json::Value(inputContainerStdio->mMultiline.mStartPattern);
-            detail["ContinuePattern"] = Json::Value(inputContainerStdio->mMultiline.mContinuePattern);
-            detail["EndPattern"] = Json::Value(inputContainerStdio->mMultiline.mEndPattern);
-            detail["IgnoringUnmatchWarning"] = Json::Value(inputContainerStdio->mMultiline.mIgnoringUnmatchWarning);
-            if (inputContainerStdio->mMultiline.mUnmatchedContentTreatment
-                == MultilineOptions::UnmatchedContentTreatment::DISCARD) {
-                detail["UnmatchedContentTreatment"] = Json::Value("discard");
-            } else if (inputContainerStdio->mMultiline.mUnmatchedContentTreatment
-                       == MultilineOptions::UnmatchedContentTreatment::SINGLE_LINE) {
-                detail["UnmatchedContentTreatment"] = Json::Value("single_line");
-            }
-        }
-        if (!processor->Init(detail, mContext)) {
-            return false;
-        }
-        mProcessorLine.emplace_back(std::move(processor));
-    }
-    return true;
-}
-
 bool Pipeline::Init(Config&& config) {
     mName = config.mName;
     mConfig = std::move(config.mDetail);
     mContext.SetConfigName(mName);
     mContext.SetCreateTime(config.mCreateTime);
     mContext.SetPipeline(*this);
+    mContext.SetIsFirstProcessorJsonFlag(config.mIsFirstProcessorJson);
 
     // for special treatment below
     const InputFile* inputFile = nullptr;
     const InputContainerStdio* inputContainerStdio = nullptr;
     bool hasFlusherSLS = false;
-    
+
 #ifdef __ENTERPRISE__
     // to send alarm before flusherSLS is built, a temporary object is made, which will be overriden shortly after.
     unique_ptr<FlusherSLS> SLSTmp = unique_ptr<FlusherSLS>(new FlusherSLS());
@@ -184,13 +66,14 @@ bool Pipeline::Init(Config&& config) {
     mContext.SetSLSInfo(SLSTmp.get());
 #endif
 
-    int16_t pluginIndex = 0;
-    for (auto detail : config.mInputs) {
-        string name = (*detail)["Type"].asString();
+    uint32_t pluginIndex = 0;
+    for (size_t i = 0; i < config.mInputs.size(); ++i) {
+        const Json::Value& detail = *config.mInputs[i];
+        string name = detail["Type"].asString();
         unique_ptr<InputInstance> input = PluginRegistry::GetInstance()->CreateInput(name, to_string(++pluginIndex));
         if (input) {
             Json::Value optionalGoPipeline;
-            if (!input->Init(*detail, mContext, optionalGoPipeline)) {
+            if (!input->Init(detail, mContext, pluginIndex, i, optionalGoPipeline)) {
                 return false;
             }
             mInputs.emplace_back(std::move(input));
@@ -204,28 +87,9 @@ bool Pipeline::Init(Config&& config) {
                 inputContainerStdio = static_cast<const InputContainerStdio*>(mInputs[0]->GetPlugin());
             }
         } else {
-            AddPluginToGoPipeline(*detail, "inputs", mGoPipelineWithInput);
+            AddPluginToGoPipeline(detail, "inputs", mGoPipelineWithInput);
         }
         ++mPluginCntMap["inputs"][name];
-    }
-
-    if (config.IsProcessRunnerInvolved()) {
-        Json::Value detail;
-        unique_ptr<ProcessorInstance> processor
-            = PluginRegistry::GetInstance()->CreateProcessor(ProcessorTagNative::sName, to_string(++pluginIndex));
-        if (!processor->Init(detail, mContext)) {
-            // should not happen
-            return false;
-        }
-        mProcessorLine.emplace_back(std::move(processor));
-    }
-
-    // add log split processor for input_file
-    if (inputFile && !handleInputFileProcessor(inputFile, pluginIndex, config)) {
-        return false;
-    }
-    if (inputContainerStdio && !handleInputContainerStdioProcessor(inputContainerStdio, pluginIndex, config)) {
-        return false;
     }
 
     for (size_t i = 0; i < config.mProcessors.size(); ++i) {
@@ -425,7 +289,10 @@ void Pipeline::Start() {
     LOG_INFO(sLogger, ("pipeline start", "succeeded")("config", mName));
 }
 
-void Pipeline::Process(vector<PipelineEventGroup>& logGroupList) {
+void Pipeline::Process(vector<PipelineEventGroup>& logGroupList, size_t inputIndex) {
+    for (auto& p : mInputs[inputIndex]->GetInnerProcessors()) {
+        p->Process(logGroupList);
+    }
     for (auto& p : mProcessorLine) {
         p->Process(logGroupList);
     }

--- a/core/pipeline/Pipeline.h
+++ b/core/pipeline/Pipeline.h
@@ -39,7 +39,7 @@ public:
     // copy/move control functions are deleted because of mContext
     bool Init(Config&& config);
     void Start();
-    void Process(std::vector<PipelineEventGroup>& logGroupList);
+    void Process(std::vector<PipelineEventGroup>& logGroupList, size_t inputIndex);
     void Stop(bool isRemoving);
     void RemoveProcessQueue() const;
 
@@ -57,10 +57,6 @@ public:
     const std::vector<std::unique_ptr<InputInstance>>& GetInputs() const { return mInputs; }
 
 private:
-    bool handleInputFileProcessor(const InputFile* inputFile, int16_t& pluginIndex, const Config& config);
-    bool handleInputContainerStdioProcessor(const InputContainerStdio* inputContainerStdio,
-                                          int16_t& pluginIndex,
-                                          const Config& config);
     void MergeGoPipeline(const Json::Value& src, Json::Value& dst);
     void AddPluginToGoPipeline(const Json::Value& plugin, const std::string& module, Json::Value& dst);
     void CopyNativeGlobalParamToGoPipeline(Json::Value& root);

--- a/core/pipeline/PipelineContext.h
+++ b/core/pipeline/PipelineContext.h
@@ -81,6 +81,8 @@ public:
     void SetRequiringJsonReaderFlag(bool flag) { mRequiringJsonReader = flag; }
     bool IsFirstProcessorApsara() const { return mIsFirstProcessorApsara; }
     void SetIsFirstProcessorApsaraFlag(bool flag) { mIsFirstProcessorApsara = flag; }
+    bool IsFirstProcessorJson() const { return mIsFirstProcessorJson; }
+    void SetIsFirstProcessorJsonFlag(bool flag) { mIsFirstProcessorJson = flag; }
 
     ProcessProfile& GetProcessProfile() const { return mProcessProfile; }
     // LogFileProfiler& GetProfiler() { return *mProfiler; }
@@ -99,6 +101,7 @@ private:
     const FlusherSLS* mSLSInfo = nullptr;
     bool mRequiringJsonReader = false;
     bool mIsFirstProcessorApsara = false;
+    bool mIsFirstProcessorJson = false;
 
     mutable ProcessProfile mProcessProfile;
     // LogFileProfiler* mProfiler = LogFileProfiler::GetInstance();

--- a/core/plugin/PluginRegistry.h
+++ b/core/plugin/PluginRegistry.h
@@ -84,7 +84,7 @@ private:
 
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class PluginRegistryUnittest;
-    friend class PipelineUnittest;
+    friend void LoadPluginMock();
 #endif
 };
 

--- a/core/plugin/instance/InputInstance.cpp
+++ b/core/plugin/instance/InputInstance.cpp
@@ -15,10 +15,15 @@
 #include "plugin/instance/InputInstance.h"
 
 namespace logtail {
-bool InputInstance::Init(const Json::Value& config, PipelineContext& context, Json::Value& optionalGoPipeline) {
+bool InputInstance::Init(const Json::Value& config,
+                         PipelineContext& context,
+                         uint32_t& pluginIdx,
+                         size_t inputIdx,
+                         Json::Value& optionalGoPipeline) {
     mPlugin->SetContext(context);
     mPlugin->SetMetricsRecordRef(Name(), Id());
-    if (!mPlugin->Init(config, optionalGoPipeline)) {
+    mPlugin->SetInputIndex(inputIdx);
+    if (!mPlugin->Init(config, pluginIdx, optionalGoPipeline)) {
         return false;
     }
     return true;

--- a/core/plugin/instance/InputInstance.h
+++ b/core/plugin/instance/InputInstance.h
@@ -16,13 +16,13 @@
 
 #pragma once
 
-#include <memory>
-
 #include <json/json.h>
 
+#include <memory>
+
+#include "pipeline/PipelineContext.h"
 #include "plugin/instance/PluginInstance.h"
 #include "plugin/interface/Input.h"
-#include "pipeline/PipelineContext.h"
 
 namespace logtail {
 
@@ -32,9 +32,14 @@ public:
 
     const std::string& Name() const override { return mPlugin->Name(); }
 
-    bool Init(const Json::Value& config, PipelineContext& context, Json::Value& optionalGoPipeline);
+    bool Init(const Json::Value& config,
+              PipelineContext& context,
+              uint32_t& pluginIdx,
+              size_t inputIdx,
+              Json::Value& optionalGoPipeline);
     bool Start() { return mPlugin->Start(); }
     bool Stop(bool isPipelineRemoving) { return mPlugin->Stop(isPipelineRemoving); }
+    std::vector<std::unique_ptr<ProcessorInstance>>& GetInnerProcessors() { return mPlugin->GetInnerProcessors(); }
 
     // just for special treatment of exactly once of input_file, should not be used otherwise!
     const Input* GetPlugin() const { return mPlugin.get(); }

--- a/core/plugin/instance/ProcessorInstance.h
+++ b/core/plugin/instance/ProcessorInstance.h
@@ -16,15 +16,15 @@
 
 #pragma once
 
-#include <memory>
-
 #include <json/json.h>
+
+#include <memory>
 
 #include "models/PipelineEventGroup.h"
 #include "monitor/LogtailMetric.h"
+#include "pipeline/PipelineContext.h"
 #include "plugin/instance/PluginInstance.h"
 #include "plugin/interface/Processor.h"
-#include "pipeline/PipelineContext.h"
 
 namespace logtail {
 
@@ -55,6 +55,8 @@ private:
     friend class ProcessorParseDelimiterNativeUnittest;
     friend class ProcessorFilterNativeUnittest;
     friend class ProcessorDesensitizeNativeUnittest;
+    friend class InputFileUnittest;
+    friend class PipelineUnittest;
 #endif
 };
 

--- a/core/plugin/interface/Input.h
+++ b/core/plugin/interface/Input.h
@@ -18,6 +18,10 @@
 
 #include <json/json.h>
 
+#include <memory>
+#include <vector>
+
+#include "plugin/instance/ProcessorInstance.h"
 #include "plugin/interface/Plugin.h"
 
 namespace logtail {
@@ -26,9 +30,20 @@ class Input : public Plugin {
 public:
     virtual ~Input() = default;
 
-    virtual bool Init(const Json::Value& config, Json::Value& optionalGoPipeline) = 0;
+    virtual bool Init(const Json::Value& config, uint32_t& pluginIdx, Json::Value& optionalGoPipeline) = 0;
     virtual bool Start() = 0;
     virtual bool Stop(bool isPipelineRemoving) = 0;
+
+    void SetInputIndex(size_t idx) { mIndex = idx; }
+    std::vector<std::unique_ptr<ProcessorInstance>>& GetInnerProcessors() { return mInnerProcessors; }
+
+protected:
+    size_t mIndex = 0;
+    std::vector<std::unique_ptr<ProcessorInstance>> mInnerProcessors;
+
+#ifdef APSARA_UNIT_TEST_MAIN
+    friend class InputInstanceUnittest;
+#endif
 };
 
 } // namespace logtail

--- a/core/processor/daemon/LogProcess.cpp
+++ b/core/processor/daemon/LogProcess.cpp
@@ -262,7 +262,7 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
             int32_t startTime = (int32_t)time(NULL);
             std::vector<PipelineEventGroup> eventGroupList;
             eventGroupList.emplace_back(std::move(item->mEventGroup));
-            pipeline->Process(eventGroupList);
+            pipeline->Process(eventGroupList, item->mInputIndex);
             int32_t elapsedTime = (int32_t)time(NULL) - startTime;
             if (elapsedTime > 1) {
                 LogtailAlarm::GetInstance()->SendAlarm(PROCESS_TOO_SLOW_ALARM,

--- a/core/unittest/config/ConfigUnittest.cpp
+++ b/core/unittest/config/ConfigUnittest.cpp
@@ -132,7 +132,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(1U, config->mFlushers.size());
     APSARA_TEST_FALSE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_FALSE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
     APSARA_TEST_FALSE(config->HasGoPlugin());
 
     // topology 2: extended -> native -> native
@@ -217,7 +217,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(1U, config->mFlushers.size());
     APSARA_TEST_TRUE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_TRUE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
     APSARA_TEST_TRUE(config->HasGoPlugin());
 
     // topology 5: extended -> extended -> native
@@ -249,7 +249,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(1U, config->mFlushers.size());
     APSARA_TEST_TRUE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_TRUE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_FALSE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_FALSE(config->IsProcessRunnerInvolved());
     APSARA_TEST_TRUE(config->HasGoPlugin());
 
     // topology 6: (native, extended) -> extended -> native
@@ -317,7 +317,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(1U, config->mFlushers.size());
     APSARA_TEST_TRUE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_TRUE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
     APSARA_TEST_TRUE(config->HasGoPlugin());
 
     // topology 8: extended -> (native -> extended) -> native
@@ -413,7 +413,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(1U, config->mFlushers.size());
     APSARA_TEST_FALSE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_FALSE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
     APSARA_TEST_FALSE(config->HasGoPlugin());
 
     // topology 11: extended -> none -> native (future changes maybe applied)
@@ -440,7 +440,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(1U, config->mFlushers.size());
     APSARA_TEST_TRUE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_TRUE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_FALSE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_FALSE(config->IsProcessRunnerInvolved());
     APSARA_TEST_TRUE(config->HasGoPlugin());
 
     // topology 12: (native, extended) -> none -> native
@@ -500,7 +500,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(1U, config->mFlushers.size());
     APSARA_TEST_FALSE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_TRUE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
     APSARA_TEST_TRUE(config->HasGoPlugin());
 
     // topology 14: extended -> native -> extended
@@ -595,7 +595,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(1U, config->mFlushers.size());
     APSARA_TEST_TRUE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_TRUE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
     APSARA_TEST_TRUE(config->HasGoPlugin());
 
     // topology 17: extended -> extended -> extended
@@ -627,7 +627,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(1U, config->mFlushers.size());
     APSARA_TEST_TRUE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_TRUE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_FALSE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_FALSE(config->IsProcessRunnerInvolved());
     APSARA_TEST_TRUE(config->HasGoPlugin());
 
     // topology 18: (native, extended) -> extended -> extended
@@ -695,7 +695,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(1U, config->mFlushers.size());
     APSARA_TEST_TRUE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_TRUE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
     APSARA_TEST_TRUE(config->HasGoPlugin());
 
     // topology 20: extended -> (native -> extended) -> extended
@@ -791,7 +791,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(1U, config->mFlushers.size());
     APSARA_TEST_FALSE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_TRUE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
     APSARA_TEST_TRUE(config->HasGoPlugin());
 
     // topology 23: extended -> none -> extended
@@ -818,7 +818,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(1U, config->mFlushers.size());
     APSARA_TEST_TRUE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_TRUE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_FALSE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_FALSE(config->IsProcessRunnerInvolved());
     APSARA_TEST_TRUE(config->HasGoPlugin());
 
     // topology 24: (native, extended) -> none -> extended
@@ -881,7 +881,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(2U, config->mFlushers.size());
     APSARA_TEST_TRUE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_TRUE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
     APSARA_TEST_TRUE(config->HasGoPlugin());
 
     // topology 26: extended -> native -> (native, extended)
@@ -985,7 +985,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(2U, config->mFlushers.size());
     APSARA_TEST_TRUE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_TRUE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
     APSARA_TEST_TRUE(config->HasGoPlugin());
 
     // topology 29: extended -> extended -> (native, extended)
@@ -1020,7 +1020,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(2U, config->mFlushers.size());
     APSARA_TEST_TRUE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_TRUE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_FALSE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_FALSE(config->IsProcessRunnerInvolved());
     APSARA_TEST_TRUE(config->HasGoPlugin());
 
     // topology 30: (native, extended) -> extended -> (native, extended)
@@ -1094,7 +1094,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(2U, config->mFlushers.size());
     APSARA_TEST_TRUE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_TRUE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
     APSARA_TEST_TRUE(config->HasGoPlugin());
 
     // topology 32: extended -> (native -> extended) -> (native, extended)
@@ -1199,7 +1199,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(2U, config->mFlushers.size());
     APSARA_TEST_TRUE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_TRUE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_TRUE(config->IsProcessRunnerInvolved());
     APSARA_TEST_TRUE(config->HasGoPlugin());
 
     // topology 35: extended -> none -> (native, extended) (future changes maybe applied)
@@ -1229,7 +1229,7 @@ void ConfigUnittest::HandleValidConfig() const {
     APSARA_TEST_EQUAL(2U, config->mFlushers.size());
     APSARA_TEST_TRUE(config->ShouldNativeFlusherConnectedByGoPipeline());
     APSARA_TEST_TRUE(config->IsFlushingThroughGoPipelineExisted());
-    APSARA_TEST_FALSE(config->IsProcessRunnerInvolved());
+    // APSARA_TEST_FALSE(config->IsProcessRunnerInvolved());
     APSARA_TEST_TRUE(config->HasGoPlugin());
 
     // topology 36: (native, extended) -> none -> (native, extended)

--- a/core/unittest/input/InputFileUnittest.cpp
+++ b/core/unittest/input/InputFileUnittest.cpp
@@ -24,6 +24,10 @@
 #include "input/InputFile.h"
 #include "pipeline/Pipeline.h"
 #include "pipeline/PipelineContext.h"
+#include "plugin/PluginRegistry.h"
+#include "processor/inner/ProcessorSplitLogStringNative.h"
+#include "processor/inner/ProcessorSplitMultilineLogStringNative.h"
+#include "processor/inner/ProcessorTagNative.h"
 #include "unittest/Unittest.h"
 
 DECLARE_FLAG_INT32(default_plugin_log_queue_size);
@@ -37,11 +41,18 @@ public:
     void OnSuccessfulInit();
     void OnFailedInit();
     void OnEnableContainerDiscovery();
+    void TestCreateInnerProcessors();
     void OnPipelineUpdate();
     void TestSetContainerBaseDir();
 
 protected:
-    static void SetUpTestCase() { AppConfig::GetInstance()->mPurageContainerMode = true; }
+    static void SetUpTestCase() {
+        AppConfig::GetInstance()->mPurageContainerMode = true;
+        PluginRegistry::GetInstance()->LoadPlugins();
+    }
+
+    static void TearDownTestCase() { PluginRegistry::GetInstance()->UnloadPlugins(); }
+
     void SetUp() override {
         p.mName = "test_config";
         ctx.SetConfigName("test_config");
@@ -57,6 +68,7 @@ void InputFileUnittest::OnSuccessfulInit() {
     unique_ptr<InputFile> input;
     Json::Value configJson, optionalGoPipeline;
     string configStr, errorMsg;
+    uint32_t pluginIdx = 0;
     filesystem::path filePath = filesystem::absolute("*.log");
 
     // only mandatory param
@@ -71,7 +83,7 @@ void InputFileUnittest::OnSuccessfulInit() {
     input.reset(new InputFile());
     input->SetContext(ctx);
     input->SetMetricsRecordRef(InputFile::sName, "1");
-    APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
+    APSARA_TEST_TRUE(input->Init(configJson, pluginIdx, optionalGoPipeline));
     APSARA_TEST_FALSE(input->mEnableContainerDiscovery);
     APSARA_TEST_EQUAL(0U, input->mMaxCheckpointDirSearchDepth);
     APSARA_TEST_EQUAL(0U, input->mExactlyOnceConcurrency);
@@ -91,7 +103,7 @@ void InputFileUnittest::OnSuccessfulInit() {
     input.reset(new InputFile());
     input->SetContext(ctx);
     input->SetMetricsRecordRef(InputFile::sName, "1");
-    APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
+    APSARA_TEST_TRUE(input->Init(configJson, pluginIdx, optionalGoPipeline));
     APSARA_TEST_TRUE(input->mEnableContainerDiscovery);
     APSARA_TEST_EQUAL(1, input->mMaxCheckpointDirSearchDepth);
     APSARA_TEST_EQUAL(1, input->mExactlyOnceConcurrency);
@@ -111,7 +123,7 @@ void InputFileUnittest::OnSuccessfulInit() {
     input.reset(new InputFile());
     input->SetContext(ctx);
     input->SetMetricsRecordRef(InputFile::sName, "1");
-    APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
+    APSARA_TEST_TRUE(input->Init(configJson, pluginIdx, optionalGoPipeline));
     APSARA_TEST_FALSE(input->mEnableContainerDiscovery);
     APSARA_TEST_EQUAL(0U, input->mMaxCheckpointDirSearchDepth);
     APSARA_TEST_EQUAL(0U, input->mExactlyOnceConcurrency);
@@ -129,7 +141,7 @@ void InputFileUnittest::OnSuccessfulInit() {
     input.reset(new InputFile());
     input->SetContext(ctx);
     input->SetMetricsRecordRef(InputFile::sName, "1");
-    APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
+    APSARA_TEST_TRUE(input->Init(configJson, pluginIdx, optionalGoPipeline));
     APSARA_TEST_TRUE(input->mFileReader.mTailingAllMatchedFiles);
     APSARA_TEST_TRUE(input->mFileDiscovery.IsTailingAllMatchedFiles());
 
@@ -146,29 +158,29 @@ void InputFileUnittest::OnSuccessfulInit() {
     input.reset(new InputFile());
     input->SetContext(ctx);
     input->SetMetricsRecordRef(InputFile::sName, "1");
-    APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
+    APSARA_TEST_TRUE(input->Init(configJson, pluginIdx, optionalGoPipeline));
     APSARA_TEST_EQUAL(0U, input->mExactlyOnceConcurrency);
 }
 
 void InputFileUnittest::OnFailedInit() {
     unique_ptr<InputFile> input;
     Json::Value configJson, optionalGoPipeline;
+    uint32_t pluginIdx = 0;
 
     input.reset(new InputFile());
     input->SetContext(ctx);
     input->SetMetricsRecordRef(InputFile::sName, "1");
-    APSARA_TEST_FALSE(input->Init(configJson, optionalGoPipeline));
+    APSARA_TEST_FALSE(input->Init(configJson, pluginIdx, optionalGoPipeline));
 }
 
 void InputFileUnittest::OnEnableContainerDiscovery() {
-    // 启用容器元信息预览
-    {
-        unique_ptr<InputFile> input;
-        Json::Value configJson, optionalGoPipelineJson, optionalGoPipeline;
-        string configStr, optionalGoPipelineStr, errorMsg;
-        filesystem::path filePath = filesystem::absolute("*.log");
+    unique_ptr<InputFile> input;
+    Json::Value configJson, optionalGoPipelineJson, optionalGoPipeline;
+    string configStr, optionalGoPipelineStr, errorMsg;
+    uint32_t pluginIdx = 0;
+    filesystem::path filePath = filesystem::absolute("*.log");
 
-        configStr = R"(
+    configStr = R"(
             {
                 "Type": "input_file",
                 "FilePaths": [],
@@ -179,7 +191,7 @@ void InputFileUnittest::OnEnableContainerDiscovery() {
                 "CollectingContainersMeta": true
             }
         )";
-        optionalGoPipelineStr = R"(
+    optionalGoPipelineStr = R"(
             {
                 "global": {
                     "AlwaysOnline": true
@@ -198,68 +210,136 @@ void InputFileUnittest::OnEnableContainerDiscovery() {
                 ]
             }
         )";
-        APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
-        APSARA_TEST_TRUE(ParseJsonTable(optionalGoPipelineStr, optionalGoPipelineJson, errorMsg));
-        configJson["FilePaths"].append(Json::Value(filePath.string()));
-        optionalGoPipelineJson["global"]["DefaultLogQueueSize"]
-            = Json::Value(INT32_FLAG(default_plugin_log_queue_size));
-        optionalGoPipelineJson["inputs"][0]["detail"]["LogPath"] = Json::Value(filePath.parent_path().string());
-        input.reset(new InputFile());
-        input->SetContext(ctx);
-        input->SetMetricsRecordRef(InputFile::sName, "1");
-        APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
-        APSARA_TEST_TRUE(input->mEnableContainerDiscovery);
-        APSARA_TEST_TRUE(input->mFileDiscovery.IsContainerDiscoveryEnabled());
-        APSARA_TEST_EQUAL(optionalGoPipelineJson.toStyledString(), optionalGoPipeline.toStyledString());
-    }
-    // 不启用容器元信息预览
-    {
-        unique_ptr<InputFile> input;
-        Json::Value configJson, optionalGoPipelineJson, optionalGoPipeline;
-        string configStr, optionalGoPipelineStr, errorMsg;
-        filesystem::path filePath = filesystem::absolute("*.log");
+    APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
+    APSARA_TEST_TRUE(ParseJsonTable(optionalGoPipelineStr, optionalGoPipelineJson, errorMsg));
+    configJson["FilePaths"].append(Json::Value(filePath.string()));
+    optionalGoPipelineJson["global"]["DefaultLogQueueSize"] = Json::Value(INT32_FLAG(default_plugin_log_queue_size));
+    optionalGoPipelineJson["inputs"][0]["detail"]["LogPath"] = Json::Value(filePath.parent_path().string());
+    input.reset(new InputFile());
+    input->SetContext(ctx);
+    input->SetMetricsRecordRef(InputFile::sName, "1");
+    APSARA_TEST_TRUE(input->Init(configJson, pluginIdx, optionalGoPipeline));
+    APSARA_TEST_TRUE(input->mEnableContainerDiscovery);
+    APSARA_TEST_TRUE(input->mFileDiscovery.IsContainerDiscoveryEnabled());
+    APSARA_TEST_EQUAL(optionalGoPipelineJson.toStyledString(), optionalGoPipeline.toStyledString());
+}
 
+void InputFileUnittest::TestCreateInnerProcessors() {
+    unique_ptr<InputFile> input;
+    Json::Value configJson, optionalGoPipeline;
+    string configStr, errorMsg;
+    uint32_t pluginIdx = 0;
+    filesystem::path filePath = filesystem::absolute("*.log");
+    {
+        // no multiline
         configStr = R"(
             {
                 "Type": "input_file",
                 "FilePaths": [],
-                "EnableContainerDiscovery": true,
-                "ContainerFilters": {
-                    "K8sNamespaceRegex": "default"
-                }
-            }
-        )";
-        optionalGoPipelineStr = R"(
-            {
-                "global": {
-                    "AlwaysOnline": true
-                },
-                "inputs": [
-                    {                
-                        "type": "metric_container_info",
-                        "detail": {
-                            "FilePattern": "*.log",
-                            "K8sNamespaceRegex": "default",
-                            "MaxDepth": 0,
-                            "LogPath": ""
-                        }
-                    }
-                ]
+                "AppendingLogPositionMeta": true
             }
         )";
         APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
-        APSARA_TEST_TRUE(ParseJsonTable(optionalGoPipelineStr, optionalGoPipelineJson, errorMsg));
         configJson["FilePaths"].append(Json::Value(filePath.string()));
-        optionalGoPipelineJson["global"]["DefaultLogQueueSize"]
-            = Json::Value(INT32_FLAG(default_plugin_log_queue_size));
-        optionalGoPipelineJson["inputs"][0]["detail"]["LogPath"] = Json::Value(filePath.parent_path().string());
         input.reset(new InputFile());
         input->SetContext(ctx);
         input->SetMetricsRecordRef(InputFile::sName, "1");
-        APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
-        APSARA_TEST_TRUE(input->mEnableContainerDiscovery);
-        APSARA_TEST_TRUE(input->mFileDiscovery.IsContainerDiscoveryEnabled());
-        APSARA_TEST_EQUAL(optionalGoPipelineJson.toStyledString(), optionalGoPipeline.toStyledString());
+        APSARA_TEST_TRUE(input->Init(configJson, pluginIdx, optionalGoPipeline));
+        APSARA_TEST_EQUAL(2U, input->mInnerProcessors.size());
+        APSARA_TEST_EQUAL(ProcessorSplitLogStringNative::sName, input->mInnerProcessors[0]->Name());
+        auto plugin = static_cast<ProcessorSplitLogStringNative*>(input->mInnerProcessors[0]->mPlugin.get());
+        APSARA_TEST_EQUAL(DEFAULT_CONTENT_KEY, plugin->mSourceKey);
+        APSARA_TEST_EQUAL('\n', plugin->mSplitChar);
+        APSARA_TEST_TRUE(plugin->mAppendingLogPositionMeta);
+        APSARA_TEST_EQUAL(ProcessorTagNative::sName, input->mInnerProcessors[1]->Name());
+    }
+    {
+        // custom multiline
+        configStr = R"(
+            {
+                "Type": "input_file",
+                "FilePaths": [],
+                "Multiline": {
+                    "StartPattern": "\\d+",
+                    "EndPattern": "end",
+                    "IgnoringUnmatchWarning": true,
+                    "UnmatchedContentTreatment": "discard"
+                },
+                "AppendingLogPositionMeta": true
+            }
+        )";
+        APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
+        configJson["FilePaths"].append(Json::Value(filePath.string()));
+        input.reset(new InputFile());
+        input->SetContext(ctx);
+        input->SetMetricsRecordRef(InputFile::sName, "1");
+        APSARA_TEST_TRUE(input->Init(configJson, pluginIdx, optionalGoPipeline));
+        APSARA_TEST_EQUAL(2U, input->mInnerProcessors.size());
+        APSARA_TEST_EQUAL(ProcessorSplitMultilineLogStringNative::sName, input->mInnerProcessors[0]->Name());
+        auto plugin = static_cast<ProcessorSplitMultilineLogStringNative*>(input->mInnerProcessors[0]->mPlugin.get());
+        APSARA_TEST_EQUAL(DEFAULT_CONTENT_KEY, plugin->mSourceKey);
+        APSARA_TEST_EQUAL(MultilineOptions::Mode::CUSTOM, plugin->mMultiline.mMode);
+        APSARA_TEST_STREQ("\\d+", plugin->mMultiline.mStartPattern.c_str());
+        APSARA_TEST_STREQ("", plugin->mMultiline.mContinuePattern.c_str());
+        APSARA_TEST_STREQ("end", plugin->mMultiline.mEndPattern.c_str());
+        APSARA_TEST_TRUE(plugin->mMultiline.mIgnoringUnmatchWarning);
+        APSARA_TEST_EQUAL(MultilineOptions::UnmatchedContentTreatment::DISCARD,
+                          plugin->mMultiline.mUnmatchedContentTreatment);
+        APSARA_TEST_TRUE(plugin->mAppendingLogPositionMeta);
+        APSARA_TEST_EQUAL(ProcessorTagNative::sName, input->mInnerProcessors[1]->Name());
+    }
+    {
+        // json multiline, first processor is json parser
+        ctx.SetIsFirstProcessorJsonFlag(true);
+        configStr = R"(
+            {
+                "Type": "input_file",
+                "FilePaths": [],
+                "AppendingLogPositionMeta": true
+            }
+        )";
+        APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
+        configJson["FilePaths"].append(Json::Value(filePath.string()));
+        input.reset(new InputFile());
+        input->SetContext(ctx);
+        input->SetMetricsRecordRef(InputFile::sName, "1");
+        APSARA_TEST_TRUE(input->Init(configJson, pluginIdx, optionalGoPipeline));
+        APSARA_TEST_EQUAL(2U, input->mInnerProcessors.size());
+        APSARA_TEST_EQUAL(ProcessorSplitLogStringNative::sName, input->mInnerProcessors[0]->Name());
+        auto plugin = static_cast<ProcessorSplitLogStringNative*>(input->mInnerProcessors[0]->mPlugin.get());
+        APSARA_TEST_EQUAL(DEFAULT_CONTENT_KEY, plugin->mSourceKey);
+        APSARA_TEST_EQUAL('\0', plugin->mSplitChar);
+        APSARA_TEST_TRUE(plugin->mAppendingLogPositionMeta);
+        APSARA_TEST_EQUAL(ProcessorTagNative::sName, input->mInnerProcessors[1]->Name());
+        ctx.SetIsFirstProcessorJsonFlag(false);
+    }
+    {
+        // json multiline, json mode
+        ctx.SetIsFirstProcessorJsonFlag(true);
+        configStr = R"(
+            {
+                "Type": "input_file",
+                "FilePaths": [],
+                "Multiline": {
+                    "Mode": "JSON"
+                },
+                "AppendingLogPositionMeta": true
+            }
+        )";
+        APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
+        configJson["FilePaths"].append(Json::Value(filePath.string()));
+        input.reset(new InputFile());
+        input->SetContext(ctx);
+        input->SetMetricsRecordRef(InputFile::sName, "1");
+        APSARA_TEST_TRUE(input->Init(configJson, pluginIdx, optionalGoPipeline));
+        APSARA_TEST_EQUAL(2U, input->mInnerProcessors.size());
+        APSARA_TEST_EQUAL(ProcessorSplitLogStringNative::sName, input->mInnerProcessors[0]->Name());
+        auto plugin = static_cast<ProcessorSplitLogStringNative*>(input->mInnerProcessors[0]->mPlugin.get());
+        APSARA_TEST_EQUAL(DEFAULT_CONTENT_KEY, plugin->mSourceKey);
+        APSARA_TEST_EQUAL('\0', plugin->mSplitChar);
+        APSARA_TEST_TRUE(plugin->mAppendingLogPositionMeta);
+        APSARA_TEST_EQUAL(ProcessorTagNative::sName, input->mInnerProcessors[1]->Name());
+        ctx.SetIsFirstProcessorJsonFlag(false);
     }
 }
 
@@ -267,6 +347,7 @@ void InputFileUnittest::OnPipelineUpdate() {
     Json::Value configJson, optionalGoPipeline;
     InputFile input;
     string configStr, errorMsg;
+    uint32_t pluginIdx = 0;
     filesystem::path filePath = filesystem::absolute("*.log");
 
     configStr = R"(
@@ -278,8 +359,8 @@ void InputFileUnittest::OnPipelineUpdate() {
     )";
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     configJson["FilePaths"].append(Json::Value(filePath.string()));
-    APSARA_TEST_TRUE(input.Init(configJson, optionalGoPipeline));
     input.SetContext(ctx);
+    APSARA_TEST_TRUE(input.Init(configJson, pluginIdx, optionalGoPipeline));
 
     APSARA_TEST_TRUE(input.Start());
     APSARA_TEST_NOT_EQUAL(nullptr, FileServer::GetInstance()->GetFileDiscoveryConfig("test_config").first);
@@ -295,46 +376,44 @@ void InputFileUnittest::OnPipelineUpdate() {
 }
 
 void InputFileUnittest::TestSetContainerBaseDir() {
-    // Create an InputFile object
     InputFile inputFile;
-    {
-        ContainerInfo containerInfo;
-        containerInfo.mID = "testContainer";
-        containerInfo.mUpperDir = "/UpperDir";
-        containerInfo.mMounts.push_back(Mount("/source1", "/data1"));
-        containerInfo.mMounts.push_back(Mount("/source2", "/data1/data2"));
-        containerInfo.mMounts.push_back(Mount("/source3", "/data1/data2/data3"));
-        containerInfo.mMounts.push_back(Mount("/source4", "/data1/data2/data3/data4"));
+    ContainerInfo containerInfo;
+    containerInfo.mID = "testContainer";
+    containerInfo.mUpperDir = "/UpperDir";
+    containerInfo.mMounts.push_back(Mount("/source1", "/data1"));
+    containerInfo.mMounts.push_back(Mount("/source2", "/data1/data2"));
+    containerInfo.mMounts.push_back(Mount("/source3", "/data1/data2/data3"));
+    containerInfo.mMounts.push_back(Mount("/source4", "/data1/data2/data3/data4"));
 
-        containerInfo.mRealBaseDir = "";
-        ASSERT_TRUE(inputFile.SetContainerBaseDir(containerInfo, "/data2/log"));
-        APSARA_TEST_EQUAL("/logtail_host/UpperDir/data2/log", containerInfo.mRealBaseDir);
+    containerInfo.mRealBaseDir = "";
+    ASSERT_TRUE(inputFile.SetContainerBaseDir(containerInfo, "/data2/log"));
+    APSARA_TEST_EQUAL("/logtail_host/UpperDir/data2/log", containerInfo.mRealBaseDir);
 
-        containerInfo.mRealBaseDir = "";
-        ASSERT_TRUE(inputFile.SetContainerBaseDir(containerInfo, "/data1/log"));
-        APSARA_TEST_EQUAL("/logtail_host/source1/log", containerInfo.mRealBaseDir);
+    containerInfo.mRealBaseDir = "";
+    ASSERT_TRUE(inputFile.SetContainerBaseDir(containerInfo, "/data1/log"));
+    APSARA_TEST_EQUAL("/logtail_host/source1/log", containerInfo.mRealBaseDir);
 
-        containerInfo.mRealBaseDir = "";
-        ASSERT_TRUE(inputFile.SetContainerBaseDir(containerInfo, "/data1/data2/log"));
-        APSARA_TEST_EQUAL("/logtail_host/source2/log", containerInfo.mRealBaseDir);
+    containerInfo.mRealBaseDir = "";
+    ASSERT_TRUE(inputFile.SetContainerBaseDir(containerInfo, "/data1/data2/log"));
+    APSARA_TEST_EQUAL("/logtail_host/source2/log", containerInfo.mRealBaseDir);
 
-        containerInfo.mRealBaseDir = "";
-        ASSERT_TRUE(inputFile.SetContainerBaseDir(containerInfo, "/data1/data2/data3/log"));
-        APSARA_TEST_EQUAL("/logtail_host/source3/log", containerInfo.mRealBaseDir);
+    containerInfo.mRealBaseDir = "";
+    ASSERT_TRUE(inputFile.SetContainerBaseDir(containerInfo, "/data1/data2/data3/log"));
+    APSARA_TEST_EQUAL("/logtail_host/source3/log", containerInfo.mRealBaseDir);
 
-        containerInfo.mRealBaseDir = "";
-        ASSERT_TRUE(inputFile.SetContainerBaseDir(containerInfo, "/data1/data2/data3/data4/log"));
-        APSARA_TEST_EQUAL("/logtail_host/source4/log", containerInfo.mRealBaseDir);
+    containerInfo.mRealBaseDir = "";
+    ASSERT_TRUE(inputFile.SetContainerBaseDir(containerInfo, "/data1/data2/data3/data4/log"));
+    APSARA_TEST_EQUAL("/logtail_host/source4/log", containerInfo.mRealBaseDir);
 
-        containerInfo.mRealBaseDir = "";
-        ASSERT_TRUE(inputFile.SetContainerBaseDir(containerInfo, "/data1/data2/data3/data4/data5/log"));
-        APSARA_TEST_EQUAL("/logtail_host/source4/data5/log", containerInfo.mRealBaseDir);
-    }
+    containerInfo.mRealBaseDir = "";
+    ASSERT_TRUE(inputFile.SetContainerBaseDir(containerInfo, "/data1/data2/data3/data4/data5/log"));
+    APSARA_TEST_EQUAL("/logtail_host/source4/data5/log", containerInfo.mRealBaseDir);
 }
 
 UNIT_TEST_CASE(InputFileUnittest, OnSuccessfulInit)
 UNIT_TEST_CASE(InputFileUnittest, OnFailedInit)
 UNIT_TEST_CASE(InputFileUnittest, OnEnableContainerDiscovery)
+UNIT_TEST_CASE(InputFileUnittest, TestCreateInnerProcessors)
 UNIT_TEST_CASE(InputFileUnittest, OnPipelineUpdate)
 UNIT_TEST_CASE(InputFileUnittest, TestSetContainerBaseDir)
 

--- a/core/unittest/pipeline/PipelineUnittest.cpp
+++ b/core/unittest/pipeline/PipelineUnittest.cpp
@@ -29,6 +29,7 @@
 #include "queue/ProcessQueueManager.h"
 #include "queue/QueueKeyManager.h"
 #include "unittest/Unittest.h"
+#include "unittest/plugin/PluginMock.h"
 
 using namespace std;
 
@@ -40,12 +41,14 @@ public:
     void OnFailedInit() const;
     void OnInitVariousTopology() const;
     void TestProcessQueue() const;
-    void OnInputFileWithMultiline() const;
+    void OnInputFileWithJsonMultiline() const;
     void OnInputFileWithContainerDiscovery() const;
+    void TestProcess() const;
 
 protected:
     static void SetUpTestCase() {
         PluginRegistry::GetInstance()->LoadPlugins();
+        LoadPluginMock();
         InputFeedbackInterfaceRegistry::GetInstance()->LoadFeedbackInterfaces();
         AppConfig::GetInstance()->mPurageContainerMode = true;
     }
@@ -94,7 +97,7 @@ void PipelineUnittest::OnSuccessfulInit() const {
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
     APSARA_TEST_EQUAL(configName, pipeline->Name());
     APSARA_TEST_EQUAL(configName, pipeline->GetContext().GetConfigName());
-    APSARA_TEST_EQUAL(123456789, int(pipeline->GetContext().GetCreateTime()));
+    APSARA_TEST_EQUAL(123456789U, pipeline->GetContext().GetCreateTime());
     APSARA_TEST_EQUAL("test_project", pipeline->GetContext().GetProjectName());
     APSARA_TEST_EQUAL("test_logstore", pipeline->GetContext().GetLogstoreName());
     APSARA_TEST_EQUAL("test_region", pipeline->GetContext().GetRegion());
@@ -127,7 +130,7 @@ void PipelineUnittest::OnSuccessfulInit() const {
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
     APSARA_TEST_EQUAL(configName, pipeline->Name());
     APSARA_TEST_EQUAL(configName, pipeline->GetContext().GetConfigName());
-    APSARA_TEST_EQUAL(0, int(pipeline->GetContext().GetCreateTime()));
+    APSARA_TEST_EQUAL(0U, pipeline->GetContext().GetCreateTime());
     APSARA_TEST_EQUAL("", pipeline->GetContext().GetProjectName());
     APSARA_TEST_EQUAL("", pipeline->GetContext().GetLogstoreName());
     APSARA_TEST_EQUAL("", pipeline->GetContext().GetRegion());
@@ -365,9 +368,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(1, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(3, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(1, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(1U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(1U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(1U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithoutInput.isNull());
 
@@ -510,9 +513,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(1, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(2, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(1, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(1U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(0U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(1U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
     goPipelineWithoutInput.clear();
@@ -588,9 +591,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(0, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(0, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(1, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(0U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(0U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(1U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(goPipelineWithInput == pipeline->mGoPipelineWithInput);
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithoutInput.isNull());
     goPipelineWithInput.clear();
@@ -711,9 +714,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(1, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(3, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(1, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(1U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(1U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(1U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
     goPipelineWithoutInput.clear();
@@ -834,9 +837,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(1, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(2, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(1, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(1U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(0U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(1U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithoutInput.isNull());
 
@@ -900,9 +903,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(0, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(0, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(1, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(0U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(0U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(1U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(goPipelineWithInput == pipeline->mGoPipelineWithInput);
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithoutInput.isNull());
     goPipelineWithInput.clear();
@@ -1002,9 +1005,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(1, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(3, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(0, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(1U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(1U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(0U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
     goPipelineWithoutInput.clear();
@@ -1143,9 +1146,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(1, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(2, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(0, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(1U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(0U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(0U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
     goPipelineWithoutInput.clear();
@@ -1214,9 +1217,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(0, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(0, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(0, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(0U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(0U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(0U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(goPipelineWithInput == pipeline->mGoPipelineWithInput);
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithoutInput.isNull());
     goPipelineWithInput.clear();
@@ -1325,9 +1328,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(1, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(3, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(0, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(1U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(1U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(0U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
     goPipelineWithoutInput.clear();
@@ -1461,9 +1464,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(1, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(2, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(0, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(1U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(0U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(0U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
     goPipelineWithoutInput.clear();
@@ -1521,9 +1524,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(0, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(0, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(0, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(0U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(0U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(0U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(goPipelineWithInput == pipeline->mGoPipelineWithInput);
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithoutInput.isNull());
     goPipelineWithInput.clear();
@@ -1632,9 +1635,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(1, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(3, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(1, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(1U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(1U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(1U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
     goPipelineWithoutInput.clear();
@@ -1803,9 +1806,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(1, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(2, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(1, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(1U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(0U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(1U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
     goPipelineWithoutInput.clear();
@@ -1888,9 +1891,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(0, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(0, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(1, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(0U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(0U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(1U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(goPipelineWithInput == pipeline->mGoPipelineWithInput);
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithoutInput.isNull());
     goPipelineWithInput.clear();
@@ -2021,9 +2024,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(1, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(3, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(1, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(1U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(1U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(1U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
     goPipelineWithoutInput.clear();
@@ -2187,9 +2190,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(1, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(2, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(1, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(1U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(0U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(1U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
     goPipelineWithoutInput.clear();
@@ -2261,9 +2264,9 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_TRUE(config->Parse());
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(0, int(pipeline->mInputs.size()));
-    APSARA_TEST_EQUAL(0, int(pipeline->mProcessorLine.size()));
-    APSARA_TEST_EQUAL(1, int(pipeline->GetFlushers().size()));
+    APSARA_TEST_EQUAL(0U, pipeline->mInputs.size());
+    APSARA_TEST_EQUAL(0U, pipeline->mProcessorLine.size());
+    APSARA_TEST_EQUAL(1U, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(goPipelineWithInput == pipeline->mGoPipelineWithInput);
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithoutInput.isNull());
     goPipelineWithInput.clear();
@@ -2365,7 +2368,7 @@ void PipelineUnittest::TestProcessQueue() const {
     APSARA_TEST_EQUAL(1U, ProcessQueueManager::GetInstance()->mPriorityQueue[0].size());
     APSARA_TEST_TRUE(ProcessQueueManager::GetInstance()->mPriorityQueue[0].begin()
                      == ProcessQueueManager::GetInstance()->mQueues[key]);
-    
+
     // update pipeline with different priority
     configStr = R"(
         {
@@ -2420,48 +2423,13 @@ void PipelineUnittest::TestProcessQueue() const {
     APSARA_TEST_EQUAL("", QueueKeyManager::GetInstance()->GetName(key));
 }
 
-void PipelineUnittest::OnInputFileWithMultiline() const {
+void PipelineUnittest::OnInputFileWithJsonMultiline() const {
     unique_ptr<Json::Value> configJson;
     string configStr, errorMsg;
     unique_ptr<Config> config;
     unique_ptr<Pipeline> pipeline;
 
-    // normal multiline
-    configStr = R"(
-        {
-            "inputs": [
-                {
-                    "Type": "input_file",
-                    "FilePaths": [
-                        "/home/test.log"
-                    ],
-                    "Multiline": {
-                        "StartPattern": "\\d+",
-                        "EndPattern": "end"
-                    }
-                }
-            ],
-            "flushers": [
-                {
-                    "Type": "flusher_sls",
-                    "Project": "test_project",
-                    "Logstore": "test_logstore",
-                    "Region": "test_region",
-                    "Endpoint": "test_endpoint",
-                    "EnableShardHash": false
-                }
-            ]
-        }
-    )";
-    configJson.reset(new Json::Value());
-    APSARA_TEST_TRUE(ParseJsonTable(configStr, *configJson, errorMsg));
-    config.reset(new Config(configName, std::move(configJson)));
-    APSARA_TEST_TRUE(config->Parse());
-    pipeline.reset(new Pipeline());
-    APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_EQUAL(ProcessorSplitMultilineLogStringNative::sName, pipeline->mProcessorLine[1]->Name());
-
-    // json multiline
+    // first processor is native json parser
     configStr = R"(
         {
             "inputs": [
@@ -2497,8 +2465,9 @@ void PipelineUnittest::OnInputFileWithMultiline() const {
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
     APSARA_TEST_TRUE(pipeline->GetContext().RequiringJsonReader());
-    APSARA_TEST_EQUAL(ProcessorSplitLogStringNative::sName, pipeline->mProcessorLine[1]->Name());
+    APSARA_TEST_EQUAL(ProcessorSplitLogStringNative::sName, pipeline->mInputs[0]->GetInnerProcessors()[0]->Name());
 
+    // first processor is extended json parser
     configStr = R"(
         {
             "inputs": [
@@ -2533,41 +2502,7 @@ void PipelineUnittest::OnInputFileWithMultiline() const {
     pipeline.reset(new Pipeline());
     APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
     APSARA_TEST_TRUE(pipeline->GetContext().RequiringJsonReader());
-    APSARA_TEST_EQUAL(ProcessorSplitLogStringNative::sName, pipeline->mProcessorLine[1]->Name());
-
-    configStr = R"(
-        {
-            "inputs": [
-                {
-                    "Type": "input_file",
-                    "FilePaths": [
-                        "/home/test.log"
-                    ],
-                    "Multiline": {
-                        "Mode": "JSON"
-                    }
-                }
-            ],
-            "flushers": [
-                {
-                    "Type": "flusher_sls",
-                    "Project": "test_project",
-                    "Logstore": "test_logstore",
-                    "Region": "test_region",
-                    "Endpoint": "test_endpoint",
-                    "EnableShardHash": false
-                }
-            ]
-        }
-    )";
-    configJson.reset(new Json::Value());
-    APSARA_TEST_TRUE(ParseJsonTable(configStr, *configJson, errorMsg));
-    config.reset(new Config(configName, std::move(configJson)));
-    APSARA_TEST_TRUE(config->Parse());
-    pipeline.reset(new Pipeline());
-    APSARA_TEST_TRUE(pipeline->Init(std::move(*config)));
-    APSARA_TEST_TRUE(pipeline->GetContext().RequiringJsonReader());
-    APSARA_TEST_EQUAL(ProcessorSplitLogStringNative::sName, pipeline->mProcessorLine[1]->Name());
+    APSARA_TEST_EQUAL(ProcessorSplitLogStringNative::sName, pipeline->mInputs[0]->GetInnerProcessors()[0]->Name());
 }
 
 void PipelineUnittest::OnInputFileWithContainerDiscovery() const {
@@ -2722,12 +2657,33 @@ void PipelineUnittest::OnInputFileWithContainerDiscovery() const {
     goPipelineWithoutInput.clear();
 }
 
+void PipelineUnittest::TestProcess() const {
+    Pipeline pipeline;
+    uint32_t pluginIdx = 0;
+    PipelineContext ctx;
+    Json::Value tmp;
+    auto input = PluginRegistry::GetInstance()->CreateInput(InputMock::sName, to_string(++pluginIdx));
+    input->Init(Json::Value(), ctx, pluginIdx, 0, tmp);
+    pipeline.mInputs.emplace_back(std::move(input));
+    auto processor = PluginRegistry::GetInstance()->CreateProcessor(ProcessorMock::sName, to_string(++pluginIdx));
+    processor->Init(Json::Value(), ctx);
+    pipeline.mProcessorLine.emplace_back(std::move(processor));
+
+    vector<PipelineEventGroup> group;
+    group.emplace_back(make_shared<SourceBuffer>());
+    pipeline.Process(group, 0);
+    APSARA_TEST_EQUAL(
+        1U, static_cast<const ProcessorInnerMock*>(pipeline.mInputs[0]->GetInnerProcessors()[0]->mPlugin.get())->mCnt);
+    APSARA_TEST_EQUAL(1U, static_cast<const ProcessorMock*>(pipeline.mProcessorLine[0]->mPlugin.get())->mCnt);
+}
+
 UNIT_TEST_CASE(PipelineUnittest, OnSuccessfulInit)
 UNIT_TEST_CASE(PipelineUnittest, OnFailedInit)
 UNIT_TEST_CASE(PipelineUnittest, TestProcessQueue)
 UNIT_TEST_CASE(PipelineUnittest, OnInitVariousTopology)
-UNIT_TEST_CASE(PipelineUnittest, OnInputFileWithMultiline)
+UNIT_TEST_CASE(PipelineUnittest, OnInputFileWithJsonMultiline)
 UNIT_TEST_CASE(PipelineUnittest, OnInputFileWithContainerDiscovery)
+UNIT_TEST_CASE(PipelineUnittest, TestProcess)
 
 } // namespace logtail
 

--- a/core/unittest/plugin/InputInstanceUnittest.cpp
+++ b/core/unittest/plugin/InputInstanceUnittest.cpp
@@ -14,9 +14,10 @@
 
 #include <memory>
 
-#include "unittest/plugin/PluginMock.h"
+#include "plugin/creator/StaticProcessorCreator.h"
 #include "plugin/instance/InputInstance.h"
 #include "unittest/Unittest.h"
+#include "unittest/plugin/PluginMock.h"
 
 using namespace std;
 
@@ -28,6 +29,13 @@ public:
     void TestInit() const;
     void TestStart() const;
     void TestStop() const;
+
+protected:
+    static void SetUpTestCase() {
+        LoadPluginMock();
+    }
+
+    static void TearDownTestCase() { PluginRegistry::GetInstance()->UnloadPlugins(); }
 };
 
 void InputInstanceUnittest::TestName() const {
@@ -39,8 +47,10 @@ void InputInstanceUnittest::TestInit() const {
     unique_ptr<InputInstance> input = unique_ptr<InputInstance>(new InputInstance(new InputMock(), "0"));
     Json::Value config, opt;
     PipelineContext context;
-    APSARA_TEST_TRUE(input->Init(config, context, opt));
+    uint32_t pluginIdx = 0;
+    APSARA_TEST_TRUE(input->Init(config, context, pluginIdx, 0U, opt));
     APSARA_TEST_EQUAL(&context, &input->GetPlugin()->GetContext());
+    APSARA_TEST_EQUAL(0U, input->GetPlugin()->mIndex);
 }
 
 void InputInstanceUnittest::TestStart() const {

--- a/core/unittest/plugin/PluginMock.h
+++ b/core/unittest/plugin/PluginMock.h
@@ -18,18 +18,44 @@
 
 #include <string>
 
+#include "plugin/PluginRegistry.h"
+#include "plugin/creator/StaticFlusherCreator.h"
+#include "plugin/creator/StaticInputCreator.h"
+#include "plugin/creator/StaticProcessorCreator.h"
 #include "plugin/instance/FlusherInstance.h"
 #include "plugin/instance/InputInstance.h"
 #include "plugin/instance/ProcessorInstance.h"
 
 namespace logtail {
 
+class ProcessorInnerMock : public Processor {
+public:
+    static const std::string sName;
+
+    const std::string& Name() const override { return sName; }
+    bool Init(const Json::Value& config) override { return true; }
+    void Process(PipelineEventGroup& logGroup) override { ++mCnt; };
+
+    uint32_t mCnt = 0;
+
+protected:
+    bool IsSupportedEvent(const PipelineEventPtr& e) const override { return true; };
+};
+
+const std::string ProcessorInnerMock::sName = "processor_inner_mock";
+
 class InputMock : public Input {
 public:
     static const std::string sName;
 
     const std::string& Name() const override { return sName; }
-    bool Init(const Json::Value& config, Json::Value& optionalGoPipeline) override { return true; }
+    bool Init(const Json::Value& config, uint32_t& pluginIdx, Json::Value& optionalGoPipeline) override {
+        auto processor
+            = PluginRegistry::GetInstance()->CreateProcessor(ProcessorInnerMock::sName, std::to_string(++pluginIdx));
+        processor->Init(Json::Value(), *mContext);
+        mInnerProcessors.emplace_back(std::move(processor));
+        return true;
+    }
     bool Start() override { return true; }
     bool Stop(bool isPipelineRemoving) override { return true; }
 };
@@ -42,7 +68,9 @@ public:
 
     const std::string& Name() const override { return sName; }
     bool Init(const Json::Value& config) override { return true; }
-    void Process(PipelineEventGroup& logGroup) override{};
+    void Process(PipelineEventGroup& logGroup) override { ++mCnt; };
+
+    uint32_t mCnt = 0;
 
 protected:
     bool IsSupportedEvent(const PipelineEventPtr& e) const override { return true; };
@@ -61,5 +89,12 @@ public:
 };
 
 const std::string FlusherMock::sName = "flusher_mock";
+
+void LoadPluginMock() {
+    PluginRegistry::GetInstance()->RegisterInputCreator(new StaticInputCreator<InputMock>());
+    PluginRegistry::GetInstance()->RegisterProcessorCreator(new StaticProcessorCreator<ProcessorInnerMock>());
+    PluginRegistry::GetInstance()->RegisterProcessorCreator(new StaticProcessorCreator<ProcessorMock>());
+    PluginRegistry::GetInstance()->RegisterFlusherCreator(new StaticFlusherCreator<FlusherMock>());
+}
 
 } // namespace logtail

--- a/core/unittest/plugin/ProcessorInstanceUnittest.cpp
+++ b/core/unittest/plugin/ProcessorInstanceUnittest.cpp
@@ -14,9 +14,9 @@
 
 #include <memory>
 
-#include "unittest/plugin/PluginMock.h"
 #include "plugin/instance/ProcessorInstance.h"
 #include "unittest/Unittest.h"
+#include "unittest/plugin/PluginMock.h"
 
 using namespace std;
 
@@ -26,6 +26,7 @@ class ProcessorInstanceUnittest : public testing::Test {
 public:
     void TestName() const;
     void TestInit() const;
+    void TestProcess() const;
 };
 
 void ProcessorInstanceUnittest::TestName() const {
@@ -43,8 +44,28 @@ void ProcessorInstanceUnittest::TestInit() const {
     APSARA_TEST_EQUAL(&context, &processor->mPlugin->GetContext());
 }
 
+void ProcessorInstanceUnittest::TestProcess() const {
+    unique_ptr<ProcessorInstance> processor
+        = unique_ptr<ProcessorInstance>(new ProcessorInstance(new ProcessorMock(), "0"));
+    Json::Value config;
+    PipelineContext context;
+    processor->Init(config, context);
+
+    vector<PipelineEventGroup> groups;
+
+    // empty group
+    processor->Process(groups);
+    APSARA_TEST_EQUAL(0U, static_cast<ProcessorMock*>(processor->mPlugin.get())->mCnt);
+
+    // non-empty group
+    groups.emplace_back(make_shared<SourceBuffer>());
+    processor->Process(groups);
+    APSARA_TEST_EQUAL(1U, static_cast<ProcessorMock*>(processor->mPlugin.get())->mCnt);
+}
+
 UNIT_TEST_CASE(ProcessorInstanceUnittest, TestName)
 UNIT_TEST_CASE(ProcessorInstanceUnittest, TestInit)
+UNIT_TEST_CASE(ProcessorInstanceUnittest, TestProcess)
 
 } // namespace logtail
 


### PR DESCRIPTION
- 背景：现有的内置处理插件（如多行切分，tag处理等）是pipeline级别的，对于一个pipeline存在多个input的情况不适用，因此需要调整为input级别。
- 方案：在Input类里增加mInnerProcessors成员，该成员在input插件Init时进行赋值。在处理时，处理线程首先会使用input里的内置处理插件，然后再使用pipeline级别的处理插件。