### PR TITLE
Add processor_gotime with nanosecond to other time format conversion capability

### DIFF
--- a/plugins/processor/gotime/processor_gotime.go
+++ b/plugins/processor/gotime/processor_gotime.go
@@ -28,6 +28,7 @@ const (
 	fixedSecondsTimestampPattern      = "seconds"
 	fixedMillisecondsTimestampPattern = "milliseconds"
 	fixedMicrosecondsTimestampPattern = "microseconds"
+	fixedNanosecondsTimestampPattern  = "nanoseconds"
 )
 
 type ProcessorGotime struct {
@@ -91,6 +92,11 @@ func (p *ProcessorGotime) Init(context pipeline.Context) error {
 	case fixedMillisecondsTimestampPattern:
 		p.timestampParseFunc = func(timestamp int64) time.Time {
 			return time.Unix(timestamp/1e3, (timestamp%1e3)*1e6)
+		}
+		p.timestampFormat = true
+	case fixedNanosecondsTimestampPattern:
+		p.timestampParseFunc = func(timestamp int64) time.Time {
+			return time.Unix(0, timestamp)
 		}
 		p.timestampFormat = true
 	}

--- a/plugins/processor/gotime/processor_gotime_test.go
+++ b/plugins/processor/gotime/processor_gotime_test.go
@@ -160,6 +160,21 @@ func TestSourceFormatTimestampMicroseconds(t *testing.T) {
 	assert.Equal(t, "2022/02/23 14:47:36.807000", log.Contents[1].Value)
 }
 
+func TestSourceFormatTimestampNanoseconds(t *testing.T) {
+	processor, err := newProcessor()
+	require.NoError(t, err)
+
+	log := &protocol.Log{Time: 0}
+	unixStr := "1645595256807000123"
+	log.Contents = append(log.Contents, &protocol.Log_Content{Key: "s_key", Value: unixStr})
+	processor.SourceFormat = fixedNanosecondsTimestampPattern
+	processor.DestFormat = "2006/01/02 15:04:05.000000000"
+	_ = processor.Init(processor.context)
+	processor.processLog(log)
+	assert.Equal(t, "d_key", log.Contents[1].Key)
+	assert.Equal(t, "2022/02/23 14:47:36.807000123", log.Contents[1].Value)
+}
+
 func TestEmptyTimezone(t *testing.T) {
 	ctx := mock.NewEmptyContext("p", "l", "c")
 	processor := &ProcessorGotime{


### PR DESCRIPTION
作用：支持将日志里的纳秒时间转换成其他时间格式

日志样例：time:1645595256807000123
插件配置样例：
```yaml
enable: true
global:
  EnableTimestampNanosecond: true
inputs:
  - Type: input_file
    FilePaths: 
      - /workspaces/ilogtail_version2/bin/ilogtail/test.log
processors:
  - Type: processor_regex
    FullMatch: false
    KeepSource: true
    KeepSourceIfParseError: true
    Keys:
    - time
    NoKeyError: true
    NoMatchError: true
    Regex: time:(.*)
    SourceKey: content
  - Type: processor_gotime
    AlarmIfFail: true
    DestFormat: '2006-01-02 15:04:05.000000000'
    DestKey: timeNano
    DestLocation: 8
    KeepSource: true
    NoKeyError: true
    SetTime: true
    SourceFormat: nanoseconds
    SourceKey: time
    SourceLocation: 8
flushers:
  - Type: flusher_stdout
    OnlyStdout: true
  ```
  日志输出结果
  ```json
{"content":"time:1645595256807000123","time":"1645595256807000123","timeNano":"2022-02-23 13:47:36.807000123","__time__":"1645595256"}
 ```
