### PR TITLE
relax pipeline topology restriction

### DIFF
--- a/core/config/Config.cpp
+++ b/core/config/Config.cpp
@@ -141,6 +141,7 @@ bool Config::Parse() {
     // inputs, processors and flushers module must be parsed first and parsed by order, since aggregators and
     // extensions module parsing will rely on their results.
     bool hasObserverInput = false;
+    bool hasFileInput = false;
 #ifdef __ENTERPRISE__
     bool hasStreamInput = false;
 #endif
@@ -224,16 +225,7 @@ bool Config::Parse() {
                         sLogger, alarm, "unsupported input plugin", pluginName, mName, mProject, mLogstore, mRegion);
                 }
             } else {
-                if (PluginRegistry::GetInstance()->IsValidNativeInputPlugin(pluginName)) {
-                    PARAM_ERROR_RETURN(sLogger,
-                                       alarm,
-                                       "more than 1 native input plugin is given",
-                                       noModule,
-                                       mName,
-                                       mProject,
-                                       mLogstore,
-                                       mRegion);
-                } else if (PluginRegistry::GetInstance()->IsValidGoPlugin(pluginName)) {
+                if (PluginRegistry::GetInstance()->IsValidGoPlugin(pluginName)) {
                     PARAM_ERROR_RETURN(sLogger,
                                        alarm,
                                        "native and extended input plugins coexist",
@@ -249,8 +241,11 @@ bool Config::Parse() {
             }
         }
         mInputs.push_back(&plugin);
+        // TODO: remove these special restrictions
         if (pluginName == "input_observer_network") {
             hasObserverInput = true;
+        } else if (pluginName == "input_file" || pluginName == "input_container_stdio") {
+            hasFileInput = true;
 #ifdef __ENTERPRISE__
         } else if (pluginName == "input_stream") {
             if (!AppConfig::GetInstance()->GetOpenStreamLog()) {
@@ -261,7 +256,22 @@ bool Config::Parse() {
 #endif
         }
     }
-    bool isSPL = false;
+    // TODO: remove these special restrictions
+    bool hasSpecialInput = hasObserverInput || hasFileInput;
+#ifdef __ENTERPRISE__
+    hasSpecialInput = hasSpecialInput || hasStreamInput;
+#endif
+    if (hasSpecialInput && (*mDetail)["inputs"].size() > 1) {
+        PARAM_ERROR_RETURN(sLogger,
+                           alarm,
+                           "more than 1 input_file or input_container_stdio plugin is given",
+                           noModule,
+                           mName,
+                           mProject,
+                           mLogstore,
+                           mRegion);
+    }
+
     key = "processors";
     itr = mDetail->find(key.c_str(), key.c_str() + key.size());
     if (itr) {
@@ -276,6 +286,7 @@ bool Config::Parse() {
                                mRegion);
         }
 #ifdef __ENTERPRISE__
+        // TODO: remove these special restrictions
         if (hasStreamInput && !itr->empty()) {
             PARAM_ERROR_RETURN(sLogger,
                                alarm,
@@ -348,6 +359,18 @@ bool Config::Parse() {
             } else {
                 if (isCurrentPluginNative) {
                     if (PluginRegistry::GetInstance()->IsValidGoPlugin(pluginName)) {
+                        // TODO: remove these special restrictions
+                        if (!hasObserverInput && !hasFileInput) {
+                            PARAM_ERROR_RETURN(sLogger,
+                                               alarm,
+                                               "extended processor plugins coexist with native input plugins other "
+                                               "than input_file or input_container_stdio",
+                                               noModule,
+                                               mName,
+                                               mProject,
+                                               mLogstore,
+                                               mRegion);
+                        }
                         isCurrentPluginNative = false;
                         mHasGoProcessor = true;
                     } else if (!PluginRegistry::GetInstance()->IsValidNativeProcessorPlugin(pluginName)) {
@@ -360,18 +383,18 @@ bool Config::Parse() {
                                            mLogstore,
                                            mRegion);
                     } else if (pluginName == "processor_spl") {
-                        isSPL = true;
                         if (i != 0 || itr->size() != 1) {
                             PARAM_ERROR_RETURN(sLogger,
-                                            alarm,
-                                            "native processor plugins coexist with spl processor",
-                                            noModule,
-                                            mName,
-                                            mProject,
-                                            mLogstore,
-                                            mRegion);
+                                               alarm,
+                                               "native processor plugins coexist with spl processor",
+                                               noModule,
+                                               mName,
+                                               mProject,
+                                               mLogstore,
+                                               mRegion);
                         }
                     } else {
+                        // TODO: remove these special restrictions
                         if (hasObserverInput) {
                             PARAM_ERROR_RETURN(sLogger,
                                                alarm,
@@ -417,6 +440,8 @@ bool Config::Parse() {
         }
     }
 
+    bool hasFlusherSLS = false;
+    uint32_t nativeFlusherCnt = 0;
     key = "flushers";
     itr = mDetail->find(key.c_str(), key.c_str() + key.size());
     if (!itr) {
@@ -473,20 +498,32 @@ bool Config::Parse() {
         }
         const string pluginName = it->asString();
         if (PluginRegistry::GetInstance()->IsValidGoPlugin(pluginName)) {
+            // TODO: remove these special restrictions
+            if (mHasNativeInput && !hasFileInput && !hasObserverInput) {
+                PARAM_ERROR_RETURN(sLogger,
+                                   alarm,
+                                   "extended flusher plugins coexist with native input plugins other than "
+                                   "input_file or input_container_stdio",
+                                   noModule,
+                                   mName,
+                                   mProject,
+                                   mLogstore,
+                                   mRegion);
+            }
             mHasGoFlusher = true;
         } else if (PluginRegistry::GetInstance()->IsValidNativeFlusherPlugin(pluginName)) {
             mHasNativeFlusher = true;
-            // processor spl could change pipelineEventGroup tags and affect the merge logic of aggregator
-            // so force specify the MergeType as logstore, loggroup will be merged into a List.
-            if (isSPL) {
-                Json::Value& tmp = const_cast<Json::Value&>(plugin);
-                tmp["Batch"]["MergeType"] = Json::Value("logstore");
+            // TODO: remove these special restrictions
+            ++nativeFlusherCnt;
+            if (pluginName == "flusher_sls") {
+                hasFlusherSLS = true;
             }
         } else {
             PARAM_ERROR_RETURN(
                 sLogger, alarm, "unsupported flusher plugin", pluginName, mName, mProject, mLogstore, mRegion);
         }
 #ifdef __ENTERPRISE__
+        // TODO: remove these special restrictions
         if (hasStreamInput && pluginName != "flusher_sls") {
             PARAM_ERROR_RETURN(sLogger,
                                alarm,
@@ -499,6 +536,27 @@ bool Config::Parse() {
         }
 #endif
         mFlushers.push_back(&plugin);
+    }
+    // TODO: remove these special restrictions
+    if (mHasGoFlusher && nativeFlusherCnt > 1) {
+        PARAM_ERROR_RETURN(sLogger,
+                           alarm,
+                           "more than 1 native flusehr plugins coexist with extended flusher plugins",
+                           noModule,
+                           mName,
+                           mProject,
+                           mLogstore,
+                           mRegion);
+    }
+    if (mHasGoFlusher && nativeFlusherCnt == 1 && !hasFlusherSLS) {
+        PARAM_ERROR_RETURN(sLogger,
+                           alarm,
+                           "native flusher plugins other than flusher_sls coexist with extended flusher plugins",
+                           noModule,
+                           mName,
+                           mProject,
+                           mLogstore,
+                           mRegion);
     }
 
     key = "aggregators";

--- a/core/go_pipeline/LogtailPlugin.cpp
+++ b/core/go_pipeline/LogtailPlugin.cpp
@@ -188,6 +188,7 @@ int LogtailPlugin::SendPbV2(const char* configName,
                          "logstore", logstore));
             return -2;
         }
+        // TODO: support multi-flusher
         pConfig = const_cast<FlusherSLS*>(static_cast<const FlusherSLS*>(p->GetFlushers()[0]->GetPlugin()));
     }
     std::string shardHashStr;

--- a/core/pipeline/Pipeline.cpp
+++ b/core/pipeline/Pipeline.cpp
@@ -144,7 +144,7 @@ bool Pipeline::Init(Config&& config) {
             }
             if (name == FlusherSLS::sName) {
                 hasFlusherSLS = true;
-                mContext.SetSLSInfo(static_cast<const FlusherSLS*>(mFlushers[0]->GetPlugin()));
+                mContext.SetSLSInfo(static_cast<const FlusherSLS*>(mFlushers.back()->GetPlugin()));
             }
         } else {
             if (ShouldAddPluginToGoPipelineWithInput()) {


### PR DESCRIPTION
由于现有的C++ input插件都不支持一个pipeline配多个input，因此现有代码简单处理为所有C++输入插件都不允许多个，这在引入新C++输入插件后不再成立，需要进行调整，包括以下几点：
1. C++输入插件仅file、stdio、老observer、stream只能1个pipeline1个，其余C++输入插件不做此限制
2. 由于CGO接口目前支持log传递，不支持metric和span，因此对于采集metric和span的C++输入插件，不允许其使用Go的任何插件（包括处理和输出）
3. 当Go输出插件和C++输出插件共存时，C++输出插件允许且仅允许存在1个flusher_sls。