### PR TITLE
modify event group size

### DIFF
--- a/core/pipeline/Pipeline.cpp
+++ b/core/pipeline/Pipeline.cpp
@@ -291,7 +291,7 @@ bool Pipeline::Init(PipelineConfig&& config) {
             ProcessQueueManager::GetInstance()->CreateOrUpdateBoundedQueue(mContext.GetProcessQueueKey(), priority);
         } else {
             ProcessQueueManager::GetInstance()->CreateOrUpdateCircularQueue(
-                mContext.GetProcessQueueKey(), priority, 2048);
+                mContext.GetProcessQueueKey(), priority, 1024);
         }
 
 

--- a/core/pipeline/Pipeline.cpp
+++ b/core/pipeline/Pipeline.cpp
@@ -291,7 +291,7 @@ bool Pipeline::Init(PipelineConfig&& config) {
             ProcessQueueManager::GetInstance()->CreateOrUpdateBoundedQueue(mContext.GetProcessQueueKey(), priority);
         } else {
             ProcessQueueManager::GetInstance()->CreateOrUpdateCircularQueue(
-                mContext.GetProcessQueueKey(), priority, 100);
+                mContext.GetProcessQueueKey(), priority, 2048);
         }
 
 


### PR DESCRIPTION
ebpf 不加任何 filter 时，event group大小为1024，目前塞不到 processqueue 里面去，就无法发到sls
如果改成1024，一个 event group 内存占用是3M～4M