### PR TITLE
feat: add self-monitor metrics for flusher_http

### DIFF
--- a/docs/cn/developer-guide/plugin-development/plugin-self-monitor-guide.md
+++ b/docs/cn/developer-guide/plugin-development/plugin-self-monitor-guide.md
@@ -3,7 +3,7 @@ iLogtail提供了指标接口，可以方便地为插件增加一些自监控指
 
 接口：
 
-<https://github.com/alibaba/ilogtail/blob/main/pkg/pipeline/self_metric.go>
+<https://github.com/alibaba/ilogtail/blob/main/pkg/pipeline/self_metrics.go>
 
 实现：
 

--- a/docs/cn/plugins/flusher/flusher-http.md
+++ b/docs/cn/plugins/flusher/flusher-http.md
@@ -30,7 +30,13 @@
 | Convert.ProtocolFieldsRename | Map<String,String> | 否       | ilogtail日志协议字段重命名，可当前可重命名的字段：`contents`,`tags`和`time`                                                                                                                                    |
 | Concurrency                  | Int                | 否       | 向url发起请求的并发数，默认为`1`                                                                                                                                                                      |
 | QueueCapacity                  | Int                | 否       | 内部channel的缓存大小，默认为1024
-| AsyncIntercept                  | Boolean                | 否       | 异步过滤数据，默认为否
+| AsyncIntercept                  | Boolean                | 否       | 异步过滤数据，默认为否 |
+| DropEventWhenQueueFull         | Boolean                | 否       | 当队列满时是否丢弃数据，否则需要等待，默认为不丢弃 |
+| JitterInSec                  |  Int               | 否      | 引入随机 Jitter，打散流量, 默认不开启 |
+| Compression                  | string                | 否       | 压缩策略，目前支持gzip和snappy，默认不开启 |
+| ExemplarEvents                  | []string                 | 否       | 打印一些采样event，默认不开启 |
+
+
 
 ## 样例
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/denisenkom/go-mssqldb v0.12.2
 	github.com/dlclark/regexp2 v1.7.0
 	github.com/docker/docker v20.10.23+incompatible
+	github.com/dustin/go-broadcast v0.0.0-00010101000000-000000000000
 	github.com/eclipse/paho.mqtt.golang v1.3.5
 	github.com/elastic/beats/v7 v7.7.1
 	github.com/elastic/go-elasticsearch/v8 v8.6.0
