### PR TITLE
Feat: Add Target Allocator

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -90,7 +90,7 @@ set(SUB_DIRECTORIES_LIST
         aggregator application app_config checkpoint common config config/provider config/watcher config_manager config_server_pb 
         container_manager controller event event_handler event_listener file_server flusher go_pipeline helper input log_pb logger 
         models monitor parser pipeline plugin plugin/creator plugin/instance plugin/interface polling processor processor/daemon processor/inner
-        profile_sender queue reader sdk sender sls_control fuse
+        profile_sender queue reader sdk sender sls_control fuse target_allocator
         )
 if (LINUX)
     set(SUB_DIRECTORIES_LIST ${SUB_DIRECTORIES_LIST} observer)

--- a/core/target_allocator/CMakeLists.txt
+++ b/core/target_allocator/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright 2023 iLogtail Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ 
+cmake_minimum_required(VERSION 3.22)
+project(target_allocator)
+ 
+file(GLOB LIB_SOURCE_FILES *.cpp *.h)
+append_source_files(LIB_SOURCE_FILES)
+add_library(${PROJECT_NAME} STATIC ${LIB_SOURCE_FILES})
+target_link_libraries(${PROJECT_NAME} common)

--- a/core/target_allocator/TargetAllocator.cpp
+++ b/core/target_allocator/TargetAllocator.cpp
@@ -1,0 +1,138 @@
+// Copyright 2023 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "TargetAllocator.h"
+#include <curl/curl.h>
+#include "common/StringTools.h"
+#include "logger/Logger.h"
+namespace logtail {
+bool TargetAllocator::Init(const Json::Value& config) {
+    this->config = config;
+    this->jobName = config["ScrapeConfig"]["job_name"].asString();
+    std::vector<std::string> sdConfigs
+        = {"azure_sd_configs",       "consul_sd_configs",     "digitalocean_sd_configs", "docker_sd_configs",
+           "dockerswarm_sd_configs", "dns_sd_configs",        "ec2_sd_configs",          "eureka_sd_configs",
+           "file_sd_configs",        "gce_sd_configs",        "hetzner_sd_configs",      "http_sd_configs",
+           "ionos_sd_configs",       "kubernetes_sd_configs", "kuma_sd_configs",         "lightsail_sd_configs",
+           "linode_sd_configs",      "marathon_sd_configs",   "nerve_sd_configs",        "nomad_sd_configs",
+           "openstack_sd_configs",   "ovhcloud_sd_configs",   "puppetdb_sd_configs",     "scaleway_sd_configs",
+           "serverset_sd_configs",   "triton_sd_configs",     "uyuni_sd_configs",        "static_configs"};
+    Json::Value httpSDConfig;
+    std::string httpPrefix = "http://";
+    httpSDConfig["url"] = httpPrefix + ToString(getenv("OPERATOR_HOST")) + ":" + ToString(getenv("OPERATOR_PORT"))
+        + "/jobs/" + this->jobName + "/targets?collector_id=" + ToString(getenv("POD_NAME"));
+    httpSDConfig["follow_redirects"] = false;
+    for (const auto& sdConfig : sdConfigs) {
+        this->config["ScrapeConfig"].removeMember(sdConfig);
+    }
+    this->config["ScrapeConfig"]["http_sd_configs"].append(httpSDConfig);
+    return true;
+}
+bool TargetAllocator::Start() {
+    const Json::Value& httpSDConfig = this->config["ScrapeConfig"]["http_sd_configs"][0];
+    try {
+        this->Refresh(httpSDConfig, this->jobName);
+    } catch (const std::exception& e) {
+        LOG_WARNING(sLogger,
+                    ("http service discovery from operator failed",
+                     e.what())("job", this->jobName)("url", httpSDConfig["url"].asString()));
+    }
+    return true;
+}
+size_t TargetAllocator::WriteCallback(char* buffer, size_t size, size_t nmemb, std::string* write_buf) {
+    unsigned long sizes = size * nmemb;
+
+    if (buffer == NULL) {
+        return 0;
+    }
+
+    write_buf->append(buffer, sizes);
+    return sizes;
+}
+void TargetAllocator::FetchHttpData(const std::string& url, std::string& readBuffer) {
+    CURL* curl = curl_easy_init();
+    if (!curl) {
+        throw std::runtime_error("Failed to initialize CURL");
+    }
+    CURLcode res;
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, ("matrix_prometheus_" + ToString(getenv("POD_NAME"))).c_str());
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, this->refeshIntervalSeconds);
+    struct curl_slist* headers = NULL;
+    headers = curl_slist_append(headers, "Accept: application/json");
+    headers = curl_slist_append(
+        headers, ("X-Prometheus-Refresh-Interval-Seconds: " + std::to_string(this->refeshIntervalSeconds)).c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    res = curl_easy_perform(curl);
+    if (res != CURLE_OK) {
+        curl_slist_free_all(headers);
+        curl_easy_cleanup(curl);
+        throw std::runtime_error("CURL request failed: " + std::string(curl_easy_strerror(res)));
+    }
+    long http_code = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+    if (http_code != 200) {
+        throw std::runtime_error("Server returned HTTP status code " + std::to_string(http_code));
+    }
+}
+std::vector<std::shared_ptr<TargetAllocator::TargetGroup>>
+TargetAllocator::ParseTargetGroups(const std::string& response, const Json::Value& httpSDConfig) {
+    Json::CharReaderBuilder readerBuilder;
+    JSONCPP_STRING errs;
+    Json::Value root;
+    std::istringstream s(response);
+    if (!Json::parseFromStream(readerBuilder, s, &root, &errs)) {
+        throw std::runtime_error("Failed to parse JSON: " + errs);
+    }
+    std::vector<std::shared_ptr<TargetGroup>> targetGroups;
+    for (const auto& element : root) {
+        if (!element.isObject()) {
+            throw std::runtime_error("Invalid target group item found");
+        }
+        auto tg = std::make_shared<TargetGroup>();
+        tg->source = httpSDConfig["url"].asString() + ":" + std::to_string(targetGroups.size());
+        // Parse labels
+        if (element.isMember("labels") && element["labels"].isObject()) {
+            for (const auto& labelKey : element["labels"].getMemberNames()) {
+                tg->labels[labelKey] = element["labels"][labelKey].asString();
+            }
+        }
+        // Parse targets
+        if (element.isMember("targets") && element["targets"].isArray()) {
+            for (const auto& target : element["targets"]) {
+                if (target.isString()) {
+                    tg->targets.push_back(target.asString());
+                } else {
+                    throw std::runtime_error("Invalid target item found");
+                }
+            }
+        }
+        targetGroups.push_back(tg);
+    }
+    return targetGroups;
+}
+void TargetAllocator::Refresh(const Json::Value& httpSDConfig, const std::string& jobName) {
+    try {
+        std::string url = httpSDConfig["url"].asString();
+        std::string readBuffer;
+        FetchHttpData(url, readBuffer);
+        targetGroups = ParseTargetGroups(readBuffer, httpSDConfig);
+    } catch (const std::exception& e) {
+        throw e;
+    }
+}
+} // namespace logtail

