### PR TITLE
fix go profile send failure

### DIFF
--- a/core/application/Application.cpp
+++ b/core/application/Application.cpp
@@ -298,6 +298,7 @@ void Application::Start() { // GCOVR_EXCL_START
 #endif
         if (curTime - lastQueueGCTime >= INT32_FLAG(queue_check_gc_interval_sec)) {
             ExactlyOnceQueueManager::GetInstance()->ClearTimeoutQueues();
+            // this should be called in the same thread as config update
             SenderQueueManager::GetInstance()->ClearUnusedQueues();
             lastQueueGCTime = curTime;
         }

--- a/core/flusher/sls/FlusherSLS.cpp
+++ b/core/flusher/sls/FlusherSLS.cpp
@@ -494,6 +494,8 @@ bool FlusherSLS::Init(const Json::Value& config, Json::Value& optionalGoPipeline
 }
 
 bool FlusherSLS::Start() {
+    Flusher::Start();
+
     InitResource();
 
     IncreaseProjectReferenceCnt(mProject);

--- a/core/flusher/sls/FlusherSLS.cpp
+++ b/core/flusher/sls/FlusherSLS.cpp
@@ -815,10 +815,18 @@ bool FlusherSLS::Send(string&& data, const string& shardHashKey, const string& l
     } else {
         compressedData = data;
     }
+
+    QueueKey key = mQueueKey;
+    if (!HasContext()) {
+        key = QueueKeyManager::GetInstance()->GetKey(mProject + "-" + mLogstore);
+        if (SenderQueueManager::GetInstance()->GetQueue(key) == nullptr) {
+            SenderQueueManager::GetInstance()->CreateQueue(key, vector<shared_ptr<ConcurrencyLimiter>>());
+        }
+    }
     return Flusher::PushToQueue(make_unique<SLSSenderQueueItem>(std::move(compressedData),
                                                                 data.size(),
                                                                 this,
-                                                                mQueueKey,
+                                                                key,
                                                                 logstore.empty() ? mLogstore : logstore,
                                                                 RawDataType::EVENT_GROUP,
                                                                 shardHashKey));

--- a/core/flusher/sls/FlusherSLS.h
+++ b/core/flusher/sls/FlusherSLS.h
@@ -35,9 +35,6 @@
 namespace logtail {
 
 class FlusherSLS : public HttpFlusher {
-    // TODO: temporarily used
-    friend class ProfileSender;
-
 public:
     enum class TelemetryType { LOG, METRIC };
 
@@ -85,6 +82,9 @@ public:
     uint32_t mMaxSendRate = 0; // preserved only for exactly once
     uint32_t mFlowControlExpireTime = 0;
 
+    // TODO: temporarily public for profile
+    std::unique_ptr<Compressor> mCompressor;
+
 private:
     static const std::unordered_set<std::string> sNativeParam;
 
@@ -124,7 +124,6 @@ private:
     Batcher<SLSEventBatchStatus> mBatcher;
     std::unique_ptr<EventGroupSerializer> mGroupSerializer;
     std::unique_ptr<Serializer<std::vector<CompressedLogGroup>>> mGroupListSerializer;
-    std::unique_ptr<Compressor> mCompressor;
 
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class FlusherSLSUnittest;

--- a/core/go_pipeline/LogtailPlugin.cpp
+++ b/core/go_pipeline/LogtailPlugin.cpp
@@ -131,6 +131,12 @@ void LogtailPlugin::Resume() {
 }
 
 int LogtailPlugin::IsValidToSend(long long logstoreKey) {
+    // TODO: because go profile pipeline is not controlled by C++, we cannot know queue key in advance
+    // therefore, we assume true here. This could be a potential problem if network is not available for profile info.
+    // However, since go profile pipeline will be stopped only during process exit, it should be find.
+    if (logstoreKey == -1) {
+        return true;
+    }
     return SenderQueueManager::GetInstance()->IsValidToPush(logstoreKey) ? 0 : -1;
 }
 

--- a/core/go_pipeline/LogtailPlugin.cpp
+++ b/core/go_pipeline/LogtailPlugin.cpp
@@ -133,7 +133,7 @@ void LogtailPlugin::Resume() {
 int LogtailPlugin::IsValidToSend(long long logstoreKey) {
     // TODO: because go profile pipeline is not controlled by C++, we cannot know queue key in advance
     // therefore, we assume true here. This could be a potential problem if network is not available for profile info.
-    // However, since go profile pipeline will be stopped only during process exit, it should be find.
+    // However, since go profile pipeline will be stopped only during process exit, it should be fine.
     if (logstoreKey == -1) {
         return true;
     }

--- a/core/go_pipeline/LogtailPlugin.cpp
+++ b/core/go_pipeline/LogtailPlugin.cpp
@@ -22,6 +22,7 @@
 #include "common/JsonUtil.h"
 #include "common/LogtailCommonFlags.h"
 #include "common/TimeUtil.h"
+#include "compression/CompressorFactory.h"
 #include "config_manager/ConfigManager.h"
 #include "container_manager/ConfigContainerInfoUpdateCmd.h"
 #include "logger/Logger.h"
@@ -50,12 +51,16 @@ LogtailPlugin::LogtailPlugin() {
     mLoadGlobalConfigFun = NULL;
     mProcessRawLogFun = NULL;
     mPluginValid = false;
-    mPluginAlarmConfig.mLogstore = "logtail_alarm";
-    mPluginAlarmConfig.mAliuid = STRING_FLAG(logtail_profile_aliuid);
+    mPluginAlarmConfig.mCompressor
+        = CompressorFactory::GetInstance()->Create(Json::Value(), PipelineContext(), "flusher_sls", CompressType::LZ4);
     mPluginProfileConfig.mLogstore = "shennong_log_profile";
     mPluginProfileConfig.mAliuid = STRING_FLAG(logtail_profile_aliuid);
+    mPluginProfileConfig.mCompressor
+        = CompressorFactory::GetInstance()->Create(Json::Value(), PipelineContext(), "flusher_sls", CompressType::LZ4);
     mPluginContainerConfig.mLogstore = "logtail_containers";
     mPluginContainerConfig.mAliuid = STRING_FLAG(logtail_profile_aliuid);
+    mPluginContainerConfig.mCompressor
+        = CompressorFactory::GetInstance()->Create(Json::Value(), PipelineContext(), "flusher_sls", CompressType::LZ4);
 
     mPluginCfg["LogtailSysConfDir"] = AppConfig::GetInstance()->GetLogtailSysConfDir();
     mPluginCfg["HostIP"] = LogFileProfiler::mIpAddr;

--- a/core/go_pipeline/LogtailPlugin.cpp
+++ b/core/go_pipeline/LogtailPlugin.cpp
@@ -51,6 +51,8 @@ LogtailPlugin::LogtailPlugin() {
     mLoadGlobalConfigFun = NULL;
     mProcessRawLogFun = NULL;
     mPluginValid = false;
+    mPluginAlarmConfig.mLogstore = "logtail_alarm";
+    mPluginAlarmConfig.mAliuid = STRING_FLAG(logtail_profile_aliuid);
     mPluginAlarmConfig.mCompressor
         = CompressorFactory::GetInstance()->Create(Json::Value(), PipelineContext(), "flusher_sls", CompressType::LZ4);
     mPluginProfileConfig.mLogstore = "shennong_log_profile";

--- a/core/plugin/interface/Flusher.cpp
+++ b/core/plugin/interface/Flusher.cpp
@@ -23,6 +23,11 @@ using namespace std;
 
 namespace logtail {
 
+bool Flusher::Start() {
+    SenderQueueManager::GetInstance()->ReuseQueue(mQueueKey);
+    return true;
+}
+
 bool Flusher::Stop(bool isPipelineRemoving) {
     SenderQueueManager::GetInstance()->DeleteQueue(mQueueKey);
     return true;

--- a/core/plugin/interface/Flusher.cpp
+++ b/core/plugin/interface/Flusher.cpp
@@ -46,9 +46,9 @@ bool Flusher::PushToQueue(unique_ptr<SenderQueueItem>&& item, uint32_t retryTime
     }
 #endif
 
-    const string& str = QueueKeyManager::GetInstance()->GetName(mQueueKey);
+    const string& str = QueueKeyManager::GetInstance()->GetName(item->mQueueKey);
     for (size_t i = 0; i < retryTimes; ++i) {
-        int rst = SenderQueueManager::GetInstance()->PushQueue(mQueueKey, std::move(item));
+        int rst = SenderQueueManager::GetInstance()->PushQueue(item->mQueueKey, std::move(item));
         if (rst == 0) {
             return true;
         }

--- a/core/plugin/interface/Flusher.h
+++ b/core/plugin/interface/Flusher.h
@@ -34,7 +34,7 @@ public:
     virtual ~Flusher() = default;
 
     virtual bool Init(const Json::Value& config, Json::Value& optionalGoPipeline) = 0;
-    virtual bool Start() { return true; }
+    virtual bool Start();
     virtual bool Stop(bool isPipelineRemoving);
     virtual bool Send(PipelineEventGroup&& g) = 0;
     virtual bool Flush(size_t key) = 0;

--- a/core/queue/SenderQueueManager.cpp
+++ b/core/queue/SenderQueueManager.cpp
@@ -195,6 +195,11 @@ void SenderQueueManager::Clear() {
     mQueues.clear();
     mQueueDeletionTimeMap.clear();
 }
+
+bool SenderQueueManager::IsQueueMarkedDeleted(QueueKey key) {
+    lock_guard<mutex> lock(mGCMux);
+    return mQueueDeletionTimeMap.find(key) != mQueueDeletionTimeMap.end();
+}
 #endif
 
 } // namespace logtail

--- a/core/queue/SenderQueueManager.h
+++ b/core/queue/SenderQueueManager.h
@@ -52,6 +52,7 @@ public:
                      uint32_t maxRate = 0);
     SenderQueue* GetQueue(QueueKey key);
     bool DeleteQueue(QueueKey key);
+    bool ReuseQueue(QueueKey key);
     // 0: success, 1: queue is full, 2: queue not found
     int PushQueue(QueueKey key, std::unique_ptr<SenderQueueItem>&& item);
     void GetAllAvailableItems(std::vector<SenderQueueItem*>& items, bool withLimits = true);

--- a/core/queue/SenderQueueManager.h
+++ b/core/queue/SenderQueueManager.h
@@ -68,6 +68,7 @@ public:
 
 #ifdef APSARA_UNIT_TEST_MAIN
     void Clear();
+    bool IsQueueMarkedDeleted(QueueKey key);
 #endif
 
 private:

--- a/core/unittest/flusher/FlusherSLSUnittest.cpp
+++ b/core/unittest/flusher/FlusherSLSUnittest.cpp
@@ -56,7 +56,7 @@ public:
     void OnGoPipelineSend();
 
 protected:
-    void SetUp() override { 
+    void SetUp() override {
         ctx.SetConfigName("test_config");
         ctx.SetPipeline(pipeline);
     }
@@ -460,14 +460,12 @@ void FlusherSLSUnittest::OnFailedInit() {
 }
 
 void FlusherSLSUnittest::OnPipelineUpdate() {
-    PipelineContext ctx1, ctx2;
+    PipelineContext ctx1;
     ctx1.SetConfigName("test_config_1");
-    ctx2.SetConfigName("test_config_2");
 
     Json::Value configJson, optionalGoPipeline;
-    FlusherSLS flusher1, flusher2;
+    FlusherSLS flusher1;
     flusher1.SetContext(ctx1);
-    flusher2.SetContext(ctx2);
     string configStr, errorMsg;
 
     configStr = R"(
@@ -481,43 +479,70 @@ void FlusherSLSUnittest::OnPipelineUpdate() {
     )";
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     APSARA_TEST_TRUE(flusher1.Init(configJson, optionalGoPipeline));
-
-    configStr = R"(
-        {
-            "Type": "flusher_sls",
-            "Project": "test_project_2",
-            "Logstore": "test_logstore_2",
-            "Region": "cn-hangzhou",
-            "Endpoint": "cn-hangzhou.log.aliyuncs.com",
-            "Aliuid": "123456789"
-        }
-    )";
-    APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
-    APSARA_TEST_TRUE(flusher2.Init(configJson, optionalGoPipeline));
-
     APSARA_TEST_TRUE(flusher1.Start());
     APSARA_TEST_EQUAL(1U, FlusherSLS::sProjectRefCntMap.size());
     APSARA_TEST_TRUE(FlusherSLS::IsRegionContainingConfig("cn-hangzhou"));
     APSARA_TEST_EQUAL(1U, SLSClientManager::GetInstance()->GetRegionAliuids("cn-hangzhou").size());
 
-    APSARA_TEST_TRUE(flusher2.Start());
-    APSARA_TEST_EQUAL(2U, FlusherSLS::sProjectRefCntMap.size());
-    APSARA_TEST_TRUE(FlusherSLS::IsRegionContainingConfig("cn-hangzhou"));
-#ifdef __ENTERPRISE__
-    APSARA_TEST_EQUAL(2U, SLSClientManager::GetInstance()->GetRegionAliuids("cn-hangzhou").size());
-#else
-    APSARA_TEST_EQUAL(1U, SLSClientManager::GetInstance()->GetRegionAliuids("cn-hangzhou").size());
-#endif
+    {
+        PipelineContext ctx2;
+        ctx2.SetConfigName("test_config_2");
+        FlusherSLS flusher2;
+        flusher2.SetContext(ctx2);
+        configStr = R"(
+            {
+                "Type": "flusher_sls",
+                "Project": "test_project_2",
+                "Logstore": "test_logstore_2",
+                "Region": "cn-hangzhou",
+                "Endpoint": "cn-hangzhou.log.aliyuncs.com",
+                "Aliuid": "123456789"
+            }
+        )";
+        APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
+        APSARA_TEST_TRUE(flusher2.Init(configJson, optionalGoPipeline));
 
-    APSARA_TEST_TRUE(flusher2.Stop(true));
-    APSARA_TEST_EQUAL(1U, FlusherSLS::sProjectRefCntMap.size());
-    APSARA_TEST_TRUE(FlusherSLS::IsRegionContainingConfig("cn-hangzhou"));
-    APSARA_TEST_EQUAL(1U, SLSClientManager::GetInstance()->GetRegionAliuids("cn-hangzhou").size());
+        APSARA_TEST_TRUE(flusher1.Stop(false));
+        APSARA_TEST_TRUE(FlusherSLS::sProjectRefCntMap.empty());
+        APSARA_TEST_FALSE(FlusherSLS::IsRegionContainingConfig("cn-hangzhou"));
+        APSARA_TEST_TRUE(SLSClientManager::GetInstance()->GetRegionAliuids("cn-hangzhou").empty());
+        APSARA_TEST_TRUE(SenderQueueManager::GetInstance()->IsQueueMarkedDeleted(flusher1.GetQueueKey()));
 
-    APSARA_TEST_TRUE(flusher1.Stop(true));
-    APSARA_TEST_TRUE(FlusherSLS::sProjectRefCntMap.empty());
-    APSARA_TEST_FALSE(FlusherSLS::IsRegionContainingConfig("cn-hangzhou"));
-    APSARA_TEST_TRUE(SLSClientManager::GetInstance()->GetRegionAliuids("cn-hangzhou").empty());
+        APSARA_TEST_TRUE(flusher2.Start());
+        APSARA_TEST_EQUAL(1U, FlusherSLS::sProjectRefCntMap.size());
+        APSARA_TEST_TRUE(FlusherSLS::IsRegionContainingConfig("cn-hangzhou"));
+        APSARA_TEST_EQUAL(1U, SLSClientManager::GetInstance()->GetRegionAliuids("cn-hangzhou").size());
+        APSARA_TEST_TRUE(SenderQueueManager::GetInstance()->IsQueueMarkedDeleted(flusher1.GetQueueKey()));
+        APSARA_TEST_FALSE(SenderQueueManager::GetInstance()->IsQueueMarkedDeleted(flusher2.GetQueueKey()));
+        flusher2.Stop(true);
+        flusher1.Start();
+    }
+    {
+        PipelineContext ctx2;
+        ctx2.SetConfigName("test_config_1");
+        FlusherSLS flusher2;
+        flusher2.SetContext(ctx2);
+        configStr = R"(
+            {
+                "Type": "flusher_sls",
+                "Project": "test_project",
+                "Logstore": "test_logstore",
+                "Region": "cn-hangzhou",
+                "Endpoint": "cn-hangzhou.log.aliyuncs.com",
+                "Aliuid": "123456789"
+            }
+        )";
+        APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
+        APSARA_TEST_TRUE(flusher2.Init(configJson, optionalGoPipeline));
+
+        APSARA_TEST_TRUE(flusher1.Stop(false));
+        APSARA_TEST_TRUE(SenderQueueManager::GetInstance()->IsQueueMarkedDeleted(flusher1.GetQueueKey()));
+
+        APSARA_TEST_TRUE(flusher2.Start());
+        APSARA_TEST_FALSE(SenderQueueManager::GetInstance()->IsQueueMarkedDeleted(flusher1.GetQueueKey()));
+        APSARA_TEST_FALSE(SenderQueueManager::GetInstance()->IsQueueMarkedDeleted(flusher2.GetQueueKey()));
+        flusher2.Stop(true);
+    }
 }
 
 void FlusherSLSUnittest::TestSend() {
@@ -958,24 +983,69 @@ void FlusherSLSUnittest::TestAddPackId() {
 }
 
 void FlusherSLSUnittest::OnGoPipelineSend() {
-    Json::Value configJson, optionalGoPipeline;
-    string configStr, errorMsg;
-    configStr = R"(
-        {
-            "Type": "flusher_sls",
-            "Project": "test_project",
-            "Logstore": "test_logstore",
-            "Region": "cn-hangzhou",
-            "Endpoint": "cn-hangzhou.log.aliyuncs.com",
-            "Aliuid": "123456789"
-        }
-    )";
-    ParseJsonTable(configStr, configJson, errorMsg);
-    FlusherSLS flusher;
-    flusher.SetContext(ctx);
-    flusher.Init(configJson, optionalGoPipeline);
     {
-        APSARA_TEST_TRUE(flusher.Send("content", "shardhash_key", "other_logstore"));
+        Json::Value configJson, optionalGoPipeline;
+        string configStr, errorMsg;
+        configStr = R"(
+            {
+                "Type": "flusher_sls",
+                "Project": "test_project",
+                "Logstore": "test_logstore",
+                "Region": "cn-hangzhou",
+                "Endpoint": "cn-hangzhou.log.aliyuncs.com",
+                "Aliuid": "123456789"
+            }
+        )";
+        ParseJsonTable(configStr, configJson, errorMsg);
+        FlusherSLS flusher;
+        flusher.SetContext(ctx);
+        flusher.Init(configJson, optionalGoPipeline);
+        {
+            APSARA_TEST_TRUE(flusher.Send("content", "shardhash_key", "other_logstore"));
+
+            vector<SenderQueueItem*> res;
+            SenderQueueManager::GetInstance()->GetAllAvailableItems(res);
+
+            APSARA_TEST_EQUAL(1U, res.size());
+            auto item = static_cast<SLSSenderQueueItem*>(res[0]);
+            APSARA_TEST_EQUAL(RawDataType::EVENT_GROUP, item->mType);
+            APSARA_TEST_TRUE(item->mBufferOrNot);
+            APSARA_TEST_EQUAL(&flusher, item->mFlusher);
+            APSARA_TEST_EQUAL(flusher.mQueueKey, item->mQueueKey);
+            APSARA_TEST_EQUAL("shardhash_key", item->mShardHashKey);
+            APSARA_TEST_EQUAL("other_logstore", item->mLogstore);
+
+            auto compressor
+                = CompressorFactory::GetInstance()->Create(Json::Value(), ctx, "flusher_sls", CompressType::LZ4);
+            string output;
+            output.resize(item->mRawSize);
+            APSARA_TEST_TRUE(compressor->UnCompress(item->mData, output, errorMsg));
+            APSARA_TEST_EQUAL("content", output);
+        }
+        {
+            APSARA_TEST_TRUE(flusher.Send("content", "shardhash_key", ""));
+
+            vector<SenderQueueItem*> res;
+            SenderQueueManager::GetInstance()->GetAllAvailableItems(res);
+
+            APSARA_TEST_EQUAL(1U, res.size());
+            auto item = static_cast<SLSSenderQueueItem*>(res[0]);
+            APSARA_TEST_EQUAL("test_logstore", item->mLogstore);
+        }
+    }
+    {
+        // go profile flusher has no context
+        FlusherSLS flusher;
+        flusher.mProject = "test_project";
+        flusher.mLogstore = "test_logstore";
+        flusher.mCompressor = CompressorFactory::GetInstance()->Create(
+            Json::Value(), PipelineContext(), "flusher_sls", CompressType::LZ4);
+
+        APSARA_TEST_TRUE(flusher.Send("content", ""));
+
+        auto key = QueueKeyManager::GetInstance()->GetKey("test_project-test_logstore");
+
+        APSARA_TEST_NOT_EQUAL(nullptr, SenderQueueManager::GetInstance()->GetQueue(key));
 
         vector<SenderQueueItem*> res;
         SenderQueueManager::GetInstance()->GetAllAvailableItems(res);
@@ -985,26 +1055,16 @@ void FlusherSLSUnittest::OnGoPipelineSend() {
         APSARA_TEST_EQUAL(RawDataType::EVENT_GROUP, item->mType);
         APSARA_TEST_TRUE(item->mBufferOrNot);
         APSARA_TEST_EQUAL(&flusher, item->mFlusher);
-        APSARA_TEST_EQUAL(flusher.mQueueKey, item->mQueueKey);
-        APSARA_TEST_EQUAL("shardhash_key", item->mShardHashKey);
-        APSARA_TEST_EQUAL("other_logstore", item->mLogstore);
+        APSARA_TEST_EQUAL(key, item->mQueueKey);
+        APSARA_TEST_EQUAL("test_logstore", item->mLogstore);
 
         auto compressor
             = CompressorFactory::GetInstance()->Create(Json::Value(), ctx, "flusher_sls", CompressType::LZ4);
         string output;
         output.resize(item->mRawSize);
+        string errorMsg;
         APSARA_TEST_TRUE(compressor->UnCompress(item->mData, output, errorMsg));
         APSARA_TEST_EQUAL("content", output);
-    }
-    {
-        APSARA_TEST_TRUE(flusher.Send("content", "shardhash_key", ""));
-
-        vector<SenderQueueItem*> res;
-        SenderQueueManager::GetInstance()->GetAllAvailableItems(res);
-
-        APSARA_TEST_EQUAL(1U, res.size());
-        auto item = static_cast<SLSSenderQueueItem*>(res[0]);
-        APSARA_TEST_EQUAL("test_logstore", item->mLogstore);
     }
 }
 

--- a/core/unittest/queue/SenderQueueManagerUnittest.cpp
+++ b/core/unittest/queue/SenderQueueManagerUnittest.cpp
@@ -141,7 +141,7 @@ void SenderQueueManagerUnittest::TestDeleteQueue() {
     APSARA_TEST_EQUAL("", QueueKeyManager::GetInstance()->GetName(key1));
 
     // update queue will remove the queue from gc queue
-    sManager->CreateQueue(key2, vector<shared_ptr<ConcurrencyLimiter>>{sConcurrencyLimiter}, sMaxRate);
+    sManager->ReuseQueue(key2);
     APSARA_TEST_EQUAL(0U, sManager->mQueueDeletionTimeMap.size());
 }
 

--- a/pluginmanager/logstore_config.go
+++ b/pluginmanager/logstore_config.go
@@ -730,7 +730,7 @@ func LoadLogstoreConfig(project string, logstore string, configName string, logs
 func loadBuiltinConfig(name string, project string, logstore string,
 	configName string, cfgStr string) (*LogstoreConfig, error) {
 	logger.Infof(context.Background(), "load built-in config %v, config name: %v, logstore: %v", name, configName, logstore)
-	return createLogstoreConfig(project, logstore, configName, 0, cfgStr)
+	return createLogstoreConfig(project, logstore, configName, -1, cfgStr)
 }
 
 // loadMetric creates a metric plugin object and append to logstoreConfig.MetricPlugins.


### PR DESCRIPTION
- 问题：Go的profile信息无法发送到C++部分
- 原因：自监控没有独立的流水线，只有一个假的flusherSLS，而且这个flusher无法走常规的初始化流程，包括建队列等，因此go的自监控信息发送到C++会找不到相应的队列。
- 处理：特殊处理，发的时候看一下队列有没有，没的话现场建一个