@@ -24,6 +25,7 @@ require (
 	github.com/go-ping/ping v0.0.0-20211130115550-779d1e919534
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang/snappy v0.0.4
 	github.com/gosnmp/gosnmp v1.34.0
 	github.com/grafana/loki-client-go v0.0.0-20230116142646-e7494d0ef70c
 	github.com/hashicorp/golang-lru/v2 v2.0.2
@@ -141,7 +143,6 @@ require (
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
@@ -271,6 +272,7 @@ replace (
 	github.com/VictoriaMetrics/metrics => github.com/iLogtail/metrics v1.23.0-ilogtail
 	github.com/alibaba/ilogtail/pkg => ./pkg
 	github.com/aliyun/alibaba-cloud-sdk-go/services/sls_inner => ./external/github.com/aliyun/alibaba-cloud-sdk-go/services/sls_inner
+	github.com/dustin/go-broadcast => github.com/shunjiazhu/go-broadcast v0.0.0-20240521121616-1cf46d6a4244
 	github.com/elastic/beats/v7 => ./external/github.com/elastic/beats/v7
 	github.com/jeromer/syslogparser => ./external/github.com/jeromer/syslogparser
 	github.com/mindprince/gonvml => github.com/iLogtail/gonvml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1414,6 +1414,8 @@ github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9Nz
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
+github.com/shunjiazhu/go-broadcast v0.0.0-20240521121616-1cf46d6a4244 h1:JN5WyECayAtVSLTwQs16C6d7Z9pqBR8WVtENzMqG2mM=
+github.com/shunjiazhu/go-broadcast v0.0.0-20240521121616-1cf46d6a4244/go.mod h1:8rK6Kbo1Jd6sK22b24aPVgAm3jlNy1q1ft+lBALdIqA=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=

--- a/licenses/LICENSE_OF_ILOGTAIL_DEPENDENCIES.md
+++ b/licenses/LICENSE_OF_ILOGTAIL_DEPENDENCIES.md
@@ -232,6 +232,7 @@ When distributed in a binary form, iLogtail may contain portions of the followin
 - [github.com/stretchr/testify](https://pkg.go.dev/github.com/stretchr/testify?tab=licenses)
 - [go.uber.org/goleak](https://pkg.go.dev/go.uber.org/goleak?tab=licenses)
 - [github.com/influxdata/telegraf](https://pkg.go.dev/github.com/influxdata/telegraf?tab=licenses)
+- [github.com/dustin/go-broadcast](https://pkg.go.dev/github.com/dustin/go-broadcast?tab=licenses)
 
 ## ISC licenses
 

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -3,6 +3,7 @@ module github.com/alibaba/ilogtail/pkg
 go 1.19
 
 require (
+	github.com/Microsoft/go-winio v0.5.2
 	github.com/cespare/xxhash v1.1.0
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
@@ -15,6 +16,7 @@ require (
 	github.com/influxdata/influxdb v1.11.0
 	github.com/influxdata/line-protocol/v2 v2.2.1
 	github.com/influxdata/telegraf v1.20.0
+	github.com/json-iterator/go v1.1.12
 	github.com/mailru/easyjson v0.7.7
 	github.com/narqo/go-dogstatsd-parser v0.2.0
 	github.com/pierrec/lz4 v2.6.1+incompatible
@@ -37,7 +39,6 @@ require (
 )
 
 require (
-	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/Microsoft/hcsshim v0.9.4 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
@@ -77,7 +78,6 @@ require (
 	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
 	github.com/intel/goresctrl v0.2.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/klauspost/compress v1.15.15 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect

--- a/pkg/helper/net_test.go
+++ b/pkg/helper/net_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 iLogtail Authors
+// Copyright 2024 iLogtail Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,20 +17,24 @@ package helper
 import (
 	"errors"
 	"io"
-	"net"
+	"net/url"
+	"testing"
 
-	knet "k8s.io/apimachinery/pkg/util/net"
+	"github.com/stretchr/testify/assert"
 )
 
-func GetFreePort() (port int, err error) {
-	listener, err := net.Listen("tcp", ":0") //nolint:gosec
-	if err != nil {
-		return 0, err
+func TestIsEOF(t *testing.T) {
+	err := &url.Error{
+		Op:  "Post",
+		URL: "http://test",
+		Err: io.EOF,
 	}
-	defer listener.Close()
-	return listener.Addr().(*net.TCPAddr).Port, nil
-}
+	assert.True(t, IsErrorEOF(err))
 
-func IsErrorEOF(err error) bool {
-	return errors.Is(err, io.EOF) || knet.IsProbableEOF(err)
+	err = &url.Error{
+		Op:  "Post",
+		URL: "http://test",
+		Err: errors.New("connection reset by peer"),
+	}
+	assert.True(t, IsErrorEOF(err))
 }

--- a/pkg/helper/time.go
+++ b/pkg/helper/time.go
@@ -1,0 +1,48 @@
+// Copyright 2024 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper
+
+import (
+	"crypto/rand"
+	"math/big"
+	"time"
+)
+
+// RandomSleep sleeps for a random duration between 0 and jitterInSec.
+// If jitterInSec is 0, it will skip sleep.
+// If shutdown is closed, it will stop sleep immediately.
+func RandomSleep(maxJitter time.Duration, stopChan chan interface{}) {
+	if maxJitter == 0 {
+		return
+	}
+
+	sleepTime := GetJitter(maxJitter)
+	t := time.NewTimer(sleepTime)
+	select {
+	case <-t.C:
+		return
+	case <-stopChan:
+		t.Stop()
+		return
+	}
+}
+
+func GetJitter(maxJitter time.Duration) time.Duration {
+	jitter, err := rand.Int(rand.Reader, big.NewInt(int64(maxJitter)))
+	if err != nil {
+		return 0
+	}
+	return time.Duration(jitter.Int64())
+}

--- a/plugins/flusher/http/flusher_http.go
+++ b/plugins/flusher/http/flusher_http.go
@@ -16,6 +16,7 @@ package http
 
 import (
 	"bytes"
+	"compress/gzip"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -23,8 +24,15 @@ import (
 	"math/big"
 	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
+
+	"github.com/dustin/go-broadcast"
+	"github.com/golang/snappy"
+	"k8s.io/apimachinery/pkg/util/net"
 
 	"github.com/alibaba/ilogtail/pkg/fmtstr"
 	"github.com/alibaba/ilogtail/pkg/helper"
@@ -39,8 +47,9 @@ import (
 const (
 	defaultTimeout = time.Minute
 
-	contentTypeHeader  = "Content-Type"
-	defaultContentType = "application/octet-stream"
+	contentTypeHeader     = "Content-Type"
+	defaultContentType    = "application/octet-stream"
+	contentEncodingHeader = "Content-Encoding"
 )
 
 var contentTypeMaps = map[string]string{
@@ -50,6 +59,16 @@ var contentTypeMaps = map[string]string{
 	converter.EncodingCustom:   defaultContentType,
 }
 
+var supportedCompressionType = map[string]any{
+	"gzip":   nil,
+	"snappy": nil,
+}
+
+var (
+	flusherID       = int64(0) // http flusher id that starts from 0
+	sensitiveLabels = []string{"u", "user", "username", "p", "password", "passwd", "pwd", "Authorization"}
+)
+
 type retryConfig struct {
 	Enable        bool          // If enable retry, default is true
 	MaxRetryTimes int           // Max retry times, default is 3
@@ -58,18 +77,22 @@ type retryConfig struct {
 }
 
 type FlusherHTTP struct {
-	RemoteURL           string                       // RemoteURL to request
-	Headers             map[string]string            // Headers to append to the http request
-	Query               map[string]string            // Query parameters to append to the http request
-	Timeout             time.Duration                // Request timeout, default is 60s
-	Retry               retryConfig                  // Retry strategy, default is retry 3 times with delay time begin from 1second, max to 30 seconds
-	Convert             helper.ConvertConfig         // Convert defines which protocol and format to convert to
-	Concurrency         int                          // How many requests can be performed in concurrent
-	Authenticator       *extensions.ExtensionConfig  // name and options of the extensions.ClientAuthenticator extension to use
-	FlushInterceptor    *extensions.ExtensionConfig  // name and options of the extensions.FlushInterceptor extension to use
-	AsyncIntercept      bool                         // intercept the event asynchronously
-	RequestInterceptors []extensions.ExtensionConfig // custom request interceptor settings
-	QueueCapacity       int                          // capacity of channel
+	RemoteURL              string                       // RemoteURL to request
+	Headers                map[string]string            // Headers to append to the http request
+	Query                  map[string]string            // Query parameters to append to the http request
+	Timeout                time.Duration                // Request timeout, default is 60s
+	Retry                  retryConfig                  // Retry strategy, default is retry 3 times with delay time begin from 1second, max to 30 seconds
+	Convert                helper.ConvertConfig         // Convert defines which protocol and format to convert to
+	Concurrency            int                          // How many requests can be performed in concurrent
+	Authenticator          *extensions.ExtensionConfig  // name and options of the extensions.ClientAuthenticator extension to use
+	FlushInterceptor       *extensions.ExtensionConfig  // name and options of the extensions.FlushInterceptor extension to use
+	AsyncIntercept         bool                         // intercept the event asynchronously
+	RequestInterceptors    []extensions.ExtensionConfig // custom request interceptor settings
+	QueueCapacity          int                          // capacity of channel
+	DropEventWhenQueueFull bool                         // If true, pipeline events will be dropped when the queue is full
+	JitterInSec            int                          // JitterInSec is the jitter time in seconds to prevent peek traffic , default is 0
+	Compression            string                       // Compression type, support gzip and snappy
+	ExemplarEvents         []string                     // log some event details for debug purpose
 
 	varKeys []string
 
@@ -78,8 +101,24 @@ type FlusherHTTP struct {
 	client      *http.Client
 	interceptor extensions.FlushInterceptor
 
-	queue   chan interface{}
-	counter sync.WaitGroup
+	broadcaster broadcast.Broadcaster
+	queue       chan *groupEventsWithTimestamp
+	counter     sync.WaitGroup
+
+	matchedEvents        pipeline.CounterMetric
+	unmatchedEvents      pipeline.CounterMetric
+	droppedEvents        pipeline.CounterMetric
+	retryCount           pipeline.CounterMetric
+	flushFailure         pipeline.CounterMetric
+	flushLatency         pipeline.CounterMetric
+	statusCodeStatistics pipeline.MetricVector[pipeline.CounterMetric]
+}
+
+// groupEventsWithTimestamp is a struct that contains the data and the time it was enqueued.
+// it is used for compute the jitter.
+type groupEventsWithTimestamp struct {
+	data        any
+	enqueueTime time.Time
 }
 
 func (f *FlusherHTTP) Description() string {
@@ -132,36 +171,70 @@ func (f *FlusherHTTP) Init(context pipeline.Context) error {
 	if f.QueueCapacity <= 0 {
 		f.QueueCapacity = 1024
 	}
-	f.queue = make(chan interface{}, f.QueueCapacity)
+	f.queue = make(chan *groupEventsWithTimestamp, f.QueueCapacity)
+
+	if f.JitterInSec > 0 {
+		f.broadcaster = broadcast.NewBroadcaster(f.Concurrency)
+	}
+
 	for i := 0; i < f.Concurrency; i++ {
-		go f.runFlushTask()
+		subscribeChan := make(chan interface{}, 1)
+		if f.JitterInSec > 0 {
+			f.broadcaster.Register(subscribeChan)
+		}
+		go f.runFlushTask(subscribeChan)
 	}
 
 	f.buildVarKeys()
 	f.fillRequestContentType()
 
-	logger.Info(f.context.GetRuntimeContext(), "http flusher init", "initialized")
+	metricsRecord := f.context.GetMetricRecord()
+	metricLabels := f.buildLabels()
+	f.matchedEvents = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_matched_events", metricLabels...)
+	f.unmatchedEvents = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_unmatched_events", metricLabels...)
+	f.droppedEvents = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_dropped_events", metricLabels...)
+	f.retryCount = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_retry_count", metricLabels...)
+	f.flushFailure = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_flush_failure_count", metricLabels...)
+	f.flushLatency = helper.NewAverageMetricAndRegister(metricsRecord, "http_flusher_flush_latency_ns", metricLabels...)
+
+	f.statusCodeStatistics = helper.NewCounterMetricVectorAndRegister(metricsRecord,
+		"http_flusher_status_code_count",
+		helper.LogContentsToMap(metricLabels),
+		[]string{"status_code"})
+
+	logger.Info(f.context.GetRuntimeContext(), "http flusher init", "initialized",
+		"timeout", f.Timeout,
+		"jitter", time.Duration(f.JitterInSec)*time.Second,
+		"compression", f.Compression,
+		"sample_events", f.ExemplarEvents)
 	return nil
 }
 
 func (f *FlusherHTTP) Flush(projectName string, logstoreName string, configName string, logGroupList []*protocol.LogGroup) error {
+	now := time.Now()
 	for _, logGroup := range logGroupList {
-		f.addTask(logGroup)
+		f.addTask(logGroup, now)
 	}
 	return nil
 }
 
 func (f *FlusherHTTP) Export(groupEventsArray []*models.PipelineGroupEvents, ctx pipeline.PipelineContext) error {
+	now := time.Now()
 	for _, groupEvents := range groupEventsArray {
+		if groupEvents == nil {
+			continue
+		}
+
 		if !f.AsyncIntercept && f.interceptor != nil {
+			originCount := int64(len(groupEvents.Events))
 			groupEvents = f.interceptor.Intercept(groupEvents)
+			f.unmatchedEvents.Add(getInterceptedEventCount(originCount, groupEvents))
 			// skip groupEvents that is nil or empty.
 			if groupEvents == nil || len(groupEvents.Events) == 0 {
 				continue
 			}
 		}
-
-		f.addTask(groupEvents)
+		f.addTask(groupEvents, now)
 	}
 	return nil
 }
@@ -174,6 +247,10 @@ func (f *FlusherHTTP) IsReady(projectName string, logstoreName string, logstoreK
 }
 
 func (f *FlusherHTTP) Stop() error {
+	if f.broadcaster != nil {
+		_ = f.broadcaster.Close() // close the broadcaster to flush all the data in the queue
+	}
+
 	f.counter.Wait()
 	close(f.queue)
 	return nil
@@ -249,18 +326,65 @@ func (f *FlusherHTTP) getConverter() (*converter.Converter, error) {
 	return converter.NewConverterWithSep(f.Convert.Protocol, f.Convert.Encoding, f.Convert.Separator, f.Convert.IgnoreUnExpectedData, f.Convert.TagFieldsRename, f.Convert.ProtocolFieldsRename, f.context.GetPipelineScopeConfig())
 }
 
-func (f *FlusherHTTP) addTask(log interface{}) {
+func (f *FlusherHTTP) addTask(log interface{}, enqueueTime time.Time) {
 	f.counter.Add(1)
-	f.queue <- log
+
+	// if queue is under high pressure, wake up all flushTask.
+	if f.JitterInSec > 0 && len(f.queue) >= cap(f.queue)/2 {
+		f.broadcaster.TrySubmit(nil)
+	}
+
+	groupWithTs := &groupEventsWithTimestamp{
+		data:        log,
+		enqueueTime: enqueueTime,
+	}
+
+	if f.DropEventWhenQueueFull {
+		select {
+		case f.queue <- groupWithTs:
+		default:
+			f.handleDroppedEvent(log)
+		}
+	} else {
+		f.queue <- groupWithTs
+	}
+}
+
+// handleDroppedEvent handles a dropped event and reports metrics.
+func (f *FlusherHTTP) handleDroppedEvent(log interface{}) {
+	f.counter.Done()
+
+	// Update the dropped events counter based on the type of the log.
+	switch v := log.(type) {
+	case *protocol.LogGroup:
+		if v != nil {
+			f.droppedEvents.Add(int64(len(v.Logs)))
+		}
+	case *models.PipelineGroupEvents:
+		if v != nil {
+			f.droppedEvents.Add(int64(len(v.Events)))
+		}
+	}
+	logger.Warningf(f.context.GetRuntimeContext(), "FLUSHER_FLUSH_ALARM", "http flusher dropped a group event since the queue is full")
 }
 
 func (f *FlusherHTTP) countDownTask() {
 	f.counter.Done()
 }
 
-func (f *FlusherHTTP) runFlushTask() {
-	for data := range f.queue {
-		err := f.convertAndFlush(data)
+func (f *FlusherHTTP) runFlushTask(subscribeChan chan interface{}) {
+	jitterDuration := time.Duration(f.JitterInSec) * time.Second
+
+	for event := range f.queue {
+		eventWaitTime := time.Since(event.enqueueTime)
+
+		// if queue is under low pressure and that there are some idle workers, sleep randomly.
+		if eventWaitTime < jitterDuration && len(f.queue) < f.Concurrency {
+			maxSleepDuration := jitterDuration - eventWaitTime
+			randomSleep(maxSleepDuration, subscribeChan)
+		}
+
+		err := f.convertAndFlush(event.data)
 		if err != nil {
 			logger.Error(f.context.GetRuntimeContext(), "FLUSHER_FLUSH_ALARM", "http flusher failed convert or flush data, data dropped, error", err)
 		}
@@ -277,9 +401,21 @@ func (f *FlusherHTTP) convertAndFlush(data interface{}) error {
 		logs, varValues, err = f.converter.ToByteStreamWithSelectedFields(v, f.varKeys)
 	case *models.PipelineGroupEvents:
 		if f.AsyncIntercept && f.interceptor != nil {
+			originCount := int64(len(v.Events))
 			v = f.interceptor.Intercept(v)
+			f.unmatchedEvents.Add(getInterceptedEventCount(originCount, v))
 			if v == nil || len(v.Events) == 0 {
 				return nil
+			}
+		}
+		f.matchedEvents.Add(int64(len(v.Events)))
+		if len(f.ExemplarEvents) > 0 {
+			for _, target := range f.ExemplarEvents {
+				for _, m := range v.Events {
+					if m.GetName() == target && m.GetType() == models.EventTypeMetric {
+						logger.Infof(f.context.GetRuntimeContext(), "http flusher found target metric: %s: details: %v", target, m.(*models.Metric).String())
+					}
+				}
 			}
 		}
 		logs, varValues, err = f.converter.ToByteStreamWithSelectedFieldsV2(v, f.varKeys)
@@ -291,20 +427,25 @@ func (f *FlusherHTTP) convertAndFlush(data interface{}) error {
 		logger.Error(f.context.GetRuntimeContext(), "FLUSHER_FLUSH_ALARM", "http flusher converter log fail, error", err)
 		return err
 	}
+
 	switch rows := logs.(type) {
 	case [][]byte:
 		for idx, data := range rows {
 			body, values := data, varValues[idx]
 			err = f.flushWithRetry(body, values)
 			if err != nil {
-				logger.Error(f.context.GetRuntimeContext(), "FLUSHER_FLUSH_ALARM", "http flusher failed flush data after retry, data dropped, error", err)
+				f.flushFailure.Add(1)
+				logger.Error(f.context.GetRuntimeContext(), "FLUSHER_FLUSH_ALARM", "http flusher failed flush data after retry, data dropped, error", err,
+					"remote url", f.RemoteURL, "headers", f.getInsensitiveMap(f.Headers), "query", f.getInsensitiveMap(f.Query))
 			}
 		}
 		return nil
 	case []byte:
 		err = f.flushWithRetry(rows, nil)
 		if err != nil {
-			logger.Error(f.context.GetRuntimeContext(), "FLUSHER_FLUSH_ALARM", "http flusher failed flush data after retry, error", err)
+			f.flushFailure.Add(1)
+			logger.Error(f.context.GetRuntimeContext(), "FLUSHER_FLUSH_ALARM", "http flusher failed flush data after retry, data dropped, error", err,
+				"remote url", f.RemoteURL, "headers", f.getInsensitiveMap(f.Headers), "query", f.getInsensitiveMap(f.Query))
 		}
 		return err
 	default:
@@ -316,16 +457,30 @@ func (f *FlusherHTTP) convertAndFlush(data interface{}) error {
 
 func (f *FlusherHTTP) flushWithRetry(data []byte, varValues map[string]string) error {
 	var err error
+	start := time.Now()
+
 	for i := 0; i <= f.Retry.MaxRetryTimes; i++ {
+		if i > 0 { // first flush is not retry
+			f.retryCount.Add(1)
+		}
+
 		ok, retryable, e := f.flush(data, varValues)
-		if ok || !retryable || !f.Retry.Enable {
+		isEoF := isErrorEOF(e)
+		//  retry if the error is io.EOF.
+		if ok || (!retryable && !isEoF) || !f.Retry.Enable {
 			err = e
 			break
 		}
+
+		if isEoF {
+			logger.Debugf(f.context.GetRuntimeContext(), "http flusher sent requests and got EOF, will retry")
+		}
+
 		err = e
 		<-time.After(f.getNextRetryDelay(i))
 	}
 	converter.PutPooledByteBuf(&data)
+	f.flushLatency.Add(time.Since(start).Nanoseconds())
 	return err
 }
 
@@ -345,8 +500,37 @@ func (f *FlusherHTTP) getNextRetryDelay(retryTime int) time.Duration {
 	return time.Duration(harf + jitter.Int64())
 }
 
+func (f *FlusherHTTP) compressData(data []byte) (io.Reader, error) {
+	var reader io.Reader = bytes.NewReader(data)
+	if compressionType, ok := f.Headers[contentEncodingHeader]; ok {
+		switch compressionType {
+		case "gzip":
+			var buf bytes.Buffer
+			gw := gzip.NewWriter(&buf)
+			if _, err := gw.Write(data); err != nil {
+				return nil, err
+			}
+			if err := gw.Close(); err != nil {
+				return nil, err
+			}
+			reader = &buf
+		case "snappy":
+			compressedData := snappy.Encode(nil, data)
+			reader = bytes.NewReader(compressedData)
+		default:
+		}
+	}
+	return reader, nil
+}
+
 func (f *FlusherHTTP) flush(data []byte, varValues map[string]string) (ok, retryable bool, err error) {
-	req, err := http.NewRequest(http.MethodPost, f.RemoteURL, bytes.NewReader(data))
+	reader, err := f.compressData(data)
+	if err != nil {
+		logger.Error(f.context.GetRuntimeContext(), "FLUSHER_FLUSH_ALARM", "create reader error", err)
+		return false, false, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, f.RemoteURL, reader)
 	if err != nil {
 		logger.Error(f.context.GetRuntimeContext(), "FLUSHER_FLUSH_ALARM", "http flusher create request fail, error", err)
 		return false, false, err
@@ -384,6 +568,7 @@ func (f *FlusherHTTP) flush(data []byte, varValues map[string]string) (ok, retry
 		}
 		req.Header.Add(k, v)
 	}
+
 	response, err := f.client.Do(req)
 	if logger.DebugFlag() {
 		logger.Debugf(f.context.GetRuntimeContext(), "request [method]: %v; [header]: %v; [url]: %v; [body]: %v", req.Method, req.Header, req.URL, string(data))
@@ -407,6 +592,9 @@ func (f *FlusherHTTP) flush(data []byte, varValues map[string]string) (ok, retry
 		logger.Warning(f.context.GetRuntimeContext(), "FLUSHER_FLUSH_ALARM", "http flusher close response body fail, error", err)
 		return false, false, err
 	}
+
+	f.statusCodeStatistics.WithLabels(pipeline.Label{Key: "status_code", Value: strconv.Itoa(response.StatusCode)}).Add(1)
+
 	switch response.StatusCode / 100 {
 	case 2:
 		return true, false, nil
@@ -417,9 +605,42 @@ func (f *FlusherHTTP) flush(data []byte, varValues map[string]string) (ok, retry
 		if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden {
 			return false, true, fmt.Errorf("err status returned: %v", response.Status)
 		}
+
 		logger.Error(f.context.GetRuntimeContext(), "FLUSHER_FLUSH_ALARM", "http flusher write data returned error, url", req.URL.String(), "status", response.Status, "body", string(body))
 		return false, false, fmt.Errorf("unexpected status returned: %v", response.Status)
 	}
+}
+
+func (f *FlusherHTTP) buildLabels() []*protocol.Log_Content {
+	id := atomic.AddInt64(&flusherID, 1) - 1
+	labels := make([]*protocol.Log_Content, 0, len(f.Query)+2)
+	labels = append(labels, &protocol.Log_Content{Key: "RemoteURL", Value: f.RemoteURL})
+	for k, v := range f.Query {
+		if !isSensitiveKey(k) {
+			labels = append(labels, &protocol.Log_Content{Key: k, Value: v})
+		}
+	}
+	labels = append(labels, &protocol.Log_Content{Key: "flusher_http_id", Value: strconv.FormatInt(id, 10)})
+	return labels
+}
+
+func (f *FlusherHTTP) getInsensitiveMap(info map[string]string) map[string]string {
+	res := make(map[string]string, len(info))
+	for k, v := range info {
+		if !isSensitiveKey(k) {
+			res[k] = v
+		}
+	}
+	return res
+}
+
+func isSensitiveKey(label string) bool {
+	for _, sensitiveKey := range sensitiveLabels {
+		if strings.ToLower(label) == sensitiveKey {
+			return true
+		}
+	}
+	return false
 }
 
 func (f *FlusherHTTP) buildVarKeys() {
@@ -450,6 +671,12 @@ func (f *FlusherHTTP) fillRequestContentType() {
 		f.Headers = make(map[string]string, 4)
 	}
 
+	if f.Compression != "" {
+		if _, ok := supportedCompressionType[f.Compression]; ok {
+			f.Headers[contentEncodingHeader] = f.Compression
+		}
+	}
+
 	_, ok := f.Headers[contentTypeHeader]
 	if ok {
 		return
@@ -462,12 +689,51 @@ func (f *FlusherHTTP) fillRequestContentType() {
 	f.Headers[contentTypeHeader] = contentType
 }
 
+func getInterceptedEventCount(origin int64, group *models.PipelineGroupEvents) int64 {
+	if group == nil {
+		return origin
+	}
+	return origin - int64(len(group.Events))
+}
+
+func isErrorEOF(err error) bool {
+	return errors.Is(err, io.EOF) || net.IsProbableEOF(err)
+}
+
+// randomSleep sleeps for a random duration between 0 and jitterInSec.
+// If jitterInSec is 0, it will skip sleep.
+// If shutdown is closed, it will stop sleep immediately.
+func randomSleep(maxJitter time.Duration, stopChan chan interface{}) {
+	if maxJitter == 0 {
+		return
+	}
+
+	sleepTime := getJitter(maxJitter)
+	t := time.NewTimer(sleepTime)
+	select {
+	case <-t.C:
+		return
+	case <-stopChan:
+		t.Stop()
+		return
+	}
+}
+
+func getJitter(maxJitter time.Duration) time.Duration {
+	jitter, err := rand.Int(rand.Reader, big.NewInt(int64(maxJitter)))
+	if err != nil {
+		return 0
+	}
+	return time.Duration(jitter.Int64())
+}
+
 func init() {
 	pipeline.Flushers["flusher_http"] = func() pipeline.Flusher {
 		return &FlusherHTTP{
 			QueueCapacity: 1024,
 			Timeout:       defaultTimeout,
 			Concurrency:   1,
+			JitterInSec:   0,
 			Convert: helper.ConvertConfig{
 				Protocol:             converter.ProtocolCustomSingle,
 				Encoding:             converter.EncodingJSON,
@@ -479,6 +745,7 @@ func init() {
 				InitialDelay:  time.Second,
 				MaxDelay:      30 * time.Second,
 			},
+			DropEventWhenQueueFull: true,
 		}
 	}
 }

--- a/plugins/flusher/http/flusher_http.go
+++ b/plugins/flusher/http/flusher_http.go
@@ -410,8 +410,8 @@ func (f *FlusherHTTP) convertAndFlush(data interface{}) error {
 		if len(f.ExemplarEvents) > 0 {
 			for _, target := range f.ExemplarEvents {
 				for _, m := range v.Events {
-					if m.GetName() == target && m.GetType() == models.EventTypeMetric {
-						logger.Infof(f.context.GetRuntimeContext(), "http flusher found target metric: %s: details: %v", target, m.(*models.Metric).String())
+					if m.GetName() == target {
+						logger.Infof(f.context.GetRuntimeContext(), "http flusher found target exemplar event: %s: details: %v", target, m)
 					}
 				}
 			}
@@ -703,7 +703,6 @@ func init() {
 			QueueCapacity: 1024,
 			Timeout:       defaultTimeout,
 			Concurrency:   1,
-			JitterInSec:   0,
 			Convert: helper.ConvertConfig{
 				Protocol:             converter.ProtocolCustomSingle,
 				Encoding:             converter.EncodingJSON,
@@ -715,7 +714,6 @@ func init() {
 				InitialDelay:  time.Second,
 				MaxDelay:      30 * time.Second,
 			},
-			DropEventWhenQueueFull: true,
 		}
 	}
 }

--- a/plugins/flusher/http/flusher_http_test.go
+++ b/plugins/flusher/http/flusher_http_test.go
@@ -15,14 +15,20 @@
 package http
 
 import (
+	"compress/gzip"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"sort"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/dustin/go-broadcast"
 	"github.com/jarcoal/httpmock"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
@@ -44,7 +50,7 @@ func TestHttpFlusherInit(t *testing.T) {
 			RemoteURL: "",
 		}
 		Convey("Then Init() should return error", func() {
-			err := flusher.Init(mockContext{})
+			err := flusher.Init(&mockContext{})
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -55,7 +61,7 @@ func TestHttpFlusherInit(t *testing.T) {
 			Convert:   helper.ConvertConfig{},
 		}
 		Convey("Then Init() should return error", func() {
-			err := flusher.Init(mockContext{})
+			err := flusher.Init(&mockContext{})
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -74,7 +80,7 @@ func TestHttpFlusherInit(t *testing.T) {
 			},
 		}
 		Convey("Then Init() should build the variable keys", func() {
-			err := flusher.Init(mockContext{})
+			err := flusher.Init(&mockContext{})
 			So(err, ShouldBeNil)
 			So(flusher.varKeys, ShouldResemble, []string{"var"})
 		})
@@ -94,7 +100,7 @@ func TestHttpFlusherInit(t *testing.T) {
 			},
 		}
 		Convey("Then Init() should build the variable keys", func() {
-			err := flusher.Init(mockContext{})
+			err := flusher.Init(&mockContext{})
 			So(err, ShouldBeNil)
 			So(flusher.varKeys, ShouldResemble, []string{"var"})
 		})
@@ -118,7 +124,7 @@ func TestHttpFlusherInit(t *testing.T) {
 			},
 		}
 		Convey("Then Init() should build the variable keys", func() {
-			err := flusher.Init(mockContext{})
+			err := flusher.Init(&mockContext{})
 			sort.Strings(flusher.varKeys)
 			So(err, ShouldBeNil)
 			So(flusher.varKeys, ShouldResemble, []string{"var1", "var2"})
@@ -156,7 +162,7 @@ func TestHttpFlusherFlush(t *testing.T) {
 			},
 		}
 
-		err := flusher.Init(mockContext{})
+		err := flusher.Init(&mockContext{})
 		So(err, ShouldBeNil)
 
 		Convey("When Flush with logGroupList contains 2 valid Log in influxdb format metrics, each with LogTag: '__tag__:db'", func() {
@@ -255,7 +261,7 @@ func TestHttpFlusherFlush(t *testing.T) {
 			},
 		}
 
-		err := flusher.Init(mockContext{})
+		err := flusher.Init(&mockContext{})
 		So(err, ShouldBeNil)
 
 		Convey("When Flush with logGroupList contains 2 valid Log in influxdb format metrics, each LOG with Content: '__tag__:db'", func() {
@@ -363,7 +369,7 @@ func TestHttpFlusherFlushWithAuthenticator(t *testing.T) {
 			},
 		}
 
-		err := flusher.Init(mockContext{basicAuth: authenticator})
+		err := flusher.Init(&mockContext{basicAuth: authenticator})
 		So(err, ShouldBeNil)
 
 		Convey("When Flush with logGroupList contains 2 valid Log in influxdb format metrics, each with LogTag: '__tag__:db'", func() {
@@ -434,6 +440,10 @@ func TestHttpFlusherFlushWithAuthenticator(t *testing.T) {
 					})
 				})
 			})
+
+			logGroup := &protocol.LogGroup{}
+			flusher.context.MetricSerializeToPB(logGroup)
+			assert.Greater(t, len(logGroup.Logs), 0)
 		})
 	})
 }
@@ -679,12 +689,22 @@ func TestHttpFlusherFlushWithInterceptor(t *testing.T) {
 				Protocol: converter.ProtocolInfluxdb,
 				Encoding: converter.EncodingCustom,
 			},
+			context:        mock.NewEmptyContext("p", "l", "c"),
 			interceptor:    mockIntercepter,
 			AsyncIntercept: false,
 			Timeout:        defaultTimeout,
 			Concurrency:    1,
-			queue:          make(chan interface{}, 10),
+			queue:          make(chan *groupEventsWithTimestamp, 10),
 		}
+		flusher.broadcaster = broadcast.NewBroadcaster(flusher.Concurrency)
+		metricLabels := flusher.buildLabels()
+		metricsRecord := flusher.context.GetMetricRecord()
+		flusher.unmatchedEvents = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_unmatched_events", metricLabels...)
+		flusher.matchedEvents = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_matched_events", metricLabels...)
+		flusher.droppedEvents = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_dropped_events", metricLabels...)
+		flusher.retryCount = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_retry_count", metricLabels...)
+		flusher.flushFailure = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_flush_failure_count", metricLabels...)
+		flusher.flushLatency = helper.NewAverageMetricAndRegister(metricsRecord, "http_flusher_flush_latency_ns", metricLabels...) // cannot use latency metric
 
 		Convey("should discard all events", func() {
 			groupEvents := models.PipelineGroupEvents{
@@ -710,11 +730,21 @@ func TestHttpFlusherFlushWithInterceptor(t *testing.T) {
 				Encoding: converter.EncodingCustom,
 			},
 			interceptor:    mockIntercepter,
+			context:        mock.NewEmptyContext("p", "l", "c"),
 			AsyncIntercept: true,
 			Timeout:        defaultTimeout,
 			Concurrency:    1,
-			queue:          make(chan interface{}, 10),
+			queue:          make(chan *groupEventsWithTimestamp, 10),
 		}
+		flusher.broadcaster = broadcast.NewBroadcaster(flusher.Concurrency)
+		metricLabels := flusher.buildLabels()
+		metricsRecord := flusher.context.GetMetricRecord()
+		flusher.unmatchedEvents = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_unmatched_events", metricLabels...)
+		flusher.matchedEvents = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_matched_events", metricLabels...)
+		flusher.droppedEvents = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_dropped_events", metricLabels...)
+		flusher.retryCount = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_retry_count", metricLabels...)
+		flusher.flushFailure = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_flush_failure_count", metricLabels...)
+		flusher.flushLatency = helper.NewAverageMetricAndRegister(metricsRecord, "http_flusher_flush_latency_ns", metricLabels...) // cannot use latency metric
 
 		Convey("should discard all events", func() {
 			groupEvents := models.PipelineGroupEvents{
@@ -728,20 +758,252 @@ func TestHttpFlusherFlushWithInterceptor(t *testing.T) {
 			err := flusher.Export([]*models.PipelineGroupEvents{&groupEvents}, nil)
 			So(err, ShouldBeNil)
 			So(len(flusher.queue), ShouldEqual, 1)
-			err = flusher.convertAndFlush(<-flusher.queue)
+			err = flusher.convertAndFlush((<-flusher.queue).data)
 			So(err, ShouldBeNil)
 		})
 
 	})
 }
 
-type mockContext struct {
-	pipeline.Context
-	basicAuth   *basicAuth
-	interceptor *mockInterceptor
+func TestHttpFlusherDropEvents(t *testing.T) {
+	Convey("Given a http flusher that drops events when queue is full", t, func() {
+		mockIntercepter := &mockInterceptor{}
+		flusher := &FlusherHTTP{
+			RemoteURL: "http://test.com/write",
+			Convert: helper.ConvertConfig{
+				Protocol: converter.ProtocolInfluxdb,
+				Encoding: converter.EncodingCustom,
+			},
+			interceptor:            mockIntercepter,
+			context:                mock.NewEmptyContext("p", "l", "c"),
+			AsyncIntercept:         true,
+			Timeout:                defaultTimeout,
+			Concurrency:            1,
+			queue:                  make(chan *groupEventsWithTimestamp, 1),
+			DropEventWhenQueueFull: true,
+		}
+		flusher.broadcaster = broadcast.NewBroadcaster(flusher.Concurrency)
+		metricLabels := flusher.buildLabels()
+		metricsRecord := flusher.context.GetMetricRecord()
+		flusher.unmatchedEvents = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_unmatched_events", metricLabels...)
+		flusher.matchedEvents = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_matched_events", metricLabels...)
+		flusher.droppedEvents = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_dropped_events", metricLabels...)
+		flusher.retryCount = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_retry_count", metricLabels...)
+		flusher.flushFailure = helper.NewCounterMetricAndRegister(metricsRecord, "http_flusher_flush_failure_count", metricLabels...)
+		flusher.flushLatency = helper.NewAverageMetricAndRegister(metricsRecord, "http_flusher_flush_latency_ns", metricLabels...) // cannot use latency metric
+
+		Convey("should discard events when queue is full", func() {
+			groupEvents := models.PipelineGroupEvents{
+				Events: []models.PipelineEvent{&models.Metric{
+					Name:      "cpu.load.short",
+					Timestamp: 1672321328000000000,
+					Tags:      models.NewTagsWithKeyValues("host", "server01", "region", "cn"),
+					Value:     &models.MetricSingleValue{Value: 0.64},
+				}},
+			}
+			err := flusher.Export([]*models.PipelineGroupEvents{&groupEvents}, nil)
+			So(err, ShouldBeNil)
+			err = flusher.Export([]*models.PipelineGroupEvents{&groupEvents}, nil)
+			So(err, ShouldBeNil)
+			So(len(flusher.queue), ShouldEqual, 1)
+			err = flusher.convertAndFlush((<-flusher.queue).data)
+			So(err, ShouldBeNil)
+			logGroup := &protocol.LogGroup{}
+			flusher.context.MetricSerializeToPB(logGroup)
+			assert.Greater(t, len(logGroup.Logs), 0)
+		})
+	})
 }
 
-func (c mockContext) GetExtension(name string, cfg any) (pipeline.Extension, error) {
+func TestBuildLabels(t *testing.T) {
+	flusher := &FlusherHTTP{
+		RemoteURL: "http://example.com",
+		Query: map[string]string{
+			"u":        "user",
+			"password": "secret",
+			"status":   "active",
+		},
+	}
+
+	expectedLabels := []*protocol.Log_Content{
+		{Key: "RemoteURL", Value: "http://example.com"},
+		{Key: "status", Value: "active"},
+	}
+
+	labels := flusher.buildLabels()
+
+	assert.Equal(t, len(expectedLabels), len(labels)-1)
+
+	for i, expected := range expectedLabels {
+		assert.Equal(t, expected.Key, labels[i].Key)
+		assert.Equal(t, expected.Value, labels[i].Value)
+	}
+}
+
+func TestHttpFlusherHandleEOF(t *testing.T) {
+	Convey("Given a http flusher with Convert.Protocol: Raw, Convert.Encoding: Custom, Query: '%{metadata.db}'", t, func() {
+		var actualRequests []string
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("POST", "http://testeof.com/write?db=mydb", func(req *http.Request) (*http.Response, error) {
+			body, _ := io.ReadAll(req.Body)
+			actualRequests = append(actualRequests, string(body))
+			return httpmock.NewStringResponse(200, "ok"), &url.Error{
+				Op:  "POST",
+				URL: "http://testeof.com/write?db=mydb",
+				Err: io.EOF,
+			}
+		})
+
+		flusher := &FlusherHTTP{
+			RemoteURL: "http://testeof.com/write",
+			Convert: helper.ConvertConfig{
+				Protocol: converter.ProtocolRaw,
+				Encoding: converter.EncodingCustom,
+			},
+			Retry: retryConfig{
+				Enable:        true,
+				MaxRetryTimes: 1,
+				InitialDelay:  time.Second,
+				MaxDelay:      5 * time.Second,
+			},
+			Timeout:     defaultTimeout,
+			Concurrency: 1,
+			Query: map[string]string{
+				"db": "%{metadata.db}",
+			},
+		}
+
+		err := flusher.Init(mock.NewEmptyContext("p", "l", "c"))
+		So(err, ShouldBeNil)
+
+		mockMetric1 := "cpu.load.short,host=server01,region=cn value=0.6 1672321328000000000"
+		mockMetric2 := "cpu.load.short,host=server01,region=cn value=0.2 1672321358000000000"
+		mockMetadata := models.NewMetadataWithKeyValues("db", "mydb")
+
+		Convey("Export a single byte events each GroupEvents with Metadata {db: mydb}", func() {
+			groupEventsArray := []*models.PipelineGroupEvents{
+				{
+					Group:  models.NewGroup(mockMetadata, nil),
+					Events: []models.PipelineEvent{models.ByteArray(mockMetric1)},
+				},
+				{
+					Group:  models.NewGroup(mockMetadata, nil),
+					Events: []models.PipelineEvent{models.ByteArray(mockMetric2)},
+				},
+			}
+			httpmock.ZeroCallCounters()
+			err := flusher.Export(groupEventsArray, nil)
+			So(err, ShouldBeNil)
+			flusher.Stop()
+
+			Convey("each GroupEvents should send in a single request", func() {
+				So(httpmock.GetTotalCallCount(), ShouldEqual, 4)
+			})
+			Convey("request body should be valid", func() {
+				So(actualRequests, ShouldResemble, []string{
+					mockMetric1, mockMetric1, mockMetric2, mockMetric2,
+				})
+			})
+			Convey("retry count is should be 2", func() {
+				So(int64(flusher.retryCount.Collect().Value), ShouldEqual, int64(2))
+			})
+		})
+	})
+}
+
+func TestHandleResetByPeer(t *testing.T) {
+	Convey("Given a http flusher with Convert.Protocol: Raw, Convert.Encoding: Custom, Query: '%{metadata.db}'", t, func() {
+		var actualRequests []string
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("POST", "http://testeof.com/write?db=mydb", func(req *http.Request) (*http.Response, error) {
+			body, _ := io.ReadAll(req.Body)
+			actualRequests = append(actualRequests, string(body))
+			return httpmock.NewStringResponse(200, "ok"), &url.Error{
+				Op:  "POST",
+				URL: "http://testeof.com/write?db=mydb",
+				Err: errors.New("connection reset by peer"),
+			}
+		})
+
+		flusher := &FlusherHTTP{
+			RemoteURL: "http://testeof.com/write",
+			Convert: helper.ConvertConfig{
+				Protocol: converter.ProtocolRaw,
+				Encoding: converter.EncodingCustom,
+			},
+			Retry: retryConfig{
+				Enable:        true,
+				MaxRetryTimes: 1,
+				InitialDelay:  time.Second,
+				MaxDelay:      5 * time.Second,
+			},
+			Timeout:     defaultTimeout,
+			Concurrency: 1,
+			Query: map[string]string{
+				"db": "%{metadata.db}",
+			},
+		}
+
+		err := flusher.Init(mock.NewEmptyContext("p", "l", "c"))
+		So(err, ShouldBeNil)
+
+		mockMetric1 := "cpu.load.short,host=server01,region=cn value=0.6 1672321328000000000"
+		mockMetric2 := "cpu.load.short,host=server01,region=cn value=0.2 1672321358000000000"
+		mockMetadata := models.NewMetadataWithKeyValues("db", "mydb")
+
+		Convey("Export a single byte events each GroupEvents with Metadata {db: mydb}", func() {
+			groupEventsArray := []*models.PipelineGroupEvents{
+				{
+					Group:  models.NewGroup(mockMetadata, nil),
+					Events: []models.PipelineEvent{models.ByteArray(mockMetric1)},
+				},
+				{
+					Group:  models.NewGroup(mockMetadata, nil),
+					Events: []models.PipelineEvent{models.ByteArray(mockMetric2)},
+				},
+			}
+			httpmock.ZeroCallCounters()
+			err := flusher.Export(groupEventsArray, nil)
+			So(err, ShouldBeNil)
+			flusher.Stop()
+
+			Convey("each GroupEvents should send in a single request", func() {
+				So(httpmock.GetTotalCallCount(), ShouldEqual, 4)
+			})
+			Convey("request body should be valid", func() {
+				So(actualRequests, ShouldResemble, []string{
+					mockMetric1, mockMetric1, mockMetric2, mockMetric2,
+				})
+			})
+			Convey("retry count is should be 2", func() {
+				So(int64(flusher.retryCount.Collect().Value), ShouldEqual, int64(2))
+			})
+		})
+
+		logGroup := &protocol.LogGroup{}
+		flusher.context.MetricSerializeToPB(logGroup)
+		assert.Greater(t, len(logGroup.Logs), 0)
+		d, _ := json.Marshal(logGroup)
+		t.Logf("logGroup: %s", string(d))
+		fmt.Println("==============")
+		for i, v := range logGroup.Logs {
+			t.Logf("[%d]log: %s", i, v.String())
+		}
+	})
+}
+
+type mockContext struct {
+	pipeline.Context
+	basicAuth      *basicAuth
+	interceptor    *mockInterceptor
+	MetricsRecords []*pipeline.MetricsRecord
+}
+
+func (c *mockContext) GetExtension(name string, cfg any) (pipeline.Extension, error) {
 	if c.basicAuth != nil {
 		return c.basicAuth, nil
 	}
@@ -752,11 +1014,28 @@ func (c mockContext) GetExtension(name string, cfg any) (pipeline.Extension, err
 	return nil, fmt.Errorf("basicAuth not set")
 }
 
-func (c mockContext) GetConfigName() string {
+func (c *mockContext) GetMetricRecord() *pipeline.MetricsRecord {
+	metricsRecord := &pipeline.MetricsRecord{}
+	metricsRecord.Labels = append(metricsRecord.Labels, pipeline.Label{Key: "plugins", Value: "flusher_http"})
+	c.MetricsRecords = append(c.MetricsRecords, metricsRecord)
+	return metricsRecord
+}
+
+func (c *mockContext) MetricSerializeToPB(logGroup *protocol.LogGroup) {
+	if logGroup == nil {
+		return
+	}
+
+	for _, metricsRecord := range c.MetricsRecords {
+		metricsRecord.Serialize(logGroup)
+	}
+}
+
+func (c *mockContext) GetConfigName() string {
 	return "ctx"
 }
 
-func (c mockContext) GetRuntimeContext() context.Context {
+func (c *mockContext) GetRuntimeContext() context.Context {
 	return context.Background()
 }
 
@@ -820,4 +1099,534 @@ func (mi *mockInterceptor) Intercept(group *models.PipelineGroupEvents) *models.
 	}
 	group.Events = group.Events[:0]
 	return group
+}
+
+func TestIsEOF(t *testing.T) {
+	err := &url.Error{
+		Op:  "Post",
+		URL: "http://test",
+		Err: io.EOF,
+	}
+	assert.True(t, isErrorEOF(err))
+
+	err = &url.Error{
+		Op:  "Post",
+		URL: "http://test",
+		Err: errors.New("connection reset by peer"),
+	}
+	assert.True(t, isErrorEOF(err))
+}
+
+func TestJitter(t *testing.T) {
+	jitter := getJitter(10)
+	assert.Greater(t, jitter, time.Duration(0))
+
+	start := time.Now()
+	randomSleep(5, nil)
+	assert.LessOrEqual(t, time.Since(start), time.Second*5)
+
+	stopCh := make(chan any)
+	go func() {
+		start = time.Now()
+		time.Sleep(time.Second)
+		close(stopCh)
+	}()
+	randomSleep(100, stopCh)
+	assert.LessOrEqual(t, time.Since(start), time.Second*2)
+}
+
+func TestFlusherHTTP_StopWithJitter(t *testing.T) {
+	Convey("Given a http flusher with protocol: Influxdb, encoding: custom, query: contains variable '%{tag.db}'", t, func() {
+
+		var actualRequests []string
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("POST", "http://test.com/write?db=mydb", func(req *http.Request) (*http.Response, error) {
+			assert.Equal(t, "mydb", req.Header.Get("db"))
+			body, _ := io.ReadAll(req.Body)
+			actualRequests = append(actualRequests, string(body))
+			return httpmock.NewStringResponse(200, "ok"), nil
+		})
+
+		flusher := &FlusherHTTP{
+			RemoteURL: "http://test.com/write",
+			Convert: helper.ConvertConfig{
+				Protocol: converter.ProtocolInfluxdb,
+				Encoding: converter.EncodingCustom,
+			},
+			Timeout:     defaultTimeout,
+			Concurrency: 10,
+			JitterInSec: 3,
+			Query: map[string]string{
+				"db": "%{tag.db}",
+			},
+			Headers: map[string]string{
+				"db": "%{tag.db}",
+			},
+		}
+
+		err := flusher.Init(&mockContext{})
+		So(err, ShouldBeNil)
+
+		Convey("When Flush with logGroupList contains 2 valid Log in influxdb format metrics, each with LogTag: '__tag__:db'", func() {
+			logGroups := []*protocol.LogGroup{
+				{
+					Logs: []*protocol.Log{
+						{
+							Contents: []*protocol.Log_Content{
+								{Key: "__time_nano__", Value: "1668653452000000000"},
+								{Key: "__name__", Value: "weather"},
+								{Key: "__labels__", Value: "location#$#hangzhou|province#$#zhejiang"},
+								{Key: "__value__", Value: "30"},
+							},
+						},
+						{
+							Contents: []*protocol.Log_Content{
+								{Key: "__time_nano__", Value: "1668653452000000001"},
+								{Key: "__name__", Value: "weather"},
+								{Key: "__labels__", Value: "location#$#hangzhou|province#$#zhejiang"},
+								{Key: "__value__", Value: "32"},
+							},
+						},
+					},
+					LogTags: []*protocol.LogTag{{Key: "__tag__:db", Value: "mydb"}},
+				},
+				{
+					Logs: []*protocol.Log{
+						{
+							Contents: []*protocol.Log_Content{
+								{Key: "__time_nano__", Value: "1668653452000000003"},
+								{Key: "__name__", Value: "weather"},
+								{Key: "__labels__", Value: "location#$#hangzhou|province#$#zhejiang"},
+								{Key: "__value__", Value: "30"},
+							},
+						},
+						{
+							Contents: []*protocol.Log_Content{
+								{Key: "__time_nano__", Value: "1668653452000000004"},
+								{Key: "__name__", Value: "weather"},
+								{Key: "__labels__", Value: "location#$#hangzhou|province#$#zhejiang"},
+								{Key: "__value__", Value: "32"},
+							},
+						},
+					},
+					LogTags: []*protocol.LogTag{{Key: "__tag__:db", Value: "mydb"}},
+				},
+			}
+
+			err := flusher.Flush("", "", "", logGroups)
+			flusher.Stop()
+			Convey("Then", func() {
+				Convey("Flush() should not return error", func() {
+					So(err, ShouldBeNil)
+				})
+
+				Convey("each logGroup should be sent as one single request", func() {
+					reqCount := httpmock.GetTotalCallCount()
+					So(reqCount, ShouldEqual, 2)
+				})
+
+				Convey("each http request body should be valid as expect", func() {
+					So(actualRequests, ShouldResemble, []string{
+						"weather,location=hangzhou,province=zhejiang value=30 1668653452000000000\n" +
+							"weather,location=hangzhou,province=zhejiang value=32 1668653452000000001\n",
+
+						"weather,location=hangzhou,province=zhejiang value=30 1668653452000000003\n" +
+							"weather,location=hangzhou,province=zhejiang value=32 1668653452000000004\n",
+					})
+				})
+			})
+		})
+	})
+
+	Convey("Given a http flusher with protocol: custom_single, encoding: json, query: contains variable '%{tag.db}'", t, func() {
+
+		var actualRequests []string
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("POST", "http://test.com/write?db=mydb", func(req *http.Request) (*http.Response, error) {
+			body, _ := io.ReadAll(req.Body)
+			actualRequests = append(actualRequests, string(body))
+			return httpmock.NewStringResponse(200, "ok"), nil
+		})
+
+		flusher := &FlusherHTTP{
+			RemoteURL: "http://test.com/write",
+			Convert: helper.ConvertConfig{
+				Protocol: converter.ProtocolCustomSingle,
+				Encoding: converter.EncodingJSON,
+			},
+			Timeout:     defaultTimeout,
+			Concurrency: 1,
+			Query: map[string]string{
+				"db": "%{tag.db}",
+			},
+		}
+
+		err := flusher.Init(&mockContext{})
+		So(err, ShouldBeNil)
+
+		Convey("When Flush with logGroupList contains 2 valid Log in influxdb format metrics, each LOG with Content: '__tag__:db'", func() {
+			logGroups := []*protocol.LogGroup{
+				{
+					Logs: []*protocol.Log{
+						{
+							Contents: []*protocol.Log_Content{
+								{Key: "__time_nano__", Value: "1668653452000000000"},
+								{Key: "__name__", Value: "weather"},
+								{Key: "__labels__", Value: "location#$#hangzhou|province#$#zhejiang"},
+								{Key: "__value__", Value: "30"},
+								{Key: "__tag__:db", Value: "mydb"},
+							},
+						},
+						{
+							Contents: []*protocol.Log_Content{
+								{Key: "__time_nano__", Value: "1668653452000000001"},
+								{Key: "__name__", Value: "weather"},
+								{Key: "__labels__", Value: "location#$#hangzhou|province#$#zhejiang"},
+								{Key: "__value__", Value: "32"},
+								{Key: "__tag__:db", Value: "mydb"},
+							},
+						},
+					},
+				},
+				{
+					Logs: []*protocol.Log{
+						{
+							Contents: []*protocol.Log_Content{
+								{Key: "__time_nano__", Value: "1668653452000000003"},
+								{Key: "__name__", Value: "weather"},
+								{Key: "__labels__", Value: "location#$#hangzhou|province#$#zhejiang"},
+								{Key: "__value__", Value: "30"},
+								{Key: "__tag__:db", Value: "mydb"},
+							},
+						},
+						{
+							Contents: []*protocol.Log_Content{
+								{Key: "__time_nano__", Value: "1668653452000000004"},
+								{Key: "__name__", Value: "weather"},
+								{Key: "__labels__", Value: "location#$#hangzhou|province#$#zhejiang"},
+								{Key: "__value__", Value: "32"},
+								{Key: "__tag__:db", Value: "mydb"},
+							},
+						},
+					},
+				},
+			}
+
+			err := flusher.Flush("", "", "", logGroups)
+			flusher.Stop()
+			Convey("Then", func() {
+				Convey("Flush() should not return error", func() {
+					So(err, ShouldBeNil)
+				})
+
+				Convey("each log in logGroups should be sent as one single request", func() {
+					reqCount := httpmock.GetTotalCallCount()
+					So(reqCount, ShouldEqual, 4)
+				})
+
+				Convey("each http request body should be valid as expect", func() {
+					So(actualRequests, ShouldResemble, []string{
+						`{"contents":{"__labels__":"location#$#hangzhou|province#$#zhejiang","__name__":"weather","__time_nano__":"1668653452000000000","__value__":"30"},"tags":{"db":"mydb","host.ip":""},"time":0}`,
+						`{"contents":{"__labels__":"location#$#hangzhou|province#$#zhejiang","__name__":"weather","__time_nano__":"1668653452000000001","__value__":"32"},"tags":{"db":"mydb","host.ip":""},"time":0}`,
+						`{"contents":{"__labels__":"location#$#hangzhou|province#$#zhejiang","__name__":"weather","__time_nano__":"1668653452000000003","__value__":"30"},"tags":{"db":"mydb","host.ip":""},"time":0}`,
+						`{"contents":{"__labels__":"location#$#hangzhou|province#$#zhejiang","__name__":"weather","__time_nano__":"1668653452000000004","__value__":"32"},"tags":{"db":"mydb","host.ip":""},"time":0}`,
+					})
+				})
+			})
+		})
+	})
+
+}
+
+func TestFlusherHTTP_GzipCompression(t *testing.T) {
+	Convey("Given a http flusher with protocol: Influxdb, encoding: custom, query: contains variable '%{tag.db}'", t, func() {
+
+		var actualRequests []string
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("POST", "http://test.com/write?db=mydb", func(req *http.Request) (*http.Response, error) {
+			assert.Equal(t, "mydb", req.Header.Get("db"))
+			body := req.Body
+
+			// Handle gzip request bodies
+			if req.Header.Get("Content-Encoding") == "gzip" {
+				body, _ = gzip.NewReader(req.Body)
+				defer body.Close()
+			}
+
+			bodyBytes, _ := io.ReadAll(body)
+			actualRequests = append(actualRequests, string(bodyBytes))
+			return httpmock.NewStringResponse(200, "ok"), nil
+		})
+
+		flusher := &FlusherHTTP{
+			RemoteURL: "http://test.com/write",
+			Convert: helper.ConvertConfig{
+				Protocol: converter.ProtocolInfluxdb,
+				Encoding: converter.EncodingCustom,
+			},
+			Timeout:     defaultTimeout,
+			Concurrency: 1,
+			JitterInSec: 3,
+			Query: map[string]string{
+				"db": "%{tag.db}",
+			},
+			Headers: map[string]string{
+				"db": "%{tag.db}",
+			},
+			Compression: "gzip",
+		}
+
+		err := flusher.Init(&mockContext{})
+		So(err, ShouldBeNil)
+
+		Convey("When Flush with logGroupList contains 2 valid Log in influxdb format metrics, each with LogTag: '__tag__:db'", func() {
+			logGroups := []*protocol.LogGroup{
+				{
+					Logs: []*protocol.Log{
+						{
+							Contents: []*protocol.Log_Content{
+								{Key: "__time_nano__", Value: "1668653452000000000"},
+								{Key: "__name__", Value: "weather"},
+								{Key: "__labels__", Value: "location#$#hangzhou|province#$#zhejiang"},
+								{Key: "__value__", Value: "30"},
+							},
+						},
+						{
+							Contents: []*protocol.Log_Content{
+								{Key: "__time_nano__", Value: "1668653452000000001"},
+								{Key: "__name__", Value: "weather"},
+								{Key: "__labels__", Value: "location#$#hangzhou|province#$#zhejiang"},
+								{Key: "__value__", Value: "32"},
+							},
+						},
+					},
+					LogTags: []*protocol.LogTag{{Key: "__tag__:db", Value: "mydb"}},
+				},
+				{
+					Logs: []*protocol.Log{
+						{
+							Contents: []*protocol.Log_Content{
+								{Key: "__time_nano__", Value: "1668653452000000003"},
+								{Key: "__name__", Value: "weather"},
+								{Key: "__labels__", Value: "location#$#hangzhou|province#$#zhejiang"},
+								{Key: "__value__", Value: "30"},
+							},
+						},
+						{
+							Contents: []*protocol.Log_Content{
+								{Key: "__time_nano__", Value: "1668653452000000004"},
+								{Key: "__name__", Value: "weather"},
+								{Key: "__labels__", Value: "location#$#hangzhou|province#$#zhejiang"},
+								{Key: "__value__", Value: "32"},
+							},
+						},
+					},
+					LogTags: []*protocol.LogTag{{Key: "__tag__:db", Value: "mydb"}},
+				},
+			}
+
+			err := flusher.Flush("", "", "", logGroups)
+			flusher.Stop()
+			Convey("Then", func() {
+				Convey("Flush() should not return error", func() {
+					So(err, ShouldBeNil)
+				})
+
+				Convey("each logGroup should be sent as one single request", func() {
+					reqCount := httpmock.GetTotalCallCount()
+					So(reqCount, ShouldEqual, 2)
+				})
+
+				Convey("each http request body should be valid as expect", func() {
+					So(actualRequests, ShouldResemble, []string{
+						"weather,location=hangzhou,province=zhejiang value=30 1668653452000000000\n" +
+							"weather,location=hangzhou,province=zhejiang value=32 1668653452000000001\n",
+
+						"weather,location=hangzhou,province=zhejiang value=30 1668653452000000003\n" +
+							"weather,location=hangzhou,province=zhejiang value=32 1668653452000000004\n",
+					})
+				})
+			})
+		})
+	})
+
+	Convey("Given a http flusher with protocol: custom_single, encoding: json, query: contains variable '%{tag.db}'", t, func() {
+
+		var actualRequests []string
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("POST", "http://test.com/write?db=mydb", func(req *http.Request) (*http.Response, error) {
+			body, _ := io.ReadAll(req.Body)
+			actualRequests = append(actualRequests, string(body))
+			return httpmock.NewStringResponse(200, "ok"), nil
+		})
+
+		flusher := &FlusherHTTP{
+			RemoteURL: "http://test.com/write",
+			Convert: helper.ConvertConfig{
+				Protocol: converter.ProtocolCustomSingle,
+				Encoding: converter.EncodingJSON,
+			},
+			Timeout:     defaultTimeout,
+			Concurrency: 1,
+			Query: map[string]string{
+				"db": "%{tag.db}",
+			},
+		}
+
+		err := flusher.Init(&mockContext{})
+		So(err, ShouldBeNil)
+
+		Convey("When Flush with logGroupList contains 2 valid Log in influxdb format metrics, each LOG with Content: '__tag__:db'", func() {
+			logGroups := []*protocol.LogGroup{
+				{
+					Logs: []*protocol.Log{
+						{
+							Contents: []*protocol.Log_Content{
+								{Key: "__time_nano__", Value: "1668653452000000000"},
+								{Key: "__name__", Value: "weather"},
+								{Key: "__labels__", Value: "location#$#hangzhou|province#$#zhejiang"},
+								{Key: "__value__", Value: "30"},
+								{Key: "__tag__:db", Value: "mydb"},
+							},
+						},
+						{
+							Contents: []*protocol.Log_Content{
+								{Key: "__time_nano__", Value: "1668653452000000001"},
+								{Key: "__name__", Value: "weather"},
+								{Key: "__labels__", Value: "location#$#hangzhou|province#$#zhejiang"},
+								{Key: "__value__", Value: "32"},
+								{Key: "__tag__:db", Value: "mydb"},
+							},
+						},
+					},
+				},
+				{
+					Logs: []*protocol.Log{
+						{
+							Contents: []*protocol.Log_Content{
+								{Key: "__time_nano__", Value: "1668653452000000003"},
+								{Key: "__name__", Value: "weather"},
+								{Key: "__labels__", Value: "location#$#hangzhou|province#$#zhejiang"},
+								{Key: "__value__", Value: "30"},
+								{Key: "__tag__:db", Value: "mydb"},
+							},
+						},
+						{
+							Contents: []*protocol.Log_Content{
+								{Key: "__time_nano__", Value: "1668653452000000004"},
+								{Key: "__name__", Value: "weather"},
+								{Key: "__labels__", Value: "location#$#hangzhou|province#$#zhejiang"},
+								{Key: "__value__", Value: "32"},
+								{Key: "__tag__:db", Value: "mydb"},
+							},
+						},
+					},
+				},
+			}
+
+			err := flusher.Flush("", "", "", logGroups)
+			flusher.Stop()
+			Convey("Then", func() {
+				Convey("Flush() should not return error", func() {
+					So(err, ShouldBeNil)
+				})
+
+				Convey("each log in logGroups should be sent as one single request", func() {
+					reqCount := httpmock.GetTotalCallCount()
+					So(reqCount, ShouldEqual, 4)
+				})
+
+				Convey("each http request body should be valid as expect", func() {
+					So(actualRequests, ShouldResemble, []string{
+						`{"contents":{"__labels__":"location#$#hangzhou|province#$#zhejiang","__name__":"weather","__time_nano__":"1668653452000000000","__value__":"30"},"tags":{"db":"mydb","host.ip":""},"time":0}`,
+						`{"contents":{"__labels__":"location#$#hangzhou|province#$#zhejiang","__name__":"weather","__time_nano__":"1668653452000000001","__value__":"32"},"tags":{"db":"mydb","host.ip":""},"time":0}`,
+						`{"contents":{"__labels__":"location#$#hangzhou|province#$#zhejiang","__name__":"weather","__time_nano__":"1668653452000000003","__value__":"30"},"tags":{"db":"mydb","host.ip":""},"time":0}`,
+						`{"contents":{"__labels__":"location#$#hangzhou|province#$#zhejiang","__name__":"weather","__time_nano__":"1668653452000000004","__value__":"32"},"tags":{"db":"mydb","host.ip":""},"time":0}`,
+					})
+				})
+			})
+		})
+	})
+
+}
+
+func TestBroadcast(t *testing.T) {
+	Convey("Given a http flusher with Convert.Protocol: Raw, Convert.Encoding: Custom, Query: '%{metadata.db}'", t, func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		ctx := mock.NewEmptyContext("p", "l", "c")
+		receivedNum := int64(0)
+		httpmock.RegisterResponder("POST", "http://testeof.com/write?db=mydb", func(req *http.Request) (*http.Response, error) {
+			logger.Info(ctx.GetRuntimeContext(), "received count", atomic.AddInt64(&receivedNum, 1))
+			return httpmock.NewStringResponse(200, "ok"), nil
+		})
+
+		flusher := &FlusherHTTP{
+			RemoteURL: "http://testeof.com/write",
+			Convert: helper.ConvertConfig{
+				Protocol: converter.ProtocolRaw,
+				Encoding: converter.EncodingCustom,
+			},
+			Retry: retryConfig{
+				Enable:        true,
+				MaxRetryTimes: 1,
+				InitialDelay:  time.Second,
+				MaxDelay:      5 * time.Second,
+			},
+			Timeout:     defaultTimeout,
+			Concurrency: 10,
+			Query: map[string]string{
+				"db": "%{metadata.db}",
+			},
+			JitterInSec: 30,
+		}
+
+		err := flusher.Init(ctx)
+		So(err, ShouldBeNil)
+
+		mockMetric1 := "cpu.load.short,host=server01,region=cn value=0.6 1672321328000000000"
+		mockMetric2 := "cpu.load.short,host=server01,region=cn value=0.2 1672321358000000000"
+		mockMetadata := models.NewMetadataWithKeyValues("db", "mydb")
+
+		Convey("Export a single byte events each GroupEvents with Metadata {db: mydb}", func() {
+			groupEventsArray := []*models.PipelineGroupEvents{}
+			flushCount := 1024
+			for i := 0; i < flushCount; i++ {
+				groupEventsArray = append(groupEventsArray,
+					&models.PipelineGroupEvents{
+						Group:  models.NewGroup(mockMetadata, nil),
+						Events: []models.PipelineEvent{models.ByteArray(mockMetric1)},
+					},
+					&models.PipelineGroupEvents{
+						Group:  models.NewGroup(mockMetadata, nil),
+						Events: []models.PipelineEvent{models.ByteArray(mockMetric2)},
+					},
+				)
+			}
+			httpmock.ZeroCallCounters()
+			err := flusher.Export(groupEventsArray, nil)
+			So(err, ShouldBeNil)
+			start := time.Now()
+			err = flusher.Stop()
+			So(err, ShouldBeNil)
+			So(time.Since(start), ShouldBeLessThan, time.Second)
+
+			Convey("each GroupEvents should send in a single request", func() {
+				So(httpmock.GetTotalCallCount(), ShouldEqual, flushCount*2)
+			})
+
+			Convey("retry count is should be 2", func() {
+				So(int64(flusher.droppedEvents.Collect().Value), ShouldEqual, int64(0))
+			})
+		})
+	})
 }

--- a/plugins/flusher/http/flusher_http_test.go
+++ b/plugins/flusher/http/flusher_http_test.go
@@ -1122,7 +1122,7 @@ func TestFlusherHTTP_StopWithJitter(t *testing.T) {
 				Encoding: converter.EncodingCustom,
 			},
 			Timeout:     defaultTimeout,
-			Concurrency: 10,
+			Concurrency: 1,
 			JitterInSec: 3,
 			Query: map[string]string{
 				"db": "%{tag.db}",

--- a/plugins/flusher/http/flusher_http_test.go
+++ b/plugins/flusher/http/flusher_http_test.go
@@ -694,7 +694,7 @@ func TestHttpFlusherFlushWithInterceptor(t *testing.T) {
 			AsyncIntercept: false,
 			Timeout:        defaultTimeout,
 			Concurrency:    1,
-			queue:          make(chan *groupEventsWithTimestamp, 10),
+			queue:          make(chan *dataWithTimestamp, 10),
 		}
 		flusher.broadcaster = broadcast.NewBroadcaster(flusher.Concurrency)
 		metricLabels := flusher.buildSelfMonitorMetricLabels()
@@ -734,7 +734,7 @@ func TestHttpFlusherFlushWithInterceptor(t *testing.T) {
 			AsyncIntercept: true,
 			Timeout:        defaultTimeout,
 			Concurrency:    1,
-			queue:          make(chan *groupEventsWithTimestamp, 10),
+			queue:          make(chan *dataWithTimestamp, 10),
 		}
 		flusher.broadcaster = broadcast.NewBroadcaster(flusher.Concurrency)
 		metricLabels := flusher.buildSelfMonitorMetricLabels()
@@ -779,7 +779,7 @@ func TestHttpFlusherDropEvents(t *testing.T) {
 			AsyncIntercept:         true,
 			Timeout:                defaultTimeout,
 			Concurrency:            1,
-			queue:                  make(chan *groupEventsWithTimestamp, 1),
+			queue:                  make(chan *dataWithTimestamp, 1),
 			DropEventWhenQueueFull: true,
 		}
 		flusher.broadcaster = broadcast.NewBroadcaster(flusher.Concurrency)

--- a/plugins/input/prometheus/input_prometheus.go
+++ b/plugins/input/prometheus/input_prometheus.go
@@ -244,6 +244,7 @@ func parseMetricNameAndLabels(labels []prompbmarshal.Label) (string, models.Tags
 			metricName = strings.Clone(label.Value)
 			continue
 		}
+		// deep copy these strings since they are unsafe to use after the function returns.
 		tags[strings.Clone(label.Name)] = strings.Clone(label.Value)
 	}
 	return metricName, models.NewMetadataWithMap(tags)

--- a/plugins/input/prometheus/input_prometheus.go
+++ b/plugins/input/prometheus/input_prometheus.go
@@ -33,8 +33,15 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/common"
 
 	"github.com/alibaba/ilogtail/pkg/logger"
+	"github.com/alibaba/ilogtail/pkg/models"
 	"github.com/alibaba/ilogtail/pkg/pipeline"
 	"github.com/alibaba/ilogtail/pkg/util"
+)
+
+var _ pipeline.ServiceInputV2 = (*ServiceStaticPrometheus)(nil)
+
+const (
+	prometheusKeyName = "__name__"
 )
 
 var libLoggerOnce sync.Once
@@ -46,14 +53,15 @@ type ServiceStaticPrometheus struct {
 	ExtraFlags        map[string]string `comment:"the prometheus extra configuration flags, like promscrape.maxScrapeSize, for more flags please see [here](https://docs.victoriametrics.com/vmagent.html#advanced-usage)"`
 	NoStaleMarkers    bool              `comment:"Whether to disable sending Prometheus stale markers for metrics when scrape target disappears. This option may reduce memory usage if stale markers aren't needed for your setup. This option also disables populating the scrape_series_added metric. See https://prometheus.io/docs/concepts/jobs_instances/#automatically-generated-labels-and-time-series"`
 
-	scraper   *promscrape.Scraper //nolint:typecheck
-	shutdown  chan struct{}
-	waitGroup sync.WaitGroup
-	context   pipeline.Context
-	lock      sync.Mutex
-	running   bool
-	collector pipeline.Collector
-	kubeMeta  *KubernetesMeta
+	scraper     *promscrape.Scraper //nolint:typecheck
+	shutdown    chan struct{}
+	waitGroup   sync.WaitGroup
+	context     pipeline.Context
+	pipelineCtx pipeline.PipelineContext
+	lock        sync.Mutex
+	running     bool
+	collector   pipeline.Collector
+	kubeMeta    *KubernetesMeta
 }
 
 func (p *ServiceStaticPrometheus) Init(context pipeline.Context) (int, error) {
@@ -131,7 +139,22 @@ func (p *ServiceStaticPrometheus) Start(c pipeline.Collector) error {
 	p.scraper.Init(p.slsPushData)
 	p.running = true
 	if p.kubeMeta.isWorkingOnClusterMode() {
-		p.StartKubeReloadScraper()
+		p.StartKubeReloadScraper(p.slsPushData)
+	}
+	<-p.shutdown
+	p.scraper.Stop()
+	return nil
+}
+
+func (p *ServiceStaticPrometheus) StartService(ctx pipeline.PipelineContext) error {
+	p.pipelineCtx = ctx
+	p.shutdown = make(chan struct{})
+	p.waitGroup.Add(1)
+	defer p.waitGroup.Done()
+	p.scraper.Init(p.groupEventPushData)
+	p.running = true
+	if p.kubeMeta.isWorkingOnClusterMode() {
+		p.StartKubeReloadScraper(p.groupEventPushData)
 	}
 	<-p.shutdown
 	p.scraper.Stop()
@@ -148,7 +171,7 @@ func (p *ServiceStaticPrometheus) Stop() error {
 	return nil
 }
 
-func (p *ServiceStaticPrometheus) StartKubeReloadScraper() {
+func (p *ServiceStaticPrometheus) StartKubeReloadScraper(pushData func(at *auth.Token, wr *prompbmarshal.WriteRequest)) {
 	go func() {
 		ticker := time.NewTicker(time.Second * 10)
 		for {
@@ -167,7 +190,7 @@ func (p *ServiceStaticPrometheus) StartKubeReloadScraper() {
 				}
 				promscrape.ConfigMemberInfo(int(p.kubeMeta.replicas), strconv.Itoa(p.kubeMeta.currentNum))
 				p.scraper.Stop()
-				p.scraper.Init(p.slsPushData)
+				p.scraper.Init(pushData)
 				p.lock.Unlock()
 				logger.Info(p.context.GetRuntimeContext(), "reload prometheus scraper done")
 			}
@@ -187,4 +210,41 @@ func (p *ServiceStaticPrometheus) slsPushData(_ *auth.Token, wr *prompbmarshal.W
 	logger.Debug(p.context.GetRuntimeContext(), "append new metrics", wr.Size())
 	appendTSDataToSlsLog(p.collector, wr)
 	logger.Debug(p.context.GetRuntimeContext(), "append done", wr.Size())
+}
+
+func (p *ServiceStaticPrometheus) groupEventPushData(_ *auth.Token, wr *prompbmarshal.WriteRequest) {
+	logger.Debug(p.context.GetRuntimeContext(), "append new metrics", wr.Size())
+	convertWriteRequestAndAppend(p.context, p.pipelineCtx, wr)
+	logger.Debug(p.context.GetRuntimeContext(), "append done", wr.Size())
+}
+
+func convertWriteRequestAndAppend(context pipeline.Context, ctx pipeline.PipelineContext, wr *prompbmarshal.WriteRequest) {
+	metricList := make([]models.PipelineEvent, 0, len(wr.Timeseries))
+	for _, ts := range wr.Timeseries {
+		for _, sample := range ts.Samples {
+			metricName, tags := parseMetricNameAndLabels(ts.Labels)
+			metric := models.NewSingleValueMetric(
+				metricName,
+				models.MetricTypeGauge,
+				tags,
+				time.Unix(0, sample.Timestamp*1_000_000).UnixNano(),
+				sample.Value)
+			metricList = append(metricList, metric)
+			logger.Debugf(context.GetRuntimeContext(), "append a metric: %v", metric.String())
+		}
+	}
+	ctx.Collector().Collect(nil, metricList...)
+}
+
+func parseMetricNameAndLabels(labels []prompbmarshal.Label) (string, models.Tags) {
+	tags := make(map[string]string, len(labels)-1)
+	metricName := ""
+	for _, label := range labels {
+		if label.Name == prometheusKeyName {
+			metricName = strings.Clone(label.Value)
+			continue
+		}
+		tags[strings.Clone(label.Name)] = strings.Clone(label.Value)
+	}
+	return metricName, models.NewMetadataWithMap(tags)
 }


### PR DESCRIPTION
[特性]
1. flusher_http:
- 支持 Jitter，打散尖峰流量，默认不开启。
- 支持 Gzip 和 Snappy 两种压缩，默认不开启。
- 增加自监控指标
- 支持采样一些 Event 输出，方便调试，默认不开启。

2. Prometheus Input插件支持 V2流水线
