### PR TITLE
fix: input_kafka consumer wont close due to ctx never done.

### DIFF
--- a/plugins/input/kafka/input_kafka.go
+++ b/plugins/input/kafka/input_kafka.go
@@ -256,8 +256,8 @@ func (k *InputKafka) Stop() error {
 	k.readyCloser.Do(func() {
 		close(k.ready)
 	})
-	k.wg.Wait()
 	k.cancelConsumer()
+	k.wg.Wait()
 	err := k.consumerGroupClient.Close()
 	if err != nil {
 		e := fmt.Errorf("[inputs.kafka_consumer] Error closing consumer: %v", err)


### PR DESCRIPTION
问题：kafka consumer 在关闭后仍然正常运行
由于 cancel 在 wait 之后调用，所以会导致一直 wait 而无法正常关闭，调整一下调用顺序