--- a/core/target_allocator/TargetAllocator.h
+++ b/core/target_allocator/TargetAllocator.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 iLogtail Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <json/json.h>
+#include <shared_mutex>
+#include <unordered_map>
+namespace logtail {
+class TargetAllocator {
+public:
+    TargetAllocator(const TargetAllocator&) = delete;
+    TargetAllocator& operator=(const TargetAllocator&) = delete;
+    static TargetAllocator* GetInstance() {
+        static TargetAllocator instance;
+        return &instance;
+    }
+    struct TargetGroup {
+        using LabelSet = std::unordered_map<std::string, std::string>;
+        std::vector<std::string> targets;
+        LabelSet labels;
+        std::string source;
+    };
+    const Json::Value& GetConfig() const { return config; }
+    const std::string& GetJobName() const { return jobName; }
+    const std::vector<std::shared_ptr<TargetGroup>>& GetTargets() const {
+        return targetGroups;
+    }
+    bool Init(const Json::Value& config);
+    bool Start();
+private:
+    TargetAllocator() = default;
+    ~TargetAllocator() = default;
+    const int refeshIntervalSeconds = 5;
+    Json::Value config;
+    std::string jobName;
+    std::vector<std::shared_ptr<TargetGroup>> targetGroups;
+    static size_t WriteCallback(char* contents, size_t size, size_t nmemb, std::string* userp);
+    void FetchHttpData(const std::string& url, std::string& readBuffer);
+    std::vector<std::shared_ptr<TargetGroup>> ParseTargetGroups(const std::string& response,
+                                                                const Json::Value& httpSDConfig);
+    void Refresh(const Json::Value& httpSDConfig, const std::string& jobName);
+};
+} // namespace logtail

