### PR TITLE
upgrade development image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:2.0.2
+FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:2.0.3
 
 ARG USERNAME=admin
 USER root

--- a/config_server/service/Dockerfile
+++ b/config_server/service/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:2.0.2 as build
+FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:2.0.3 as build
 
 USER root
 WORKDIR /src

--- a/core/dependencies.cmake
+++ b/core/dependencies.cmake
@@ -242,7 +242,7 @@ macro(link_lz4 target_name)
     if (lz4_${LINK_OPTION_SUFFIX})
         target_link_libraries(${target_name} "${lz4_${LINK_OPTION_SUFFIX}}")
     elseif (UNIX)
-        target_link_libraries(${target_name} "${lz4_${LIBRARY_DIR_SUFFIX}}/liblz4.so")
+        target_link_libraries(${target_name} "${lz4_${LIBRARY_DIR_SUFFIX}}/liblz4.a")
     elseif (MSVC)
         target_link_libraries(${target_name}
                 debug "liblz4_staticd"
@@ -306,7 +306,7 @@ macro(link_unwind target_name)
     elseif (ANDROID)
         # target_link_libraries(${target_name} "${unwind_${LIBRARY_DIR_SUFFIX}}/libunwindstack.a")
     elseif (UNIX)
-        target_link_libraries(${target_name} "${unwind_${LIBRARY_DIR_SUFFIX}}/libunwind.so")
+        target_link_libraries(${target_name} "${unwind_${LIBRARY_DIR_SUFFIX}}/libunwind.a")
     elseif (MSVC)
         target_link_libraries(${target_name}
                 debug "breakpad_commond.lib"

--- a/docker/Dockerfile.ilogtail-build-linux
+++ b/docker/Dockerfile.ilogtail-build-linux
@@ -1,11 +1,11 @@
-FROM --platform=$TARGETPLATFORM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-toolchain-linux:gcc_9.3.1-1 as dep-build
+FROM --platform=$TARGETPLATFORM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-toolchain-linux:2.0.3 as dep-build
 
 ARG TARGETPLATFORM
 
 RUN curl -sSfL https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/goc-v1.4.1-linux-${TARGETPLATFORM##*/}.tar.gz -o goc-v1.4.1-linux-${TARGETPLATFORM##*/}.tar.gz && \
     tar -xzf goc-v1.4.1-linux-${TARGETPLATFORM##*/}.tar.gz
 
-RUN curl -sSfL https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/prebuilt-dependencies/ilogtail-deps.linux-${TARGETPLATFORM##*/}-2.0.2.tar.gz -o ilogtail-deps.linux-${TARGETPLATFORM##*/}.tar.gz && \
+RUN curl -sSfL https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/prebuilt-dependencies/ilogtail-deps.linux-${TARGETPLATFORM##*/}-2.0.3.tar.gz -o ilogtail-deps.linux-${TARGETPLATFORM##*/}.tar.gz && \
     mkdir ilogtail-deps &&\
     tar -xzvf ilogtail-deps.linux-${TARGETPLATFORM##*/}.tar.gz -C ilogtail-deps --strip-components 1
 
@@ -13,7 +13,7 @@ RUN curl -sSfL https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/l
     mkdir ilogtail-spl  &&\
     tar -xzvf ilogtail-spl.linux-${TARGETPLATFORM##*/}.tar.gz -C ilogtail-spl --strip-components 1
 
-FROM --platform=$TARGETPLATFORM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-toolchain-linux:gcc_9.3.1-1
+FROM --platform=$TARGETPLATFORM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-toolchain-linux:2.0.3
 RUN mkdir -p /usr/local/bin /opt/logtail /opt/logtail_spl
 
 # install goc for coverage

--- a/docker/Dockerfile.ilogtail-toolchain-linux
+++ b/docker/Dockerfile.ilogtail-toolchain-linux
@@ -3,7 +3,40 @@ FROM --platform=$TARGETPLATFORM sls-opensource-registry.cn-shanghai.cr.aliyuncs.
 ARG TARGETPLATFORM
 
 # install dependencies
+RUN sed -i \
+    -e 's/^mirrorlist/#mirrorlist/' \
+    -e 's/^#baseurl/baseurl/' \
+    -e 's/mirror\.centos\.org/vault.centos.org/' \
+    /etc/yum.repos.d/*.repo
 RUN yum -y install epel-release centos-release-scl
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+    sed -i \
+    -e 's/^mirrorlist/#mirrorlist/' \
+    -e 's/^# baseurl/baseurl/' \
+    -e 's/mirror\.centos\.org/vault.centos.org/' \
+    /etc/yum.repos.d/CentOS-SCLo-scl.repo && \
+    sed -i \
+    -e 's/^mirrorlist/#mirrorlist/' \
+    -e 's/^#baseurl/baseurl/' \
+    -e 's/mirror\.centos\.org/vault.centos.org/' \
+    /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
+    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+    sed -i \
+    -e 's/^mirrorlist/#mirrorlist/' \
+    -e 's/^# baseurl/baseurl/' \
+    -e 's/mirror\.centos\.org/vault.centos.org/' \
+    -e 's/vault\.centos\.org\/centos/vault.centos.org\/altarch/' \
+    /etc/yum.repos.d/CentOS-SCLo-scl.repo && \
+    sed -i \
+    -e 's/^mirrorlist/#mirrorlist/' \
+    -e 's/^#baseurl/baseurl/' \
+    -e 's/mirror\.centos\.org/vault.centos.org/' \
+    -e 's/vault\.centos\.org\/centos/vault.centos.org\/altarch/' \
+    /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
+    else \
+    echo "Unsupported platform"; \
+    exit 1; \
+    fi
 RUN yum -y install devtoolset-9-gcc devtoolset-9-gcc-c++ make
 RUN yum -y install curl-devel expat-devel gettext-devel openssl-devel perl-devel python3-devel zlib-devel \
     asciidoc xmlto docbook2X wget bison
@@ -35,17 +68,10 @@ RUN wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/too
     mkdir llvm-project-14.0.0.src/build && \
     cd llvm-project-14.0.0.src/build && \
     cmake -G 'Unix Makefiles' -D CMAKE_C_COMPILER=/opt/rh/devtoolset-9/root/usr/bin/gcc \
-        -D CMAKE_CXX_COMPILER=/opt/rh/devtoolset-9/root/usr/bin/g++ \
-        -D LLVM_ENABLE_PROJECTS='clang' \
-        -D CMAKE_BUILD_TYPE=Release ../llvm && \
+    -D CMAKE_CXX_COMPILER=/opt/rh/devtoolset-9/root/usr/bin/g++ \
+    -D LLVM_ENABLE_PROJECTS='clang' \
+    -D CMAKE_BUILD_TYPE=Release ../llvm && \
     make -sj$(nproc) clang-format && \
-    cd /
-
-# build git
-RUN wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/toolchain/git-2.29.3.tar.xz && \
-    tar -xf git-2.29.3.tar.xz && \
-    cd git-2.29.3 && \
-    make -sj$(nproc) install install-man prefix=$PWD/build && \
     cd /
 
 # prepare go
@@ -59,10 +85,54 @@ RUN wget -nv https://ilogtail-community-edition.oss-cn-shanghai.aliyuncs.com/too
 
 FROM --platform=$TARGETPLATFORM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/centos7-cve-fix:1.0.0
 
+ARG TARGETPLATFORM
+
 # install dev tool set and debug utilities
+RUN sed -i \
+    -e 's/^mirrorlist/#mirrorlist/' \
+    -e 's/^#baseurl/baseurl/' \
+    -e 's/mirror\.centos\.org/vault.centos.org/' \
+    /etc/yum.repos.d/*.repo
 RUN yum -y install centos-release-scl
-RUN yum -y install devtoolset-9-gcc devtoolset-9-gcc-c++ devtoolset-9-libasan-devel make libuuid-devel libstdc++-static systemd-devel iproute gdb net-tools which wget vim tree man openssh-clients sudo
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+    sed -i \
+    -e 's/^mirrorlist/#mirrorlist/' \
+    -e 's/^# baseurl/baseurl/' \
+    -e 's/mirror\.centos\.org/vault.centos.org/' \
+    /etc/yum.repos.d/CentOS-SCLo-scl.repo && \
+    sed -i \
+    -e 's/^mirrorlist/#mirrorlist/' \
+    -e 's/^#baseurl/baseurl/' \
+    -e 's/mirror\.centos\.org/vault.centos.org/' \
+    /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
+    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+    sed -i \
+    -e 's/^mirrorlist/#mirrorlist/' \
+    -e 's/^# baseurl/baseurl/' \
+    -e 's/mirror\.centos\.org/vault.centos.org/' \
+    -e 's/vault\.centos\.org\/centos/vault.centos.org\/altarch/' \
+    /etc/yum.repos.d/CentOS-SCLo-scl.repo && \
+    sed -i \
+    -e 's/^mirrorlist/#mirrorlist/' \
+    -e 's/^#baseurl/baseurl/' \
+    -e 's/mirror\.centos\.org/vault.centos.org/' \
+    -e 's/vault\.centos\.org\/centos/vault.centos.org\/altarch/' \
+    /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
+    else \
+    echo "Unsupported platform"; \
+    exit 1; \
+    fi
+RUN yum -y install devtoolset-9-gcc devtoolset-9-gcc-c++ devtoolset-9-libasan-devel make libuuid-devel libstdc++-static systemd-devel iproute gdb net-tools which wget vim tree man openssh-clients sudo openssl-devel zlib-devel
+
 RUN yum -y clean all && rm -fr /var/cache && rm -rf /core.*
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+    sed -i \
+    -e 's/debuginfo\.centos\.org\/centos/debuginfo.centos.org\/altarch/' \
+    /etc/yum.repos.d/CentOS-SCLo-scl.repo && \
+    sed -i \
+    -e 's/debuginfo\.centos\.org\/centos/debuginfo.centos.org\/altarch/' \
+    /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
+    fi
 RUN [[ ${TARGETPLATFORM##*/} == 'amd64' ]] && ARCH='x86_64' || ARCH='aarch64' && \
     debuginfo-install -y glibc-2.17-326.el7_9.${ARCH} libuuid-2.23.2-65.el7_9.1.${ARCH}
 
@@ -90,9 +160,6 @@ RUN go install golang.org/x/tools/gopls@v0.12.2 && \
     go install github.com/cweill/gotests/gotests@v1.6.0 && \
     go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
 
-# install git
-COPY --from=toolchain-build /git-2.29.3/git /usr/bin
-
 # using gcc9
 ENV MANPATH=/opt/rh/devtoolset-9/root/usr/share/man \
     PERL5LIB=/opt/rh/devtoolset-9/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-9/root/usr/lib/perl5:/opt/rh/devtoolset-9/root//usr/share/perl5/vendor_perl \
@@ -103,5 +170,3 @@ ENV MANPATH=/opt/rh/devtoolset-9/root/usr/share/man \
     PYTHONPATH=/opt/rh/devtoolset-9/root/usr/lib64/python2.7/site-packages:/opt/rh/devtoolset-9/root/usr/lib/python2.7/site-packages \
     PKG_CONFIG_PATH=/opt/rh/devtoolset-9/root/usr/lib64/pkgconfig \
     INFOPATH=/opt/rh/devtoolset-9/root/usr/share/info
-RUN chmod +x /usr/bin/git
-

--- a/docker/Dockerfile_build
+++ b/docker/Dockerfile_build
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:2.0.2 as build
+FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:2.0.3 as build
 
 WORKDIR /src
 

--- a/docker/Dockerfile_coverage
+++ b/docker/Dockerfile_coverage
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:2.0.2
+FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:2.0.3
 
 WORKDIR /src
 

--- a/docker/Dockerfile_development_part
+++ b/docker/Dockerfile_development_part
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:2.0.2
+FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:2.0.3
 
 ARG HOST_OS=Linux
 ARG VERSION=2.0.0

--- a/docker/Dockerfile_goc
+++ b/docker/Dockerfile_goc
@@ -14,7 +14,7 @@
 
 # goc server is only for e2e test to analysis code coverage.
 
-FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:2.0.2 as build
+FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:2.0.3 as build
 
 USER root
 ENTRYPOINT ["goc","server"]

--- a/docker/build-multi-arch-build-image.sh
+++ b/docker/build-multi-arch-build-image.sh
@@ -18,12 +18,12 @@
 #        --no-cache -f Dockerfile.centos7-cve-fix .
 
 #docker buildx build --platform linux/amd64,linux/arm64 \
-#        -t sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-toolchain-linux:1.2.0 \
+#        -t sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-toolchain-linux:2.0.3 \
 #        -o type=registry \
 #        --no-cache -f Dockerfile.ilogtail-toolchain-linux .
 
 #docker buildx build --sbom=false --provenance=false --platform linux/amd64,linux/arm64 \
-#        -t sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:2.0.1 \
+#        -t sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/ilogtail-community-edition/ilogtail-build-linux:2.0.3 \
 #        -o type=registry \
 #        --no-cache -f Dockerfile.ilogtail-build-linux .
 


### PR DESCRIPTION
1. 更新镜像依赖：
    1. 编译两个fPIC的静态链接库，替代动态链接库
    2. 将 libgmock.a 复制到 lib 目录下
2. 删除开发镜像中的 git
3. 修复 dockerfile 中由于 centos 源失效导致的问题

正确的方案还是尽快升级镜像版本，但是Centos7与8之间对于包管理方式，存在较大的差异，需要投入一定的时间。