### PR TITLE
fix checkpoint dump idx in reader array

### DIFF
--- a/core/checkpoint/CheckPointManager.cpp
+++ b/core/checkpoint/CheckPointManager.cpp
@@ -13,19 +13,22 @@
 // limitations under the License.
 
 #include "CheckPointManager.h"
-#include <string>
-#include <fstream>
-#include <thread>
+
 #include <fcntl.h>
-#include "monitor/LogtailAlarm.h"
+
+#include <fstream>
+#include <string>
+#include <thread>
+
 #include "app_config/AppConfig.h"
-#include "config_manager/ConfigManager.h"
+#include "common/FileSystemUtil.h"
 #include "common/Flags.h"
 #include "common/HashUtil.h"
 #include "common/StringTools.h"
-#include "common/FileSystemUtil.h"
-#include "logger/Logger.h"
+#include "config_manager/ConfigManager.h"
 #include "file_server/FileDiscoveryOptions.h"
+#include "logger/Logger.h"
+#include "monitor/LogtailAlarm.h"
 
 using namespace std;
 #if defined(__linux__)
@@ -200,6 +203,7 @@ void CheckPointManager::LoadFileCheckPoint(const Json::Value& root) {
             int32_t fileOpenFlag = 0; // default, we close file ptr
             int32_t containerStopped = 0;
             int32_t lastForceRead = 0;
+            int32_t idxInReaderArray = LogFileReader::CHECKPOINT_IDX_OF_NEW_READER_IN_ARRAY;
             if (meta.isMember("real_file_name")) {
                 realFilePath = meta["real_file_name"].asString();
             }
@@ -237,6 +241,9 @@ void CheckPointManager::LoadFileCheckPoint(const Json::Value& root) {
             if (meta.isMember("last_force_read")) {
                 lastForceRead = meta["last_force_read"].asInt();
             }
+            if (meta.isMember("idx_in_reader_array")) {
+                idxInReaderArray = meta["idx_in_reader_array"].asInt();
+            }
             // can not get file's dev inode
             if (!devInode.IsValid()) {
                 LOG_WARNING(sLogger, ("can not find check point dev inode, discard it", filePath));
@@ -258,6 +265,7 @@ void CheckPointManager::LoadFileCheckPoint(const Json::Value& root) {
                                                  containerStopped != 0,
                                                  lastForceRead != 0);
                 ptr->mLastUpdateTime = update_time;
+                ptr->mIdxInReaderArray = idxInReaderArray;
                 AddCheckPoint(ptr);
             } else {
                 // find config
@@ -290,6 +298,7 @@ void CheckPointManager::LoadFileCheckPoint(const Json::Value& root) {
                                                      containerStopped != 0,
                                                      lastForceRead != 0);
                     ptr->mLastUpdateTime = update_time;
+                    ptr->mIdxInReaderArray = idxInReaderArray;
                     AddCheckPoint(ptr);
                 }
             }
@@ -336,6 +345,7 @@ bool CheckPointManager::DumpCheckPointToLocal() {
             leaf["config_name"] = Json::Value(checkPointPtr->mConfigName);
             // forward compatible
             leaf["sig"] = Json::Value(string(""));
+            leaf["idx_in_reader_array"] = Json::Value(checkPointPtr->mIdxInReaderArray);
             // use filename + dev + inode + configName to prevent same filename conflict
             root[checkPointPtr->mFileName + "*" + ToString(checkPointPtr->mDevInode.dev) + "*"
                  + ToString(checkPointPtr->mDevInode.inode) + "*" + checkPointPtr->mConfigName]
@@ -365,6 +375,7 @@ bool CheckPointManager::DumpCheckPointToLocal() {
             leaf["config_name"] = Json::Value(checkPointPtr->mConfigName);
             // forward compatible
             leaf["sig"] = Json::Value(string(""));
+            leaf["idx_in_reader_array"] = Json::Value(checkPointPtr->mIdxInReaderArray);
             // use filename + dev + inode + configName to prevent same filename conflict
             root[checkPointPtr->mFileName + "*" + ToString(checkPointPtr->mDevInode.dev) + "*"
                  + ToString(checkPointPtr->mDevInode.inode) + "*" + checkPointPtr->mConfigName]

--- a/core/checkpoint/CheckPointManager.h
+++ b/core/checkpoint/CheckPointManager.h
@@ -27,6 +27,7 @@
 #include "common/DevInode.h"
 #include "common/EncodingConverter.h"
 #include "common/SplitedFilePath.h"
+#include "reader/LogFileReader.h"
 
 #ifdef APSARA_UNIT_TEST_MAIN
 #include "AppConfig.h"
@@ -49,7 +50,7 @@ public:
     std::string mConfigName;
     std::string mFileName;
     std::string mRealFileName;
-    int32_t mPositionInReaderArray = -1; // default not in the reader queue
+    int32_t mIdxInReaderArray = LogFileReader::CHECKPOINT_IDX_OF_NEW_READER_IN_ARRAY;
 
     CheckPoint() {}
 

--- a/core/reader/LogFileReader.cpp
+++ b/core/reader/LogFileReader.cpp
@@ -212,7 +212,7 @@ void LogFileReader::SetMetrics() {
         mMetricsEnabled = false;
         return;
     }
-    
+
     mMetricsEnabled = true;
 
     mInputRecordsSizeBytesCounter = mMetricsRecordRef->GetCounter(METRIC_INPUT_RECORDS_SIZE_BYTES);
@@ -263,7 +263,7 @@ void LogFileReader::DumpMetaToMem(bool checkConfigFlag, int32_t idxInReaderArray
     // use last event time as checkpoint's last update time
     checkPointPtr->mLastUpdateTime = mLastEventTime;
     checkPointPtr->mCache = mCache;
-    checkPointPtr->mPositionInReaderArray = idxInReaderArray;
+    checkPointPtr->mIdxInReaderArray = idxInReaderArray;
     CheckPointManager::Instance()->AddCheckPoint(checkPointPtr);
 }
 
@@ -308,7 +308,7 @@ void LogFileReader::InitReader(bool tailExisted, FileReadPolicy policy, uint32_t
             mLastEventTime = checkPointPtr->mLastUpdateTime;
             mContainerStopped = checkPointPtr->mContainerStopped;
             // new property to recover reader exactly from checkpoint
-            mIdxInReaderArrayFromLastCpt = checkPointPtr->mPositionInReaderArray;
+            mIdxInReaderArrayFromLastCpt = checkPointPtr->mIdxInReaderArray;
             LOG_INFO(sLogger,
                      ("recover log reader status from checkpoint, project", GetProject())("logstore", GetLogstore())(
                          "config", GetConfigName())("log reader queue name", mHostLogPath)("file device",

--- a/core/reader/LogFileReader.h
+++ b/core/reader/LogFileReader.h
@@ -264,7 +264,7 @@ public:
     void
     InitReader(bool tailExisted = false, FileReadPolicy policy = BACKWARD_TO_FIXED_POS, uint32_t eoConcurrency = 0);
 
-    void DumpMetaToMem(bool checkConfigFlag = false, int32_t idxInReaderArray = -1);
+    void DumpMetaToMem(bool checkConfigFlag = false, int32_t idxInReaderArray = CHECKPOINT_IDX_OF_NEW_READER_IN_ARRAY);
 
     std::string GetSourceId() { return mSourceId; }
 


### PR DESCRIPTION
## 背景
https://github.com/alibaba/ilogtail/pull/1620 只在内存的checkpoint中新增了一个字段，但是没有dump到本地文件中
## 方案
1. checkpoint dump到本地文件的时候也要加一下idx in reader array字段
2. 其他一些命名不一致的优化