--- a/core/unittest/CMakeLists.txt
+++ b/core/unittest/CMakeLists.txt
@@ -93,6 +93,7 @@ add_subdirectory(queue)
 add_subdirectory(reader)
 add_subdirectory(sdk)
 add_subdirectory(sender)
+add_subdirectory(target_allocator)
 
 if (LINUX)
     if (NOT WITHOUTSPL)

--- a/core/unittest/target_allocator/CMakeLists.txt
+++ b/core/unittest/target_allocator/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright 2022 iLogtail Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ 
+cmake_minimum_required(VERSION 3.22)
+project(target_allocator_unittest)
+ 
+add_executable(target_allocator_unittest TargetAllocatorUnittest.cpp)
+target_link_libraries(target_allocator_unittest unittest_base)
+ 
+include(GoogleTest)
+gtest_discover_tests(target_allocator_unittest)

--- a/core/unittest/target_allocator/TargetAllocatorUnittest.cpp
+++ b/core/unittest/target_allocator/TargetAllocatorUnittest.cpp
@@ -1,0 +1,247 @@
+#include <curl/curl.h>
+#include <gtest/gtest.h>
+#include <json/json.h>
+#include <boost/asio.hpp>
+#include <boost/asio/strand.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
+#include <boost/beast/version.hpp>
+#include <boost/config.hpp>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+#include "TargetAllocator.h"
+#include "unittest/Unittest.h"
+namespace beast = boost::beast; // from <boost/beast.hpp>
+namespace http = beast::http; // from <boost/beast/http.hpp>
+namespace net = boost::asio; // from <boost/asio.hpp>
+using tcp = net::ip::tcp; // from <boost/asio/ip/tcp.hpp>
+namespace logtail {
+class TargetAllocatorUnittest : public ::testing::Test {
+public:
+    void TestTargetAllocatorInit();
+    void TestTargetAllocatorStart();
+protected:
+    void SetUp() override {
+        setenv("POD_NAME", "matrix-test", 1);
+        setenv("OPERATOR_HOST", "127.0.0.1", 1);
+        setenv("OPERATOR_PORT", "12345", 1);
+        if (StringToJsonValue(configString, config)) {
+            std::cout << "JSON parsing succeeded." << std::endl;
+            std::cout << config.toStyledString() << std::endl;
+        } else {
+            std::cerr << "JSON parsing failed." << std::endl;
+        }
+    }
+    void TearDown() override {
+        unsetenv("POD_NAME");
+        unsetenv("OPERATOR_HOST");
+        unsetenv("OPERATOR_PORT");
+    }
+    bool StringToJsonValue(const std::string& jsonString, Json::Value& jsonValue) {
+        Json::CharReaderBuilder readerBuilder;
+        std::string errs;
+        std::istringstream iss(jsonString);
+        bool parsingSuccessful = Json::parseFromStream(readerBuilder, iss, &jsonValue, &errs);
+        if (!parsingSuccessful) {
+            std::cerr << "Failed to parse JSON: " << errs << std::endl;
+        }
+        return parsingSuccessful;
+    }
+    Json::Value config;
+    std::string configString = R"JSON(
+{
+    "Type": "matrix_prometheus",
+    "ScrapeConfig": {
+        "enable_http2": true,
+        "follow_redirects": true,
+        "honor_timestamps": false,
+        "job_name": "_kube-state-metrics",
+        "kubernetes_sd_configs": [
+            {
+                "enable_http2": true,
+                "follow_redirects": true,
+                "kubeconfig_file": "",
+                "namespaces": {
+                    "names": [
+                        "arms-prom"
+                    ],
+                    "own_namespace": false
+                },
+                "role": "pod"
+            }
+        ],
+        "metrics_path": "/metrics",
+        "relabel_configs": [
+            {
+                "action": "keep",
+                "regex": "kube-state-metrics",
+                "replacement": "$1",
+                "separator": ";",
+                "source_labels": [
+                    "__meta_kubernetes_pod_label_k8s_app"
+                ]
+            },
+            {
+                "action": "keep",
+                "regex": "8080",
+                "replacement": "$1",
+                "separator": ";",
+                "source_labels": [
+                    "__meta_kubernetes_pod_container_port_number"
+                ]
+            },
+            {
+                "action": "replace",
+                "regex": "([^:]+)(?::\\d+)?;(\\d+)",
+                "replacement": "$1:$2",
+                "separator": ";",
+                "source_labels": [
+                    "__address__",
+                    "__meta_kubernetes_pod_container_port_number"
+                ],
+                "target_label": "__address__"
+            }
+        ],
+        "scheme": "http",
+        "scrape_interval": "30s",
+        "scrape_timeout": "30s"
+    }
+}
+    )JSON";
+};
+http::response<http::string_body> handle_request(const http::request<http::string_body>& req,
+                                                 const std::unordered_map<std::string, std::string>& response_map) {
+    http::response<http::string_body> res{http::status::ok, req.version()};
+    res.set(http::field::server, BOOST_BEAST_VERSION_STRING);
+    res.set(http::field::content_type, "text/plain");
+    res.keep_alive(req.keep_alive());
+    auto it = response_map.find(std::string(req.target()));
+    if (it != response_map.end()) {
+        res.body() = it->second;
+    } else {
+        res.result(http::status::not_found);
+        res.body() = "Resource not found";
+    }
+    res.prepare_payload();
+    return res;
+}
+void do_session(tcp::socket socket, const std::unordered_map<std::string, std::string>& response_map) {
+    try {
+        beast::flat_buffer buffer;
+        http::request<http::string_body> req;
+        http::read(socket, buffer, req);
+        http::response<http::string_body> res = handle_request(req, response_map);
+        http::write(socket, res);
+        socket.shutdown(tcp::socket::shutdown_send);
+    } catch (std::exception const& e) {
+        std::cerr << "Error in session: " << e.what() << std::endl;
+    }
+}
+void start_server() {
+    try {
+        auto const address = net::ip::make_address(getenv("OPERATOR_HOST"));
+        unsigned short port = static_cast<unsigned short>(std::stoi(getenv("OPERATOR_PORT")));
+        std::cout << "Server starting at " << address.to_string() << ":" << port << std::endl;
+        net::io_context ioc{1};
+        tcp::acceptor acceptor{ioc, {address, port}};
+        std::unordered_map<std::string, std::string> response_map = {
+            {"/jobs/_kube-state-metrics/targets?collector_id=matrix-test", R"JSON([
+    {
+        "targets": [
+            "192.168.22.32:6443"
+        ],
+        "labels": {
+            "__meta_kubernetes_endpoints_labelpresent_endpointslice_kubernetes_io_skip_mirror": "true",
+            "__meta_kubernetes_endpoint_port_name": "https",
+            "__meta_kubernetes_endpoint_ready": "true",
+            "__address__": "192.168.22.32:6443",
+            "__meta_kubernetes_namespace": "default",
+            "__meta_kubernetes_service_label_component": "apiserver",
+            "__meta_kubernetes_endpoints_label_endpointslice_kubernetes_io_skip_mirror": "true",
+            "__meta_kubernetes_endpoint_port_protocol": "TCP",
+            "__meta_kubernetes_service_labelpresent_provider": "true",
+            "__meta_kubernetes_service_name": "kubernetes",
+            "__meta_kubernetes_endpoints_name": "kubernetes",
+            "__meta_kubernetes_service_labelpresent_component": "true",
+            "__meta_kubernetes_service_label_provider": "kubernetes"
+        }
+    },
+    {
+        "targets": [
+            "192.168.22.31:6443"
+        ],
+        "labels": {
+            "__address__": "192.168.22.31:6443",
+            "__meta_kubernetes_endpoint_port_protocol": "TCP",
+            "__meta_kubernetes_service_label_provider": "kubernetes",
+            "__meta_kubernetes_endpoints_name": "kubernetes",
+            "__meta_kubernetes_service_name": "kubernetes",
+            "__meta_kubernetes_endpoints_labelpresent_endpointslice_kubernetes_io_skip_mirror": "true",
+            "__meta_kubernetes_service_labelpresent_provider": "true",
+            "__meta_kubernetes_endpoint_port_name": "https",
+            "__meta_kubernetes_namespace": "default",
+            "__meta_kubernetes_service_label_component": "apiserver",
+            "__meta_kubernetes_service_labelpresent_component": "true",
+            "__meta_kubernetes_endpoint_ready": "true"
+        }
+    }
+])JSON"},
+        };
+        for (;;) {
+            tcp::socket socket{ioc};
+            acceptor.accept(socket);
+            std::thread{[&response_map](tcp::socket socket) { do_session(std::move(socket), response_map); },
+                        std::move(socket)}
+                .detach();
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+    }
+}
+UNIT_TEST_CASE(TargetAllocatorUnittest, TestTargetAllocatorInit);
+UNIT_TEST_CASE(TargetAllocatorUnittest, TestTargetAllocatorStart);
+void TargetAllocatorUnittest::TestTargetAllocatorInit() {
+    bool result = TargetAllocator::GetInstance()->Init(config);
+    EXPECT_TRUE(result);
+    const Json::Value& newConfig = TargetAllocator::GetInstance()->GetConfig();
+    EXPECT_TRUE(newConfig["ScrapeConfig"].isMember("http_sd_configs"));
+    EXPECT_TRUE(newConfig["ScrapeConfig"]["http_sd_configs"].isArray());
+    EXPECT_EQ(newConfig["ScrapeConfig"]["http_sd_configs"].size(), 1u);
+    for (const auto& httpSdConfig : newConfig["ScrapeConfig"]["http_sd_configs"]) {
+        EXPECT_TRUE(httpSdConfig.isMember("url"));
+        EXPECT_EQ(httpSdConfig["url"].asString(),
+                  "http://" + std::string(getenv("OPERATOR_HOST")) + ":" + std::string(getenv("OPERATOR_PORT"))
+                      + "/jobs/" + TargetAllocator::GetInstance()->GetJobName()
+                      + "/targets?collector_id=" + std::string(getenv("POD_NAME")));
+    }
+}
+void TargetAllocatorUnittest::TestTargetAllocatorStart() {
+    std::thread server_thread([]() { start_server(); });
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    bool initResult = TargetAllocator::GetInstance()->Init(config);
+    EXPECT_TRUE(initResult);
+    const Json::Value& newConfig = TargetAllocator::GetInstance()->GetConfig();
+    std::cout << newConfig.toStyledString() << std::endl;
+    bool result = false;
+    try {
+        result = TargetAllocator::GetInstance()->Start();
+    } catch (const std::exception& e) {
+        std::cout << e.what() << std::endl;
+    }
+    const std::vector<std::shared_ptr<logtail::TargetAllocator::TargetGroup>>& targetGroup
+        = TargetAllocator::GetInstance()->GetTargets();
+    EXPECT_EQ(targetGroup.size(), 2u);
+    EXPECT_EQ(targetGroup[0].get()->targets.size(), 1u);
+    EXPECT_EQ(targetGroup[0].get()->targets[0], "192.168.22.32:6443");
+    EXPECT_EQ(targetGroup[0].get()->labels.size(), 13u);
+    EXPECT_EQ(targetGroup[1].get()->targets.size(), 1u);
+    EXPECT_EQ(targetGroup[1].get()->targets[0], "192.168.22.31:6443");
+    EXPECT_EQ(targetGroup[1].get()->labels.size(), 12u);
+    EXPECT_TRUE(result);
+    server_thread.detach();
+}
+} // namespace logtail
+UNIT_TEST_MAIN


### PR DESCRIPTION
The Target Allocator is used to interact with OneOperator. It retrieves the Targets to be scraped from OneOperator using HTTP service discovery, based on the Input configuration which includes Scrape Config.