### PR TITLE
fix: extend default timeout duration for reader flush

### DIFF
--- a/core/reader/FileReaderOptions.cpp
+++ b/core/reader/FileReaderOptions.cpp
@@ -30,7 +30,7 @@ DEFINE_FLAG_INT32(default_tail_limit_kb,
                   "when first open file, if offset little than this value, move offset to beginning, KB",
                   1024 * 50);
 #endif
-DEFINE_FLAG_INT32(default_reader_flush_timeout, "", 300);
+DEFINE_FLAG_INT32(default_reader_flush_timeout, "", 60);
 DEFINE_FLAG_INT32(delay_bytes_upperlimit,
                   "if (total_file_size - current_readed_size) exceed uppperlimit, send READ_LOG_DELAY_ALARM, bytes",
                   200 * 1024 * 1024);

--- a/core/reader/FileReaderOptions.cpp
+++ b/core/reader/FileReaderOptions.cpp
@@ -30,7 +30,7 @@ DEFINE_FLAG_INT32(default_tail_limit_kb,
                   "when first open file, if offset little than this value, move offset to beginning, KB",
                   1024 * 50);
 #endif
-DEFINE_FLAG_INT32(default_reader_flush_timeout, "", 5);
+DEFINE_FLAG_INT32(default_reader_flush_timeout, "", 300);
 DEFINE_FLAG_INT32(delay_bytes_upperlimit,
                   "if (total_file_size - current_readed_size) exceed uppperlimit, send READ_LOG_DELAY_ALARM, bytes",
                   200 * 1024 * 1024);

--- a/test/e2e/test_cases/input_container_stdio_multiline/case.feature
+++ b/test/e2e/test_cases/input_container_stdio_multiline/case.feature
@@ -20,6 +20,7 @@ Feature: input container stdio multiline
         IgnoringStdout: false
         Multiline:
           StartPattern: "today"
+        FlushTimeoutSecs: 5
     """
     When start docker-compose {input_container_stdio_multiline}
     Then there is at least {1} logs


### PR DESCRIPTION
## 问题
应用侧写入日志可能存在延迟，例如，某一行日志写入一半之后，5秒内都没有写入后半行。从而触发超时强制读取，导致截断。
已知触发原因：
1. 日志框架缓存
2. 操作系统缓存
3. 磁盘IO

## 解决方案
适当延长默认的超时时间

## 可能存在的风险
1. 多行依赖超时时间判断一组多行是否结束
2. C++ stdout依赖超时时间刷取最后一行