### PR TITLE
remove use_containerd to keep compatibility

### DIFF
--- a/docs/cn/configuration/system-config.md
+++ b/docs/cn/configuration/system-config.md
@@ -33,7 +33,6 @@
 
 | 参数                      | 类型     | 说明                                                                                                         |
 | ----------------------- |--------|------------------------------------------------------------------------------------------------------------|
-| `USE_CONTAINERD`       | Bool   | 是否使用containerd runtime，非必选。ilogtail会自动通过接口探测。                                                              |
 | `CONTAINERD_SOCK_PATH`       | String | 自定义containerd sock路径，非必选。默认为/run/containerd/containerd.sock。自定义取值可以通过查看/etc/containerd/config.toml grpc.address字段获取。 |
 | `CONTAINERD_STATE_DIR` | String | 自定义containerd 数据目录，非必选。自定义取值可以通过查看/etc/containerd/config.toml state字段获取。                                             |
 | `LOGTAIL_LOG_LEVEL` | String |  用于控制/apsara/sls/ilogtail和golang插件的日志等级，支持通用日志等级，如trace, debug，info，warning，error，fatal|

--- a/pkg/helper/container_discover_controller.go
+++ b/pkg/helper/container_discover_controller.go
@@ -184,12 +184,7 @@ func (c *ContainerDiscoverManager) Init() bool {
 	c.enableCRIDiscover = criRuntimeWrapper != nil
 	c.enableDockerDiscover = dockerCenterInstance.initClient() == nil
 	c.enableStaticDiscover = isStaticContainerInfoEnabled()
-	discoverdRuntime := false
-	if len(os.Getenv("USE_CONTAINERD")) > 0 {
-		discoverdRuntime = c.enableCRIDiscover
-	} else {
-		discoverdRuntime = c.enableCRIDiscover || c.enableDockerDiscover || c.enableStaticDiscover
-	}
+	discoverdRuntime := c.enableCRIDiscover || c.enableDockerDiscover || c.enableStaticDiscover
 	if !discoverdRuntime {
 		return false
 	}


### PR DESCRIPTION
`USE_CONTAINERD`这个环境变量真实作用是在有docker的情况下，仍然去探测containerd。探测不到，还会去用docker。
现在已经实现了所有运行时平等的探测，所以不再需要改环境变量。
为了兼容旧版本的行为，直接删除该变量。