### PR TITLE
refine config server v2 protocol

### DIFF
--- a/config_server/protocol/v2/README.md
+++ b/config_server/protocol/v2/README.md
@@ -96,15 +96,14 @@
 
     message HeartbeatResponse {
         bytes request_id = 1;  
-        int32 code = 2;      
-        string message = 3;     
-        uint64 capabilities = 4;                            // Bitmask of flags defined by ServerCapabilities enum
+        ServerErrorResponse error_response = 2;             // Set value indicates error
+        uint64 capabilities = 3;                            // Bitmask of flags defined by ServerCapabilities enum
 
-        repeated ConfigDetail pipeline_config_updates = 5;  // Agent's pipeline config update status
-        repeated ConfigDetail process_config_updates = 6;   // Agent's process config update status
-        repeated CommandDetail custom_command_updates = 7;  // Agent's commands updates
-        uint64 flags = 8;                                   // Predefined command flag
-        bytes opaque = 9;                                   // Opaque data for extension
+        repeated ConfigDetail pipeline_config_updates = 4;  // Agent's pipeline config update status
+        repeated ConfigDetail process_config_updates = 5;   // Agent's process config update status
+        repeated CommandDetail custom_command_updates = 6;  // Agent's commands updates
+        uint64 flags = 7;                                   // Predefined command flag
+        bytes opaque = 8;                                   // Opaque data for extension
     }
     
     message ConfigDetail {
@@ -133,6 +132,11 @@
         RembersCustomCommandStatus         = 0x00000008;
 
         // bits before 2^16 (inclusive) are reserved for future official fields
+    }
+
+    message ServerErrorResponse {
+        int32 error_code = 1;                               // None-zero value indicates error
+        string error_message = 2;                           // Error message
     }
 
     enum ResponseFlags {

--- a/config_server/protocol/v2/README.md
+++ b/config_server/protocol/v2/README.md
@@ -25,7 +25,8 @@
         repeated ConfigInfo process_configs = 11;   // Information about the current AGENT_CONFIG held by the Agent
         repeated CommandInfo custom_commands = 12;  // Information about command history
         uint64 flags = 13;                          // Predefined command flag
-        // 14-99 reserved for future official fields
+        bytes opaque = 14;                          // Opaque data for extension
+        // before 100 (inclusive) are reserved for future official fields
     }
     
     message AgentGroupTag {
@@ -64,8 +65,8 @@
         bytes version = 1;                 // Agent's version
         bytes ip = 2;                      // Agent's ip
         bytes hostname = 3;                // Agent's hostname
-        // 4-99 reserved for future official fields
         map<string, bytes> extras = 100;   // Agent's other attributes
+        // before 100 (inclusive) are reserved for future official fields
     }
 
     enum AgentCapabilities {
@@ -78,7 +79,7 @@
         // The Agent can accept custom command from the Server.
         AcceptsCustomCommand           = 0x00000004;
 
-        // Add new capabilities here, continuing with the least significant unused bit.
+        // bits before 2^16 (inclusive) are reserved for future official fields
     }
 
     enum RequestFlags {
@@ -88,6 +89,7 @@
 
         // Must be set if this request contains full state
         FullState               = 0x00000001;
+        // bits before 2^16 (inclusive) are reserved for future official fields
     }
 
 ### HeartbeatResponse 消息
@@ -101,7 +103,8 @@
         repeated ConfigDetail pipeline_config_updates = 5;  // Agent's pipeline config update status
         repeated ConfigDetail process_config_updates = 6;   // Agent's process config update status
         repeated CommandDetail custom_command_updates = 7;  // Agent's commands updates
-        uint64 flags = 7;                                   // Predefined command flag
+        uint64 flags = 8;                                   // Predefined command flag
+        bytes opaque = 9;                                   // Opaque data for extension
     }
     
     message ConfigDetail {
@@ -129,7 +132,7 @@
         // The Server can remember custom command status.
         RembersCustomCommandStatus         = 0x00000008;
 
-        // Add new capabilities here, continuing with the least significant unused bit.
+        // bits before 2^16 (inclusive) are reserved for future official fields
     }
 
     enum ResponseFlags {
@@ -144,6 +147,7 @@
         ReportFullState           = 0x00000001;
         FetchPipelineConfigDetail = 0x00000002;
         FetchProcessConfigDetail  = 0x00000004;
+        // bits before 2^16 (inclusive) are reserved for future official fields
     }
 
 ## 行为规范

