### PR TITLE
fix unittest include and devcontainer user

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -55,4 +55,6 @@ RUN source /tmp/.env && rm /tmp/.env; \
     chown -R $USERNAME:$GROUPNAME /opt $(eval echo ~$USERNAME); \
     chmod -R 755 $(eval echo ~$USERNAME);
 
+USER $USERNAME
+
 RUN go env -w GO111MODULE=on && go env -w GOPROXY=https://goproxy.cn,direct

--- a/core/unittest/event_handler/ModifyHandlerUnittest.cpp
+++ b/core/unittest/event_handler/ModifyHandlerUnittest.cpp
@@ -26,6 +26,7 @@
 #include "event/Event.h"
 #include "event_handler/EventHandler.h"
 #include "file_server/FileServer.h"
+#include "pipeline/Pipeline.h"
 #include "queue/ProcessQueueManager.h"
 #include "reader/LogFileReader.h"
 #include "unittest/Unittest.h"


### PR DESCRIPTION
修复两个小问题
1. 之前是间接引用了Pipeline.h，但是直接include的文件发生了变化，导致单测编译失败。
2. devcontainer里的user之前误删除了