--- a/config_server/protocol/v2/agent.proto
+++ b/config_server/protocol/v2/agent.proto
@@ -86,6 +86,7 @@ message HearbeatRequest {
     uint64 flags = 13;                          // Predefined command flag
     bytes opaque = 14;                          // Opaque data for extension
     // before 100 (inclusive) are reserved for future official fields}
+}
 
 // Define Config's detail
 message ConfigDetail {
@@ -99,6 +100,11 @@ message CommandDetail {
     string name = 2;                // Required, Command name
     bytes detail = 3;               // Required, Command's detail
     int64 expire_time = 4;          // After which the command can be safely removed from history
+}
+
+message ServerErrorResponse {
+    int32 error_code = 1;           // None-zero value indicates error
+    string error_message = 2;       // Error message
 }
 
 enum ServerCapabilities {
@@ -134,15 +140,14 @@ enum ResponseFlags {
 // ConfigServer's response to Agent's request
 message HeartbeatResponse {
     bytes request_id = 1;  
-    int32 code = 2;      
-    string message = 3;     
-    uint64 capabilities = 4;                            // Bitmask of flags defined by ServerCapabilities enum
+    ServerErrorResponse error_response = 2;             // Set value indicates error
+    uint64 capabilities = 3;                            // Bitmask of flags defined by ServerCapabilities enum
 
-    repeated ConfigDetail pipeline_config_updates = 5;  // Agent's pipeline config update status
-    repeated ConfigDetail process_config_updates = 6;   // Agent's process config update status
-    repeated CommandDetail custom_command_updates = 7;  // Agent's commands updates
-    uint64 flags = 8;                                   // Predefined command flag
-    bytes opaque = 9;                                   // Opaque data for extension
+    repeated ConfigDetail pipeline_config_updates = 4;  // Agent's pipeline config update status
+    repeated ConfigDetail process_config_updates = 5;   // Agent's process config update status
+    repeated CommandDetail custom_command_updates = 6;  // Agent's commands updates
+    uint64 flags = 7;                                   // Predefined command flag
+    bytes opaque = 8;                                   // Opaque data for extension
 }
 
 // API: /Agent/FetchPipelineConfig/
@@ -157,7 +162,6 @@ message FetchConfigRequest {
 // ConfigServer response to Agent's request
 message FetchConfigResponse {
     bytes request_id = 1;                     
-    int32 code = 2;      
-    string message = 3;     
-    repeated ConfigDetail config_details = 4;   // config detail
+    ServerErrorResponse error_response = 2;
+    repeated ConfigDetail config_details = 3;   // config detail
 }

--- a/config_server/protocol/v2/agent.proto
+++ b/config_server/protocol/v2/agent.proto
@@ -40,8 +40,8 @@ message AgentAttributes {
     bytes version = 1;                 // Agent's version
     bytes ip = 2;                      // Agent's ip
     bytes hostname = 3;                // Agent's hostname
-    // 4-99 reserved for future official fields
     map<string, bytes> extras = 100;   // Agent's other attributes
+    // before 100 (inclusive) are reserved for future official fields
 }
 
 enum AgentCapabilities {
@@ -64,6 +64,7 @@ enum RequestFlags {
 
     // Must be set if this request contains full state
     FullState               = 0x00000001;
+    // bits before 2^16 (inclusive) are reserved for future official fields
 }
 
 // API: /Agent/Heartbeat
@@ -83,8 +84,8 @@ message HearbeatRequest {
     repeated ConfigInfo process_configs = 11;   // Information about the current AGENT_CONFIG held by the Agent
     repeated CommandInfo custom_commands = 12;  // Information about command history
     uint64 flags = 13;                          // Predefined command flag
-    // 14-99 reserved for future official fields
-}
+    bytes opaque = 14;                          // Opaque data for extension
+    // before 100 (inclusive) are reserved for future official fields}
 
 // Define Config's detail
 message ConfigDetail {
@@ -112,7 +113,7 @@ enum ServerCapabilities {
     // The Server can remember custom command status.
     RembersCustomCommandStatus         = 0x00000008;
 
-    // Add new capabilities here, continuing with the least significant unused bit.
+    // bits before 2^16 (inclusive) are reserved for future official fields
 }
 
 enum ResponseFlags {
@@ -127,6 +128,7 @@ enum ResponseFlags {
     ReportFullState           = 0x00000001;
     FetchPipelineConfigDetail = 0x00000002;
     FetchProcessConfigDetail  = 0x00000004;
+    // bits before 2^16 (inclusive) are reserved for future official fields
 }
 
 // ConfigServer's response to Agent's request
@@ -139,7 +141,8 @@ message HeartbeatResponse {
     repeated ConfigDetail pipeline_config_updates = 5;  // Agent's pipeline config update status
     repeated ConfigDetail process_config_updates = 6;   // Agent's process config update status
     repeated CommandDetail custom_command_updates = 7;  // Agent's commands updates
-    uint64 flags = 7;                                   // Predefined command flag
+    uint64 flags = 8;                                   // Predefined command flag
+    bytes opaque = 9;                                   // Opaque data for extension
 }
 
 // API: /Agent/FetchPipelineConfig/


### PR DESCRIPTION
1. capability bits开源留16个bit，从2^16开始留给第三方做二次扩展
2. request和response中都额外增加一个bytes opaque字段，留给第三方做二次扩展
3. 抽取相同的error_response部分