### PR TITLE
add metric for queue

### DIFF
--- a/core/file_server/reader/LogFileReader.cpp
+++ b/core/file_server/reader/LogFileReader.cpp
@@ -445,7 +445,7 @@ void LogFileReader::initExactlyOnce(uint32_t concurrency) {
     mEOOption->fbKey = QueueKeyManager::GetInstance()->GetKey(GetProject() + "-" + mEOOption->primaryCheckpointKey
                                                               + mEOOption->rangeCheckpointPtrs[0]->data.hash_key());
     ExactlyOnceQueueManager::GetInstance()->CreateOrUpdateQueue(
-        mEOOption->fbKey, ProcessQueueManager::sMaxPriority, mConfigName, mEOOption->rangeCheckpointPtrs);
+        mEOOption->fbKey, ProcessQueueManager::sMaxPriority, *mReaderConfig.second, mEOOption->rangeCheckpointPtrs);
     for (auto& cpt : mEOOption->rangeCheckpointPtrs) {
         cpt->fbKey = mEOOption->fbKey;
     }

--- a/core/monitor/LogtailMetric.cpp
+++ b/core/monitor/LogtailMetric.cpp
@@ -36,7 +36,7 @@ CounterPtr MetricsRecord::CreateCounter(const std::string& name) {
 }
 
 IntGaugePtr MetricsRecord::CreateIntGauge(const std::string& name) {
-    IntGaugePtr gaugePtr = std::make_shared<Gauge<uint64_t>>(name);
+    IntGaugePtr gaugePtr = std::make_shared<IntGauge>(name);
     mIntGauges.emplace_back(gaugePtr);
     return gaugePtr;
 }
@@ -134,6 +134,21 @@ const MetricsRecord* MetricsRecordRef::operator->() const {
     return mMetrics;
 }
 
+void MetricsRecordRef::AddLabels(MetricLabels&& labels) {
+    mMetrics->GetLabels()->insert(mMetrics->GetLabels()->end(), labels.begin(), labels.end());
+}
+
+#ifdef APSARA_UNIT_TEST_MAIN
+bool MetricsRecordRef::HasLabel(const std::string& key, const std::string& value) const {
+    for (auto item : *(mMetrics->GetLabels())) {
+        if (item.first == key && item.second == value) {
+            return true;
+        }
+    }
+    return false;
+}
+#endif
+
 // ReentrantMetricsRecord相关操作可以无锁，因为mCounters、mGauges只在初始化时会添加内容，后续只允许Get操作
 void ReentrantMetricsRecord::Init(MetricLabels& labels, std::unordered_map<std::string, MetricType>& metricKeys) {
     WriteMetrics::GetInstance()->PrepareMetricsRecordRef(mMetricsRecordRef, std::move(labels));
@@ -218,6 +233,20 @@ void WriteMetrics::PrepareMetricsRecordRef(MetricsRecordRef& ref,
     std::lock_guard<std::mutex> lock(mMutex);
     cur->SetNext(mHead);
     mHead = cur;
+}
+
+void WriteMetrics::CreateMetricsRecordRef(MetricsRecordRef& ref,
+                                          MetricLabels&& labels,
+                                          DynamicMetricLabels&& dynamicLabels) {
+    MetricsRecord* cur = new MetricsRecord(std::make_shared<MetricLabels>(labels),
+                                           std::make_shared<DynamicMetricLabels>(dynamicLabels));
+    ref.SetMetricsRecord(cur);
+}
+
+void WriteMetrics::CommitMetricsRecordRef(MetricsRecordRef& ref) {
+    std::lock_guard<std::mutex> lock(mMutex);
+    ref.mMetrics->SetNext(mHead);
+    mHead = ref.mMetrics;
 }
 
 MetricsRecord* WriteMetrics::GetHead() {

--- a/core/monitor/LogtailMetric.h
+++ b/core/monitor/LogtailMetric.h
@@ -76,6 +76,7 @@ public:
     IntGaugePtr CreateIntGauge(const std::string& name);
     DoubleGaugePtr CreateDoubleGauge(const std::string& name);
     const MetricsRecord* operator->() const;
+    // this is not thread-safe, and should be only used before WriteMetrics::CommitMetricsRecordRef
     void AddLabels(MetricLabels&& labels);
 #ifdef APSARA_UNIT_TEST_MAIN
     bool HasLabel(const std::string& key, const std::string& value) const;

--- a/core/monitor/MetricConstants.cpp
+++ b/core/monitor/MetricConstants.cpp
@@ -71,10 +71,10 @@ const std::string METRIC_LABEL_PLUGIN_ID = "plugin_id";
 const std::string METRIC_LABEL_NODE_ID = "node_id";
 const std::string METRIC_LABEL_CHILD_NODE_ID = "child_node_id";
 
-const std::string METRIC_LABEL_COMPONENT_NAME = "component_name";
-const std::string METRIC_LABEL_QUEUE_TYPE = "queue_type";
-const std::string METRIC_LABEL_EXACTLY_ONCE_FLAG = "is_exactly_once";
-const std::string METRIC_LABEL_FLUSHER_NODE_ID = "flusher_node_id";
+const std::string METRIC_LABEL_KEY_COMPONENT_NAME = "component_name";
+const std::string METRIC_LABEL_KEY_QUEUE_TYPE = "queue_type";
+const std::string METRIC_LABEL_KEY_EXACTLY_ONCE_FLAG = "is_exactly_once";
+const std::string METRIC_LABEL_KEY_FLUSHER_NODE_ID = "flusher_node_id";
 
 // input file plugin labels
 const std::string METRIC_LABEL_FILE_DEV = "file_dev";

--- a/core/monitor/MetricConstants.cpp
+++ b/core/monitor/MetricConstants.cpp
@@ -74,7 +74,7 @@ const std::string METRIC_LABEL_CHILD_NODE_ID = "child_node_id";
 const std::string METRIC_LABEL_COMPONENT_NAME = "component_name";
 const std::string METRIC_LABEL_QUEUE_TYPE = "queue_type";
 const std::string METRIC_LABEL_EXACTLY_ONCE_FLAG = "is_exactly_once";
-const std::string METRIC_LABEL_FLUSHER_PLUGIN_ID = "flusher_plugin_id";
+const std::string METRIC_LABEL_FLUSHER_NODE_ID = "flusher_node_id";
 
 // input file plugin labels
 const std::string METRIC_LABEL_FILE_DEV = "file_dev";

--- a/core/monitor/MetricConstants.cpp
+++ b/core/monitor/MetricConstants.cpp
@@ -71,6 +71,11 @@ const std::string METRIC_LABEL_PLUGIN_ID = "plugin_id";
 const std::string METRIC_LABEL_NODE_ID = "node_id";
 const std::string METRIC_LABEL_CHILD_NODE_ID = "child_node_id";
 
+const std::string METRIC_LABEL_COMPONENT_NAME = "component_name";
+const std::string METRIC_LABEL_QUEUE_TYPE = "queue_type";
+const std::string METRIC_LABEL_EXACTLY_ONCE_FLAG = "is_exactly_once";
+const std::string METRIC_LABEL_FLUSHER_PLUGIN_ID = "flusher_plugin_id";
+
 // input file plugin labels
 const std::string METRIC_LABEL_FILE_DEV = "file_dev";
 const std::string METRIC_LABEL_FILE_INODE = "file_inode";

--- a/core/monitor/MetricConstants.h
+++ b/core/monitor/MetricConstants.h
@@ -81,7 +81,7 @@ extern const std::string METRIC_LABEL_FILE_NAME;
 extern const std::string METRIC_LABEL_COMPONENT_NAME;
 extern const std::string METRIC_LABEL_QUEUE_TYPE;
 extern const std::string METRIC_LABEL_EXACTLY_ONCE_FLAG;
-extern const std::string METRIC_LABEL_FLUSHER_PLUGIN_ID;
+extern const std::string METRIC_LABEL_FLUSHER_NODE_ID;
 
 // input file metrics
 extern const std::string METRIC_INPUT_RECORDS_TOTAL;

--- a/core/monitor/MetricConstants.h
+++ b/core/monitor/MetricConstants.h
@@ -78,6 +78,11 @@ extern const std::string METRIC_LABEL_FILE_DEV;
 extern const std::string METRIC_LABEL_FILE_INODE;
 extern const std::string METRIC_LABEL_FILE_NAME;
 
+extern const std::string METRIC_LABEL_COMPONENT_NAME;
+extern const std::string METRIC_LABEL_QUEUE_TYPE;
+extern const std::string METRIC_LABEL_EXACTLY_ONCE_FLAG;
+extern const std::string METRIC_LABEL_FLUSHER_PLUGIN_ID;
+
 // input file metrics
 extern const std::string METRIC_INPUT_RECORDS_TOTAL;
 extern const std::string METRIC_INPUT_RECORDS_SIZE_BYTES;

--- a/core/monitor/MetricConstants.h
+++ b/core/monitor/MetricConstants.h
@@ -78,10 +78,10 @@ extern const std::string METRIC_LABEL_FILE_DEV;
 extern const std::string METRIC_LABEL_FILE_INODE;
 extern const std::string METRIC_LABEL_FILE_NAME;
 
-extern const std::string METRIC_LABEL_COMPONENT_NAME;
-extern const std::string METRIC_LABEL_QUEUE_TYPE;
-extern const std::string METRIC_LABEL_EXACTLY_ONCE_FLAG;
-extern const std::string METRIC_LABEL_FLUSHER_NODE_ID;
+extern const std::string METRIC_LABEL_KEY_COMPONENT_NAME;
+extern const std::string METRIC_LABEL_KEY_QUEUE_TYPE;
+extern const std::string METRIC_LABEL_KEY_EXACTLY_ONCE_FLAG;
+extern const std::string METRIC_LABEL_KEY_FLUSHER_NODE_ID;
 
 // input file metrics
 extern const std::string METRIC_INPUT_RECORDS_TOTAL;

--- a/core/pipeline/Pipeline.cpp
+++ b/core/pipeline/Pipeline.cpp
@@ -19,17 +19,17 @@
 #include <cstdint>
 #include <utility>
 
-#include "pipeline/batch/TimeoutFlushManager.h"
 #include "common/Flags.h"
 #include "common/ParamExtractor.h"
-#include "plugin/flusher/sls/FlusherSLS.h"
 #include "go_pipeline/LogtailPlugin.h"
-#include "plugin/input/InputFeedbackInterfaceRegistry.h"
+#include "pipeline/batch/TimeoutFlushManager.h"
 #include "pipeline/plugin/PluginRegistry.h"
-#include "plugin/processor/ProcessorParseApsaraNative.h"
 #include "pipeline/queue/ProcessQueueManager.h"
 #include "pipeline/queue/QueueKeyManager.h"
 #include "pipeline/queue/SenderQueueManager.h"
+#include "plugin/flusher/sls/FlusherSLS.h"
+#include "plugin/input/InputFeedbackInterfaceRegistry.h"
+#include "plugin/processor/ProcessorParseApsaraNative.h"
 
 DECLARE_FLAG_INT32(default_plugin_log_queue_size);
 
@@ -288,10 +288,11 @@ bool Pipeline::Init(PipelineConfig&& config) {
             ? ProcessQueueManager::sMaxPriority
             : mContext.GetGlobalConfig().mProcessPriority - 1;
         if (isInputSupportAck) {
-            ProcessQueueManager::GetInstance()->CreateOrUpdateBoundedQueue(mContext.GetProcessQueueKey(), priority);
+            ProcessQueueManager::GetInstance()->CreateOrUpdateBoundedQueue(
+                mContext.GetProcessQueueKey(), priority, mContext);
         } else {
             ProcessQueueManager::GetInstance()->CreateOrUpdateCircularQueue(
-                mContext.GetProcessQueueKey(), priority, 1024);
+                mContext.GetProcessQueueKey(), priority, 1024, mContext);
         }
 
 

--- a/core/pipeline/plugin/instance/FlusherInstance.cpp
+++ b/core/pipeline/plugin/instance/FlusherInstance.cpp
@@ -19,6 +19,7 @@
 namespace logtail {
 bool FlusherInstance::Init(const Json::Value& config, PipelineContext& context, Json::Value& optionalGoPipeline) {
     mPlugin->SetContext(context);
+    mPlugin->SetNodeID(NodeID());
     mPlugin->SetMetricsRecordRef(Name(), PluginID(), NodeID(), ChildNodeID());
     if (!mPlugin->Init(config, optionalGoPipeline)) {
         return false;

--- a/core/pipeline/plugin/interface/Flusher.h
+++ b/core/pipeline/plugin/interface/Flusher.h
@@ -44,6 +44,7 @@ public:
 
     QueueKey GetQueueKey() const { return mQueueKey; }
     void SetNodeID(const std::string& nodeID) { mNodeID = nodeID; }
+    const std::string& GetNodeID() const { return mNodeID; }
 
 protected:
     void GenerateQueueKey(const std::string& target);

--- a/core/pipeline/plugin/interface/Flusher.h
+++ b/core/pipeline/plugin/interface/Flusher.h
@@ -43,6 +43,7 @@ public:
     virtual SinkType GetSinkType() { return SinkType::NONE; }
 
     QueueKey GetQueueKey() const { return mQueueKey; }
+    void SetNodeID(const std::string& nodeID) { mNodeID = nodeID; }
 
 protected:
     void GenerateQueueKey(const std::string& target);
@@ -50,6 +51,7 @@ protected:
     void DealSenderQueueItemAfterSend(SenderQueueItem* item, bool keep);
 
     QueueKey mQueueKey;
+    std::string mNodeID;
 
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class FlusherInstanceUnittest;

--- a/core/pipeline/queue/BoundedProcessQueue.cpp
+++ b/core/pipeline/queue/BoundedProcessQueue.cpp
@@ -24,7 +24,7 @@ BoundedProcessQueue::BoundedProcessQueue(
       BoundedQueueInterface(key, cap, low, high, ctx),
       ProcessQueueInterface(key, cap, priority, ctx) {
     if (ctx.IsExactlyOnceEnabled()) {
-        mMetricsRecordRef.AddLabels({{METRIC_LABEL_EXACTLY_ONCE_FLAG, "true"}});
+        mMetricsRecordRef.AddLabels({{METRIC_LABEL_KEY_EXACTLY_ONCE_FLAG, "true"}});
     }
     WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
 }

--- a/core/pipeline/queue/BoundedProcessQueue.cpp
+++ b/core/pipeline/queue/BoundedProcessQueue.cpp
@@ -39,7 +39,7 @@ bool BoundedProcessQueue::Push(unique_ptr<ProcessQueueItem>&& item) {
     ChangeStateIfNeededAfterPush();
 
     mInItemsCnt->Add(1);
-    mInItemsSizeByte->Add(size);
+    mInItemDataSizeBytes->Add(size);
     mQueueSize->Set(Size());
     mQueueDataSizeByte->Add(size);
     mValidToPushFlag->Set(IsValidToPush());

--- a/core/pipeline/queue/BoundedProcessQueue.cpp
+++ b/core/pipeline/queue/BoundedProcessQueue.cpp
@@ -18,12 +18,31 @@ using namespace std;
 
 namespace logtail {
 
+BoundedProcessQueue::BoundedProcessQueue(
+    size_t cap, size_t low, size_t high, int64_t key, uint32_t priority, const PipelineContext& ctx)
+    : QueueInterface(key, cap, ctx),
+      BoundedQueueInterface(key, cap, low, high, ctx),
+      ProcessQueueInterface(key, cap, priority, ctx) {
+    if (ctx.IsExactlyOnceEnabled()) {
+        mMetricsRecordRef.AddLabels({{METRIC_LABEL_EXACTLY_ONCE_FLAG, "true"}});
+    }
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
+}
+
 bool BoundedProcessQueue::Push(unique_ptr<ProcessQueueItem>&& item) {
     if (!IsValidToPush()) {
         return false;
     }
+    item->mEnqueTime = chrono::system_clock::now();
+    auto size = item->mEventGroup.DataSize();
     mQueue.push(std::move(item));
     ChangeStateIfNeededAfterPush();
+
+    mInItemsCnt->Add(1);
+    mInItemsSizeByte->Add(size);
+    mQueueSize->Set(Size());
+    mQueueDataSizeByte->Add(size);
+    mValidToPushFlag->Set(IsValidToPush());
     return true;
 }
 
@@ -36,10 +55,17 @@ bool BoundedProcessQueue::Pop(unique_ptr<ProcessQueueItem>& item) {
     if (ChangeStateIfNeededAfterPop()) {
         GiveFeedback();
     }
+
+    mOutItemsCnt->Add(1);
+    mTotalDelayMs->Add(
+        chrono::duration_cast<chrono::milliseconds>(chrono::system_clock::now() - item->mEnqueTime).count());
+    mQueueSize->Set(Size());
+    mQueueDataSizeByte->Sub(item->mEventGroup.DataSize());
+    mValidToPushFlag->Set(IsValidToPush());
     return true;
 }
 
-void BoundedProcessQueue::SetUpStreamFeedbacks(std::vector<FeedbackInterface*>&& feedbacks) {
+void BoundedProcessQueue::SetUpStreamFeedbacks(vector<FeedbackInterface*>&& feedbacks) {
     mUpStreamFeedbacks.clear();
     for (auto& item : feedbacks) {
         if (item == nullptr) {

--- a/core/pipeline/queue/BoundedProcessQueue.h
+++ b/core/pipeline/queue/BoundedProcessQueue.h
@@ -31,10 +31,7 @@ namespace logtail {
 class BoundedProcessQueue : public BoundedQueueInterface<std::unique_ptr<ProcessQueueItem>>,
                             public ProcessQueueInterface {
 public:
-    BoundedProcessQueue(size_t cap, size_t low, size_t high, int64_t key, uint32_t priority, const std::string& config)
-        : QueueInterface(key, cap),
-          BoundedQueueInterface(key, cap, low, high),
-          ProcessQueueInterface(key, cap, priority, config) {}
+    BoundedProcessQueue(size_t cap, size_t low, size_t high, int64_t key, uint32_t priority, const PipelineContext& ctx);
 
     bool Push(std::unique_ptr<ProcessQueueItem>&& item) override;
     bool Pop(std::unique_ptr<ProcessQueueItem>& item) override;

--- a/core/pipeline/queue/BoundedQueueInterface.h
+++ b/core/pipeline/queue/BoundedQueueInterface.h
@@ -25,7 +25,7 @@ class BoundedQueueInterface : virtual public QueueInterface<T> {
 public:
     BoundedQueueInterface(QueueKey key, size_t cap, size_t low, size_t high, const PipelineContext& ctx)
         : QueueInterface<T>(key, cap, ctx), mLowWatermark(low), mHighWatermark(high) {
-        this->mMetricsRecordRef.AddLabels({{METRIC_LABEL_QUEUE_TYPE, "bounded"}});
+        this->mMetricsRecordRef.AddLabels({{METRIC_LABEL_KEY_QUEUE_TYPE, "bounded"}});
         mValidToPushFlag = this->mMetricsRecordRef.CreateIntGauge("valid_to_push");
     }
     virtual ~BoundedQueueInterface() = default;

--- a/core/pipeline/queue/BoundedQueueInterface.h
+++ b/core/pipeline/queue/BoundedQueueInterface.h
@@ -23,8 +23,11 @@ namespace logtail {
 template <typename T>
 class BoundedQueueInterface : virtual public QueueInterface<T> {
 public:
-    BoundedQueueInterface(QueueKey key, size_t cap, size_t low, size_t high)
-        : QueueInterface<T>(key, cap), mLowWatermark(low), mHighWatermark(high) {}
+    BoundedQueueInterface(QueueKey key, size_t cap, size_t low, size_t high, const PipelineContext& ctx)
+        : QueueInterface<T>(key, cap, ctx), mLowWatermark(low), mHighWatermark(high) {
+        this->mMetricsRecordRef.AddLabels({{METRIC_LABEL_QUEUE_TYPE, "bounded"}});
+        mValidToPushFlag = this->mMetricsRecordRef.CreateIntGauge("valid_to_push");
+    }
     virtual ~BoundedQueueInterface() = default;
 
     BoundedQueueInterface(const BoundedQueueInterface& que) = delete;
@@ -56,6 +59,8 @@ protected:
         mHighWatermark = high;
         mValidToPush = true;
     }
+
+    IntGaugePtr mValidToPushFlag;
 
 private:
     virtual void GiveFeedback() const = 0;

--- a/core/pipeline/queue/BoundedSenderQueueInterface.cpp
+++ b/core/pipeline/queue/BoundedSenderQueueInterface.cpp
@@ -27,7 +27,7 @@ BoundedSenderQueueInterface::BoundedSenderQueueInterface(
     mMetricsRecordRef.AddLabels({{METRIC_LABEL_COMPONENT_NAME, "sender_queue"}});
     mMetricsRecordRef.AddLabels({{METRIC_LABEL_FLUSHER_NODE_ID, flusherId}});
     mExtraBufferCnt = mMetricsRecordRef.CreateIntGauge("extra_buffer_size");
-    mExtraBufferDataSizeByte = mMetricsRecordRef.CreateIntGauge("extra_buffer_data_size_byte");
+    mExtraBufferDataSizeByte = mMetricsRecordRef.CreateIntGauge("extra_buffer_data_size_bytes");
 }
 
 void BoundedSenderQueueInterface::SetFeedback(FeedbackInterface* feedback) {

--- a/core/pipeline/queue/BoundedSenderQueueInterface.cpp
+++ b/core/pipeline/queue/BoundedSenderQueueInterface.cpp
@@ -24,8 +24,8 @@ FeedbackInterface* BoundedSenderQueueInterface::sFeedback = nullptr;
 BoundedSenderQueueInterface::BoundedSenderQueueInterface(
     size_t cap, size_t low, size_t high, QueueKey key, const string& flusherId, const PipelineContext& ctx)
     : QueueInterface(key, cap, ctx), BoundedQueueInterface<std::unique_ptr<SenderQueueItem>>(key, cap, low, high, ctx) {
-    mMetricsRecordRef.AddLabels({{METRIC_LABEL_COMPONENT_NAME, "sender_queue"}});
-    mMetricsRecordRef.AddLabels({{METRIC_LABEL_FLUSHER_NODE_ID, flusherId}});
+    mMetricsRecordRef.AddLabels({{METRIC_LABEL_KEY_COMPONENT_NAME, "sender_queue"}});
+    mMetricsRecordRef.AddLabels({{METRIC_LABEL_KEY_FLUSHER_NODE_ID, flusherId}});
     mExtraBufferSize = mMetricsRecordRef.CreateIntGauge("extra_buffer_size");
     mExtraBufferDataSizeBytes = mMetricsRecordRef.CreateIntGauge("extra_buffer_data_size_bytes");
 }

--- a/core/pipeline/queue/BoundedSenderQueueInterface.cpp
+++ b/core/pipeline/queue/BoundedSenderQueueInterface.cpp
@@ -25,7 +25,7 @@ BoundedSenderQueueInterface::BoundedSenderQueueInterface(
     size_t cap, size_t low, size_t high, QueueKey key, const string& flusherId, const PipelineContext& ctx)
     : QueueInterface(key, cap, ctx), BoundedQueueInterface<std::unique_ptr<SenderQueueItem>>(key, cap, low, high, ctx) {
     mMetricsRecordRef.AddLabels({{METRIC_LABEL_COMPONENT_NAME, "sender_queue"}});
-    mMetricsRecordRef.AddLabels({{METRIC_LABEL_FLUSHER_PLUGIN_ID, flusherId}});
+    mMetricsRecordRef.AddLabels({{METRIC_LABEL_FLUSHER_NODE_ID, flusherId}});
     mExtraBufferCnt = mMetricsRecordRef.CreateIntGauge("extra_buffer_size");
     mExtraBufferDataSizeByte = mMetricsRecordRef.CreateIntGauge("extra_buffer_data_size_byte");
 }

--- a/core/pipeline/queue/BoundedSenderQueueInterface.cpp
+++ b/core/pipeline/queue/BoundedSenderQueueInterface.cpp
@@ -26,8 +26,8 @@ BoundedSenderQueueInterface::BoundedSenderQueueInterface(
     : QueueInterface(key, cap, ctx), BoundedQueueInterface<std::unique_ptr<SenderQueueItem>>(key, cap, low, high, ctx) {
     mMetricsRecordRef.AddLabels({{METRIC_LABEL_COMPONENT_NAME, "sender_queue"}});
     mMetricsRecordRef.AddLabels({{METRIC_LABEL_FLUSHER_NODE_ID, flusherId}});
-    mExtraBufferCnt = mMetricsRecordRef.CreateIntGauge("extra_buffer_size");
-    mExtraBufferDataSizeByte = mMetricsRecordRef.CreateIntGauge("extra_buffer_data_size_bytes");
+    mExtraBufferSize = mMetricsRecordRef.CreateIntGauge("extra_buffer_size");
+    mExtraBufferDataSizeBytes = mMetricsRecordRef.CreateIntGauge("extra_buffer_data_size_bytes");
 }
 
 void BoundedSenderQueueInterface::SetFeedback(FeedbackInterface* feedback) {

--- a/core/pipeline/queue/BoundedSenderQueueInterface.cpp
+++ b/core/pipeline/queue/BoundedSenderQueueInterface.cpp
@@ -21,6 +21,15 @@ namespace logtail {
 
 FeedbackInterface* BoundedSenderQueueInterface::sFeedback = nullptr;
 
+BoundedSenderQueueInterface::BoundedSenderQueueInterface(
+    size_t cap, size_t low, size_t high, QueueKey key, const string& flusherId, const PipelineContext& ctx)
+    : QueueInterface(key, cap, ctx), BoundedQueueInterface<std::unique_ptr<SenderQueueItem>>(key, cap, low, high, ctx) {
+    mMetricsRecordRef.AddLabels({{METRIC_LABEL_COMPONENT_NAME, "sender_queue"}});
+    mMetricsRecordRef.AddLabels({{METRIC_LABEL_FLUSHER_PLUGIN_ID, flusherId}});
+    mExtraBufferCnt = mMetricsRecordRef.CreateIntGauge("extra_buffer_size");
+    mExtraBufferDataSizeByte = mMetricsRecordRef.CreateIntGauge("extra_buffer_data_size_byte");
+}
+
 void BoundedSenderQueueInterface::SetFeedback(FeedbackInterface* feedback) {
     if (feedback == nullptr) {
         // should not happen

--- a/core/pipeline/queue/BoundedSenderQueueInterface.h
+++ b/core/pipeline/queue/BoundedSenderQueueInterface.h
@@ -64,8 +64,8 @@ protected:
 
     std::queue<std::unique_ptr<SenderQueueItem>> mExtraBuffer;
 
-    IntGaugePtr mExtraBufferCnt;
-    IntGaugePtr mExtraBufferDataSizeByte;
+    IntGaugePtr mExtraBufferSize;
+    IntGaugePtr mExtraBufferDataSizeBytes;
 };
 
 } // namespace logtail

--- a/core/pipeline/queue/BoundedSenderQueueInterface.h
+++ b/core/pipeline/queue/BoundedSenderQueueInterface.h
@@ -22,11 +22,11 @@
 #include <vector>
 
 #include "common/FeedbackInterface.h"
+#include "pipeline/limiter/ConcurrencyLimiter.h"
+#include "pipeline/limiter/RateLimiter.h"
 #include "pipeline/queue/BoundedQueueInterface.h"
 #include "pipeline/queue/QueueKey.h"
 #include "pipeline/queue/SenderQueueItem.h"
-#include "pipeline/limiter/ConcurrencyLimiter.h"
-#include "pipeline/limiter/RateLimiter.h"
 
 namespace logtail {
 
@@ -37,8 +37,8 @@ class BoundedSenderQueueInterface : public BoundedQueueInterface<std::unique_ptr
 public:
     static void SetFeedback(FeedbackInterface* feedback);
 
-    BoundedSenderQueueInterface(size_t cap, size_t low, size_t high, QueueKey key)
-        : QueueInterface(key, cap), BoundedQueueInterface<std::unique_ptr<SenderQueueItem>>(key, cap, low, high) {}
+    BoundedSenderQueueInterface(
+        size_t cap, size_t low, size_t high, QueueKey key, const std::string& flusherId, const PipelineContext& ctx);
 
     bool Pop(std::unique_ptr<SenderQueueItem>& item) override { return false; }
 
@@ -63,6 +63,9 @@ protected:
     std::vector<std::shared_ptr<ConcurrencyLimiter>> mConcurrencyLimiters;
 
     std::queue<std::unique_ptr<SenderQueueItem>> mExtraBuffer;
+
+    IntGaugePtr mExtraBufferCnt;
+    IntGaugePtr mExtraBufferDataSizeByte;
 };
 
 } // namespace logtail

--- a/core/pipeline/queue/CircularProcessQueue.cpp
+++ b/core/pipeline/queue/CircularProcessQueue.cpp
@@ -21,17 +21,36 @@ using namespace std;
 
 namespace logtail {
 
+CircularProcessQueue::CircularProcessQueue(size_t cap, int64_t key, uint32_t priority, const PipelineContext& ctx)
+    : QueueInterface<std::unique_ptr<ProcessQueueItem>>(key, cap, ctx), ProcessQueueInterface(key, cap, priority, ctx) {
+    mMetricsRecordRef.AddLabels({{METRIC_LABEL_QUEUE_TYPE, "circular"}});
+    mDroppedEventsCnt = mMetricsRecordRef.CreateCounter("dropped_events_cnt");
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
+}
+
 bool CircularProcessQueue::Push(unique_ptr<ProcessQueueItem>&& item) {
     size_t newCnt = item->mEventGroup.GetEvents().size();
     while (!mQueue.empty() && mEventCnt + newCnt > mCapacity) {
-        mEventCnt -= mQueue.front()->mEventGroup.GetEvents().size();
+        auto cnt = mQueue.front()->mEventGroup.GetEvents().size();
+        auto size = mQueue.front()->mEventGroup.DataSize();
+        mEventCnt -= cnt;
         mQueue.pop_front();
+        mQueueSize->Set(Size());
+        mQueueDataSizeByte->Sub(size);
+        mDroppedEventsCnt->Add(cnt);
     }
     if (mEventCnt + newCnt > mCapacity) {
         return false;
     }
+    item->mEnqueTime = chrono::system_clock::now();
+    auto size = item->mEventGroup.DataSize();
     mQueue.push_back(std::move(item));
     mEventCnt += newCnt;
+
+    mInItemsCnt->Add(1);
+    mInItemsSizeByte->Add(size);
+    mQueueSize->Set(Size());
+    mQueueDataSizeByte->Add(size);
     return true;
 }
 
@@ -42,12 +61,19 @@ bool CircularProcessQueue::Pop(unique_ptr<ProcessQueueItem>& item) {
     item = std::move(mQueue.front());
     mQueue.pop_front();
     mEventCnt -= item->mEventGroup.GetEvents().size();
+
+    mOutItemsCnt->Add(1);
+    mTotalDelayMs->Add(
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - item->mEnqueTime)
+            .count());
+    mQueueSize->Set(Size());
+    mQueueDataSizeByte->Sub(item->mEventGroup.DataSize());
     return true;
 }
 
 void CircularProcessQueue::Reset(size_t cap) {
-    // it seems more reasonable to retain extra items and process them immediately, however this contray to current framework design
-    // so we simply discard extra items, considering that it is a rare case to change capacity
+    // it seems more reasonable to retain extra items and process them immediately, however this contray to current
+    // framework design so we simply discard extra items, considering that it is a rare case to change capacity
     uint32_t cnt = 0;
     while (!mQueue.empty() && mEventCnt > cap) {
         mEventCnt -= mQueue.front()->mEventGroup.GetEvents().size();

--- a/core/pipeline/queue/CircularProcessQueue.cpp
+++ b/core/pipeline/queue/CircularProcessQueue.cpp
@@ -48,7 +48,7 @@ bool CircularProcessQueue::Push(unique_ptr<ProcessQueueItem>&& item) {
     mEventCnt += newCnt;
 
     mInItemsCnt->Add(1);
-    mInItemsSizeByte->Add(size);
+    mInItemDataSizeBytes->Add(size);
     mQueueSize->Set(Size());
     mQueueDataSizeByte->Add(size);
     return true;

--- a/core/pipeline/queue/CircularProcessQueue.cpp
+++ b/core/pipeline/queue/CircularProcessQueue.cpp
@@ -23,7 +23,7 @@ namespace logtail {
 
 CircularProcessQueue::CircularProcessQueue(size_t cap, int64_t key, uint32_t priority, const PipelineContext& ctx)
     : QueueInterface<std::unique_ptr<ProcessQueueItem>>(key, cap, ctx), ProcessQueueInterface(key, cap, priority, ctx) {
-    mMetricsRecordRef.AddLabels({{METRIC_LABEL_QUEUE_TYPE, "circular"}});
+    mMetricsRecordRef.AddLabels({{METRIC_LABEL_KEY_QUEUE_TYPE, "circular"}});
     mDroppedEventsCnt = mMetricsRecordRef.CreateCounter("dropped_events_cnt");
     WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
 }

--- a/core/pipeline/queue/CircularProcessQueue.h
+++ b/core/pipeline/queue/CircularProcessQueue.h
@@ -29,9 +29,7 @@ namespace logtail {
 class CircularProcessQueue : virtual public QueueInterface<std::unique_ptr<ProcessQueueItem>>,
                              public ProcessQueueInterface {
 public:
-    CircularProcessQueue(size_t cap, int64_t key, uint32_t priority, const std::string& config)
-        : QueueInterface<std::unique_ptr<ProcessQueueItem>>(key, cap),
-          ProcessQueueInterface(key, cap, priority, config) {}
+    CircularProcessQueue(size_t cap, int64_t key, uint32_t priority, const PipelineContext& ctx);
 
     bool Push(std::unique_ptr<ProcessQueueItem>&& item) override;
     bool Pop(std::unique_ptr<ProcessQueueItem>& item) override;
@@ -43,6 +41,8 @@ private:
 
     std::deque<std::unique_ptr<ProcessQueueItem>> mQueue;
     size_t mEventCnt = 0;
+
+    CounterPtr mDroppedEventsCnt;
 
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class CircularProcessQueueUnittest;

--- a/core/pipeline/queue/ExactlyOnceQueueManager.h
+++ b/core/pipeline/queue/ExactlyOnceQueueManager.h
@@ -51,7 +51,7 @@ public:
 
     bool CreateOrUpdateQueue(QueueKey key,
                              uint32_t priority,
-                             const std::string& config,
+                             const PipelineContext& ctx,
                              const std::vector<RangeCheckpointPtr>& checkpoints);
     bool DeleteQueue(QueueKey key);
 

--- a/core/pipeline/queue/ExactlyOnceSenderQueue.cpp
+++ b/core/pipeline/queue/ExactlyOnceSenderQueue.cpp
@@ -32,7 +32,7 @@ ExactlyOnceSenderQueue::ExactlyOnceSenderQueue(const std::vector<RangeCheckpoint
       BoundedSenderQueueInterface(checkpoints.size(), checkpoints.size() - 1, checkpoints.size(), key, "", ctx),
       mRangeCheckpoints(checkpoints) {
     mQueue.resize(checkpoints.size());
-    mMetricsRecordRef.AddLabels({{METRIC_LABEL_EXACTLY_ONCE_FLAG, "true"}});
+    mMetricsRecordRef.AddLabels({{METRIC_LABEL_KEY_EXACTLY_ONCE_FLAG, "true"}});
     WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
 }
 

--- a/core/pipeline/queue/ExactlyOnceSenderQueue.h
+++ b/core/pipeline/queue/ExactlyOnceSenderQueue.h
@@ -30,13 +30,7 @@ namespace logtail {
 // not thread-safe, should be protected explicitly by queue manager
 class ExactlyOnceSenderQueue : public BoundedSenderQueueInterface {
 public:
-    // mFlusher will be set on first push
-    ExactlyOnceSenderQueue(const std::vector<RangeCheckpointPtr>& checkpoints, QueueKey key)
-        : QueueInterface(key, checkpoints.size()),
-          BoundedSenderQueueInterface(checkpoints.size(), checkpoints.size() - 1, checkpoints.size(), key),
-          mRangeCheckpoints(checkpoints) {
-        mQueue.resize(checkpoints.size());
-    }
+    ExactlyOnceSenderQueue(const std::vector<RangeCheckpointPtr>& checkpoints, QueueKey key, const PipelineContext& ctx);
 
     bool Push(std::unique_ptr<SenderQueueItem>&& item) override;
     bool Remove(SenderQueueItem* item) override;

--- a/core/pipeline/queue/ProcessQueueInterface.cpp
+++ b/core/pipeline/queue/ProcessQueueInterface.cpp
@@ -20,6 +20,11 @@ using namespace std;
 
 namespace logtail {
 
+ProcessQueueInterface::ProcessQueueInterface(int64_t key, size_t cap, uint32_t priority, const PipelineContext& ctx)
+    : QueueInterface(key, cap, ctx), mPriority(priority), mConfigName(ctx.GetConfigName()) {
+    mMetricsRecordRef.AddLabels({{METRIC_LABEL_COMPONENT_NAME, "process_queue"}});
+}
+
 void ProcessQueueInterface::SetDownStreamQueues(vector<BoundedSenderQueueInterface*>&& ques) {
     mDownStreamQueues.clear();
     for (auto& item : ques) {

--- a/core/pipeline/queue/ProcessQueueInterface.cpp
+++ b/core/pipeline/queue/ProcessQueueInterface.cpp
@@ -22,7 +22,7 @@ namespace logtail {
 
 ProcessQueueInterface::ProcessQueueInterface(int64_t key, size_t cap, uint32_t priority, const PipelineContext& ctx)
     : QueueInterface(key, cap, ctx), mPriority(priority), mConfigName(ctx.GetConfigName()) {
-    mMetricsRecordRef.AddLabels({{METRIC_LABEL_COMPONENT_NAME, "process_queue"}});
+    mMetricsRecordRef.AddLabels({{METRIC_LABEL_KEY_COMPONENT_NAME, "process_queue"}});
 }
 
 void ProcessQueueInterface::SetDownStreamQueues(vector<BoundedSenderQueueInterface*>&& ques) {

--- a/core/pipeline/queue/ProcessQueueInterface.h
+++ b/core/pipeline/queue/ProcessQueueInterface.h
@@ -31,8 +31,7 @@ class BoundedSenderQueueInterface;
 // not thread-safe, should be protected explicitly by queue manager
 class ProcessQueueInterface : virtual public QueueInterface<std::unique_ptr<ProcessQueueItem>> {
 public:
-    ProcessQueueInterface(int64_t key, size_t cap, uint32_t priority, const std::string& config)
-        : QueueInterface(key, cap), mPriority(priority), mConfigName(config) {}
+    ProcessQueueInterface(int64_t key, size_t cap, uint32_t priority, const PipelineContext& ctx);
     virtual ~ProcessQueueInterface() = default;
 
     void SetPriority(uint32_t priority) { mPriority = priority; }
@@ -46,9 +45,7 @@ public:
     void InvalidatePop() { mValidToPop = false; }
     void ValidatePop() { mValidToPop = true; }
 
-    void Reset() {
-        mDownStreamQueues.clear();
-    }
+    void Reset() { mDownStreamQueues.clear(); }
 
 protected:
     bool IsValidToPop() const;

--- a/core/pipeline/queue/ProcessQueueItem.h
+++ b/core/pipeline/queue/ProcessQueueItem.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
 
 #include "models/PipelineEventGroup.h"
@@ -28,6 +29,7 @@ struct ProcessQueueItem {
     PipelineEventGroup mEventGroup;
     std::shared_ptr<Pipeline> mPipeline; // not null only during pipeline update
     size_t mInputIndex = 0; // index of the input in the pipeline
+    std::chrono::system_clock::time_point mEnqueTime;
 
     ProcessQueueItem(PipelineEventGroup&& group, size_t index) : mEventGroup(std::move(group)), mInputIndex(index) {}
 };

--- a/core/pipeline/queue/ProcessQueueManager.h
+++ b/core/pipeline/queue/ProcessQueueManager.h
@@ -52,8 +52,8 @@ public:
 
     void Feedback(QueueKey key) override { Trigger(); }
 
-    bool CreateOrUpdateBoundedQueue(QueueKey key, uint32_t priority);
-    bool CreateOrUpdateCircularQueue(QueueKey key, uint32_t priority, size_t capacity);
+    bool CreateOrUpdateBoundedQueue(QueueKey key, uint32_t priority, const PipelineContext& ctx);
+    bool CreateOrUpdateCircularQueue(QueueKey key, uint32_t priority, size_t capacity, const PipelineContext& ctx);
     bool DeleteQueue(QueueKey key);
     bool IsValidToPush(QueueKey key) const;
     // 0: success, 1: queue is full, 2: queue not found
@@ -76,8 +76,8 @@ private:
     ProcessQueueManager();
     ~ProcessQueueManager() = default;
 
-    void CreateBoundedQueue(QueueKey key, uint32_t priority);
-    void CreateCircularQueue(QueueKey key, uint32_t priority, size_t capacity);
+    void CreateBoundedQueue(QueueKey key, uint32_t priority, const PipelineContext& ctx);
+    void CreateCircularQueue(QueueKey key, uint32_t priority, size_t capacity, const PipelineContext& ctx);
     void AdjustQueuePriority(const ProcessQueueIterator& iter, uint32_t priority);
     void DeleteQueueEntity(const ProcessQueueIterator& iter);
     void ResetCurrentQueueIndex();

--- a/core/pipeline/queue/QueueInterface.h
+++ b/core/pipeline/queue/QueueInterface.h
@@ -34,11 +34,11 @@ public:
                                                             });
 
         mInItemsCnt = mMetricsRecordRef.CreateCounter("in_items_cnt");
-        mInItemsSizeByte = mMetricsRecordRef.CreateCounter("in_items_size_byte");
+        mInItemsSizeByte = mMetricsRecordRef.CreateCounter("in_items_size_bytes");
         mOutItemsCnt = mMetricsRecordRef.CreateCounter("out_items_cnt");
         mTotalDelayMs = mMetricsRecordRef.CreateCounter("total_delay_ms");
         mQueueSize = mMetricsRecordRef.CreateIntGauge("queue_size");
-        mQueueDataSizeByte = mMetricsRecordRef.CreateIntGauge("queue_data_size_byte");
+        mQueueDataSizeByte = mMetricsRecordRef.CreateIntGauge("queue_data_size_bytes");
     }
     virtual ~QueueInterface() = default;
 

--- a/core/pipeline/queue/QueueInterface.h
+++ b/core/pipeline/queue/QueueInterface.h
@@ -34,7 +34,7 @@ public:
                                                             });
 
         mInItemsCnt = mMetricsRecordRef.CreateCounter("in_items_cnt");
-        mInItemDataSizeBytes = mMetricsRecordRef.CreateCounter("in_items_size_bytes");
+        mInItemDataSizeBytes = mMetricsRecordRef.CreateCounter("in_item_data_size_bytes");
         mOutItemsCnt = mMetricsRecordRef.CreateCounter("out_items_cnt");
         mTotalDelayMs = mMetricsRecordRef.CreateCounter("total_delay_ms");
         mQueueSize = mMetricsRecordRef.CreateIntGauge("queue_size");

--- a/core/pipeline/queue/QueueInterface.h
+++ b/core/pipeline/queue/QueueInterface.h
@@ -34,7 +34,7 @@ public:
                                                             });
 
         mInItemsCnt = mMetricsRecordRef.CreateCounter("in_items_cnt");
-        mInItemsSizeByte = mMetricsRecordRef.CreateCounter("in_items_size_bytes");
+        mInItemDataSizeBytes = mMetricsRecordRef.CreateCounter("in_items_size_bytes");
         mOutItemsCnt = mMetricsRecordRef.CreateCounter("out_items_cnt");
         mTotalDelayMs = mMetricsRecordRef.CreateCounter("total_delay_ms");
         mQueueSize = mMetricsRecordRef.CreateIntGauge("queue_size");
@@ -60,7 +60,7 @@ protected:
 
     mutable MetricsRecordRef mMetricsRecordRef;
     CounterPtr mInItemsCnt;
-    CounterPtr mInItemsSizeByte;
+    CounterPtr mInItemDataSizeBytes;
     CounterPtr mOutItemsCnt;
     CounterPtr mTotalDelayMs;
     IntGaugePtr mQueueSize;

--- a/core/pipeline/queue/SenderQueue.cpp
+++ b/core/pipeline/queue/SenderQueue.cpp
@@ -20,10 +20,25 @@ using namespace std;
 
 namespace logtail {
 
+SenderQueue::SenderQueue(
+    size_t cap, size_t low, size_t high, QueueKey key, const string& flusherId, const PipelineContext& ctx)
+    : QueueInterface(key, cap, ctx), BoundedSenderQueueInterface(cap, low, high, key, flusherId, ctx) {
+    mQueue.resize(cap);
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
+}
+
 bool SenderQueue::Push(unique_ptr<SenderQueueItem>&& item) {
+    item->mEnqueTime = chrono::system_clock::now();
+    auto size = item->mData.size();
+
+    mInItemsCnt->Add(1);
+    mInItemsSizeByte->Add(size);
+
     if (Full()) {
-        item->mEnqueTime = time(nullptr);
         mExtraBuffer.push(std::move(item));
+
+        mExtraBufferCnt->Set(mExtraBuffer.size());
+        mExtraBufferDataSizeByte->Add(size);
         return true;
     }
 
@@ -33,17 +48,25 @@ bool SenderQueue::Push(unique_ptr<SenderQueueItem>&& item) {
             break;
         }
     }
-    item->mEnqueTime = time(nullptr);
     mQueue[index % mCapacity] = std::move(item);
     if (index == mWrite) {
         ++mWrite;
     }
     ++mSize;
     ChangeStateIfNeededAfterPush();
+
+    mQueueSize->Set(Size());
+    mQueueDataSizeByte->Add(size);
+    mValidToPushFlag->Set(IsValidToPush());
     return true;
 }
 
 bool SenderQueue::Remove(SenderQueueItem* item) {
+    if (item == nullptr) {
+        return false;
+    }
+    auto size = item->mData.size();
+    auto enQueuTime = item->mEnqueTime;
     auto index = mRead;
     for (; index < mWrite; ++index) {
         if (mQueue[index % mCapacity].get() == item) {
@@ -58,14 +81,26 @@ bool SenderQueue::Remove(SenderQueueItem* item) {
         ++mRead;
     }
     --mSize;
+
+    mOutItemsCnt->Add(1);
+    mTotalDelayMs->Add(chrono::duration_cast<chrono::milliseconds>(chrono::system_clock::now() - enQueuTime).count());
+    mQueueDataSizeByte->Sub(size);
+
     if (!mExtraBuffer.empty()) {
+        auto newSize = mExtraBuffer.front()->mData.size();
         Push(std::move(mExtraBuffer.front()));
         mExtraBuffer.pop();
+
+        mExtraBufferCnt->Set(mExtraBuffer.size());
+        mExtraBufferDataSizeByte->Sub(newSize);
         return true;
     }
     if (ChangeStateIfNeededAfterPop()) {
         GiveFeedback();
     }
+
+    mQueueSize->Set(Size());
+    mValidToPushFlag->Set(IsValidToPush());
     return true;
 }
 

--- a/core/pipeline/queue/SenderQueue.cpp
+++ b/core/pipeline/queue/SenderQueue.cpp
@@ -65,11 +65,13 @@ bool SenderQueue::Remove(SenderQueueItem* item) {
     if (item == nullptr) {
         return false;
     }
-    auto size = item->mData.size();
-    auto enQueuTime = item->mEnqueTime;
+    size_t size = 0;
+    chrono::system_clock::time_point enQueuTime;
     auto index = mRead;
     for (; index < mWrite; ++index) {
         if (mQueue[index % mCapacity].get() == item) {
+            size = item->mData.size();
+            enQueuTime = item->mEnqueTime;
             mQueue[index % mCapacity].reset();
             break;
         }

--- a/core/pipeline/queue/SenderQueue.cpp
+++ b/core/pipeline/queue/SenderQueue.cpp
@@ -32,13 +32,13 @@ bool SenderQueue::Push(unique_ptr<SenderQueueItem>&& item) {
     auto size = item->mData.size();
 
     mInItemsCnt->Add(1);
-    mInItemsSizeByte->Add(size);
+    mInItemDataSizeBytes->Add(size);
 
     if (Full()) {
         mExtraBuffer.push(std::move(item));
 
-        mExtraBufferCnt->Set(mExtraBuffer.size());
-        mExtraBufferDataSizeByte->Add(size);
+        mExtraBufferSize->Set(mExtraBuffer.size());
+        mExtraBufferDataSizeBytes->Add(size);
         return true;
     }
 
@@ -93,8 +93,8 @@ bool SenderQueue::Remove(SenderQueueItem* item) {
         Push(std::move(mExtraBuffer.front()));
         mExtraBuffer.pop();
 
-        mExtraBufferCnt->Set(mExtraBuffer.size());
-        mExtraBufferDataSizeByte->Sub(newSize);
+        mExtraBufferSize->Set(mExtraBuffer.size());
+        mExtraBufferDataSizeBytes->Sub(newSize);
         return true;
     }
     if (ChangeStateIfNeededAfterPop()) {

--- a/core/pipeline/queue/SenderQueue.h
+++ b/core/pipeline/queue/SenderQueue.h
@@ -19,8 +19,8 @@
 #include <memory>
 #include <vector>
 
-#include "pipeline/queue/QueueKey.h"
 #include "pipeline/queue/BoundedSenderQueueInterface.h"
+#include "pipeline/queue/QueueKey.h"
 #include "pipeline/queue/SenderQueueItem.h"
 
 namespace logtail {
@@ -30,10 +30,8 @@ class Flusher;
 // not thread-safe, should be protected explicitly by queue manager
 class SenderQueue : public BoundedSenderQueueInterface {
 public:
-    SenderQueue(size_t cap, size_t low, size_t high, QueueKey key)
-        : QueueInterface(key, cap), BoundedSenderQueueInterface(cap, low, high, key) {
-        mQueue.resize(cap);
-    }
+    SenderQueue(
+        size_t cap, size_t low, size_t high, QueueKey key, const std::string& flusherId, const PipelineContext& ctx);
 
     bool Push(std::unique_ptr<SenderQueueItem>&& item) override;
     bool Remove(SenderQueueItem* item) override;

--- a/core/pipeline/queue/SenderQueueItem.h
+++ b/core/pipeline/queue/SenderQueueItem.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
+#include <chrono>
 #include <cstdint>
-#include <ctime>
 #include <memory>
 #include <string>
 
@@ -41,7 +41,7 @@ struct SenderQueueItem {
     QueueKey mQueueKey;
 
     SendingStatus mStatus = SendingStatus::IDLE;
-    time_t mEnqueTime = 0;
+    std::chrono::system_clock::time_point mEnqueTime;
     time_t mLastSendTime = 0;
     uint32_t mTryCnt = 1;
 

--- a/core/pipeline/queue/SenderQueueManager.cpp
+++ b/core/pipeline/queue/SenderQueueManager.cpp
@@ -29,13 +29,20 @@ SenderQueueManager::SenderQueueManager() : mQueueParam(INT32_FLAG(sender_queue_c
 }
 
 bool SenderQueueManager::CreateQueue(QueueKey key,
+                                     const string& flusherId,
+                                     const PipelineContext& ctx,
                                      vector<shared_ptr<ConcurrencyLimiter>>&& concurrencyLimiters,
                                      uint32_t maxRate) {
     lock_guard<mutex> lock(mQueueMux);
     auto iter = mQueues.find(key);
     if (iter == mQueues.end()) {
-        mQueues.try_emplace(
-            key, mQueueParam.GetCapacity(), mQueueParam.GetLowWatermark(), mQueueParam.GetHighWatermark(), key);
+        mQueues.try_emplace(key,
+                            mQueueParam.GetCapacity(),
+                            mQueueParam.GetLowWatermark(),
+                            mQueueParam.GetHighWatermark(),
+                            key,
+                            flusherId,
+                            ctx);
         iter = mQueues.find(key);
     }
     iter->second.SetConcurrencyLimiters(std::move(concurrencyLimiters));

--- a/core/pipeline/queue/SenderQueueManager.h
+++ b/core/pipeline/queue/SenderQueueManager.h
@@ -24,11 +24,11 @@
 #include <vector>
 
 #include "common/FeedbackInterface.h"
+#include "pipeline/limiter/ConcurrencyLimiter.h"
+#include "pipeline/limiter/RateLimiter.h"
 #include "pipeline/queue/QueueParam.h"
 #include "pipeline/queue/SenderQueue.h"
 #include "pipeline/queue/SenderQueueItem.h"
-#include "pipeline/limiter/ConcurrencyLimiter.h"
-#include "pipeline/limiter/RateLimiter.h"
 
 namespace logtail {
 
@@ -47,6 +47,8 @@ public:
     void Feedback(QueueKey key) override { Trigger(); }
 
     bool CreateQueue(QueueKey key,
+                     const std::string& flusherId,
+                     const PipelineContext& ctx,
                      std::vector<std::shared_ptr<ConcurrencyLimiter>>&& concurrencyLimiters
                      = std::vector<std::shared_ptr<ConcurrencyLimiter>>(),
                      uint32_t maxRate = 0);

--- a/core/plugin/flusher/blackhole/FlusherBlackHole.cpp
+++ b/core/plugin/flusher/blackhole/FlusherBlackHole.cpp
@@ -25,7 +25,7 @@ const string FlusherBlackHole::sName = "flusher_blackhole";
 bool FlusherBlackHole::Init(const Json::Value& config, Json::Value& optionalGoPipeline) {
     static uint32_t cnt = 0;
     GenerateQueueKey(to_string(++cnt));
-    SenderQueueManager::GetInstance()->CreateQueue(mQueueKey);
+    SenderQueueManager::GetInstance()->CreateQueue(mQueueKey, mNodeID, *mContext);
     return true;
 }
 

--- a/core/plugin/flusher/sls/FlusherSLS.cpp
+++ b/core/plugin/flusher/sls/FlusherSLS.cpp
@@ -18,28 +18,28 @@
 #include "config/provider/EnterpriseConfigProvider.h"
 #endif
 #include "app_config/AppConfig.h"
-#include "pipeline/batch/FlushStrategy.h"
 #include "common/EndpointUtil.h"
 #include "common/HashUtil.h"
 #include "common/LogtailCommonFlags.h"
 #include "common/ParamExtractor.h"
 #include "common/TimeUtil.h"
+#include "pipeline/Pipeline.h"
+#include "pipeline/batch/FlushStrategy.h"
 #include "pipeline/compression/CompressorFactory.h"
+#include "pipeline/queue/QueueKeyManager.h"
+#include "pipeline/queue/SLSSenderQueueItem.h"
+#include "pipeline/queue/SenderQueueManager.h"
 #include "plugin/flusher/sls/PackIdManager.h"
 #include "plugin/flusher/sls/SLSClientManager.h"
 #include "plugin/flusher/sls/SLSResponse.h"
 #include "plugin/flusher/sls/SendResult.h"
-#include "pipeline/Pipeline.h"
 #include "profile_sender/ProfileSender.h"
-#include "pipeline/queue/QueueKeyManager.h"
-#include "pipeline/queue/SLSSenderQueueItem.h"
-#include "pipeline/queue/SenderQueueManager.h"
-#include "sdk/Common.h"
 #include "runner/FlusherRunner.h"
+#include "sdk/Common.h"
 #include "sls_control/SLSControl.h"
 // TODO: temporarily used here
-#include "plugin/flusher/sls/DiskBufferWriter.h"
 #include "pipeline/PipelineManager.h"
+#include "plugin/flusher/sls/DiskBufferWriter.h"
 
 using namespace std;
 
@@ -470,6 +470,8 @@ bool FlusherSLS::Init(const Json::Value& config, Json::Value& optionalGoPipeline
         GenerateQueueKey(mProject + "#" + mLogstore);
         SenderQueueManager::GetInstance()->CreateQueue(
             mQueueKey,
+            mNodeID,
+            *mContext,
             vector<shared_ptr<ConcurrencyLimiter>>{GetRegionConcurrencyLimiter(mRegion),
                                                    GetProjectConcurrencyLimiter(mProject)},
             mMaxSendRate);
@@ -610,6 +612,7 @@ void FlusherSLS::OnSendDone(const HttpResponse& response, SenderQueueItem* item)
     string configName = HasContext() ? GetContext().GetConfigName() : "";
     bool isProfileData = ProfileSender::GetInstance()->IsProfileData(mRegion, mProject, data->mLogstore);
     int32_t curTime = time(NULL);
+    auto curSystemTime = chrono::system_clock::now();
     if (slsResponse.mStatusCode == 200) {
         auto& cpt = data->mExactlyOnceCheckpoint;
         if (cpt) {
@@ -620,10 +623,13 @@ void FlusherSLS::OnSendDone(const HttpResponse& response, SenderQueueItem* item)
         GetRegionConcurrencyLimiter(mRegion)->OnSuccess();
         DealSenderQueueItemAfterSend(item, false);
         LOG_DEBUG(sLogger,
-                  ("send data to sls succeeded, item address", item)("request id", slsResponse.mRequestId)(
-                      "config", configName)("region", mRegion)("project", mProject)("logstore", data->mLogstore)(
-                      "response time", curTime - data->mLastSendTime)("total send time", curTime - data->mEnqueTime)(
-                      "try cnt", data->mTryCnt)("endpoint", data->mCurrentEndpoint)("is profile data", isProfileData));
+                  ("send data to sls succeeded, item address",
+                   item)("request id", slsResponse.mRequestId)("config", configName)("region", mRegion)(
+                      "project", mProject)("logstore", data->mLogstore)("response time", curTime - data->mLastSendTime)(
+                      "total send time",
+                      ToString(chrono::duration_cast<chrono::milliseconds>(curSystemTime - item->mEnqueTime).count())
+                          + "ms")("try cnt", data->mTryCnt)("endpoint", data->mCurrentEndpoint)("is profile data",
+                                                                                                isProfileData));
     } else {
         OperationOnFail operation;
         SendResult sendResult = ConvertErrorCode(slsResponse.mErrorCode);
@@ -748,7 +754,8 @@ void FlusherSLS::OnSendDone(const HttpResponse& response, SenderQueueItem* item)
             // when retry times > unknow_error_try_max, we will drop this data
             operation = DefaultOperation(item->mTryCnt);
         }
-        if (curTime - data->mEnqueTime > INT32_FLAG(discard_send_fail_interval)) {
+        if (chrono::duration_cast<chrono::seconds>(curSystemTime - item->mEnqueTime).count()
+            > INT32_FLAG(discard_send_fail_interval)) {
             operation = OperationOnFail::DISCARD;
         }
         if (isProfileData && data->mTryCnt >= static_cast<uint32_t>(INT32_FLAG(profile_data_send_retrytimes))) {
@@ -761,8 +768,9 @@ void FlusherSLS::OnSendDone(const HttpResponse& response, SenderQueueItem* item)
         "status code", slsResponse.mStatusCode)("error code", slsResponse.mErrorCode)( \
         "errMsg", slsResponse.mErrorMsg)("config", configName)("region", mRegion)("project", mProject)( \
         "logstore", data->mLogstore)("try cnt", data->mTryCnt)("response time", curTime - data->mLastSendTime)( \
-        "total send time", curTime - data->mEnqueTime)("endpoint", data->mCurrentEndpoint)("is profile data", \
-                                                                                           isProfileData)
+        "total send time", \
+        ToString(chrono::duration_cast<chrono::seconds>(curSystemTime - data->mEnqueTime).count()) \
+            + "ms")("endpoint", data->mCurrentEndpoint)("is profile data", isProfileData)
 
         switch (operation) {
             case OperationOnFail::RETRY_IMMEDIATELY:
@@ -822,7 +830,8 @@ bool FlusherSLS::Send(string&& data, const string& shardHashKey, const string& l
     if (!HasContext()) {
         key = QueueKeyManager::GetInstance()->GetKey(mProject + "-" + mLogstore);
         if (SenderQueueManager::GetInstance()->GetQueue(key) == nullptr) {
-            SenderQueueManager::GetInstance()->CreateQueue(key, vector<shared_ptr<ConcurrencyLimiter>>());
+            PipelineContext ctx;
+            SenderQueueManager::GetInstance()->CreateQueue(key, "", ctx, vector<shared_ptr<ConcurrencyLimiter>>());
         }
     }
     return Flusher::PushToQueue(make_unique<SLSSenderQueueItem>(std::move(compressedData),

--- a/core/unittest/event_handler/ModifyHandlerUnittest.cpp
+++ b/core/unittest/event_handler/ModifyHandlerUnittest.cpp
@@ -23,12 +23,12 @@
 #include "common/Flags.h"
 #include "common/JsonUtil.h"
 #include "config/PipelineConfig.h"
+#include "file_server/FileServer.h"
 #include "file_server/event/Event.h"
 #include "file_server/event_handler/EventHandler.h"
-#include "file_server/FileServer.h"
+#include "file_server/reader/LogFileReader.h"
 #include "pipeline/Pipeline.h"
 #include "pipeline/queue/ProcessQueueManager.h"
-#include "file_server/reader/LogFileReader.h"
 #include "unittest/Unittest.h"
 
 using namespace std;
@@ -115,7 +115,7 @@ protected:
         FileServer::GetInstance()->AddFileDiscoveryConfig(mConfigName, &discoveryOpts, &ctx);
         FileServer::GetInstance()->AddFileReaderConfig(mConfigName, &readerOpts, &ctx);
         FileServer::GetInstance()->AddMultilineConfig(mConfigName, &multilineOpts, &ctx);
-        ProcessQueueManager::GetInstance()->CreateOrUpdateBoundedQueue(0, 0);
+        ProcessQueueManager::GetInstance()->CreateOrUpdateBoundedQueue(0, 0, ctx);
 
         // build a reader
         mReaderPtr = std::make_shared<LogFileReader>(

--- a/core/unittest/flusher/FlusherSLSUnittest.cpp
+++ b/core/unittest/flusher/FlusherSLSUnittest.cpp
@@ -581,7 +581,7 @@ void FlusherSLSUnittest::TestSend() {
         }
         QueueKey eooKey = QueueKeyManager::GetInstance()->GetKey("eoo");
         ExactlyOnceQueueManager::GetInstance()->CreateOrUpdateQueue(
-            eooKey, ProcessQueueManager::sMaxPriority, flusher.GetContext().GetConfigName(), checkpoints);
+            eooKey, ProcessQueueManager::sMaxPriority, flusher.GetContext(), checkpoints);
 
         {
             // replayed group

--- a/core/unittest/plugin/PluginMock.h
+++ b/core/unittest/plugin/PluginMock.h
@@ -94,7 +94,7 @@ public:
     const std::string& Name() const override { return sName; }
     bool Init(const Json::Value& config, Json::Value& optionalGoPipeline) override {
         GenerateQueueKey("mock");
-        SenderQueueManager::GetInstance()->CreateQueue(mQueueKey);
+        SenderQueueManager::GetInstance()->CreateQueue(mQueueKey, mNodeID, *mContext);
         return true;
     }
     bool Send(PipelineEventGroup&& g) override { return mIsValid; }
@@ -117,7 +117,7 @@ public:
     const std::string& Name() const override { return sName; }
     bool Init(const Json::Value& config, Json::Value& optionalGoPipeline) override {
         GenerateQueueKey("mock");
-        SenderQueueManager::GetInstance()->CreateQueue(mQueueKey);
+        SenderQueueManager::GetInstance()->CreateQueue(mQueueKey, mNodeID, *mContext);
         return true;
     }
     bool Send(PipelineEventGroup&& g) override { return mIsValid; }

--- a/core/unittest/queue/BoundedProcessQueueUnittest.cpp
+++ b/core/unittest/queue/BoundedProcessQueueUnittest.cpp
@@ -117,11 +117,11 @@ void BoundedProcessQueueUnittest::TestPop() {
 }
 
 void BoundedProcessQueueUnittest::TestMetric() {
-    // APSARA_TEST_EQUAL(4U, mQueue->mMetricsRecordRef->GetLabels()->size());
-    // APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_PROJECT, ""));
-    // APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_CONFIG_NAME, "test_config"));
-    // APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_COMPONENT_NAME, "process_queue"));
-    // APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_QUEUE_TYPE, "bounded"));
+    APSARA_TEST_EQUAL(4U, mQueue->mMetricsRecordRef->GetLabels()->size());
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_PROJECT, ""));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_CONFIG_NAME, "test_config"));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_COMPONENT_NAME, "process_queue"));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_QUEUE_TYPE, "bounded"));
 
     auto item = GenerateItem();
     auto e = item->mEventGroup.AddLogEvent();
@@ -135,11 +135,11 @@ void BoundedProcessQueueUnittest::TestMetric() {
     APSARA_TEST_EQUAL(dataSize, mQueue->mQueueDataSizeByte->GetValue());
     APSARA_TEST_EQUAL(1U, mQueue->mValidToPushFlag->GetValue());
 
-    mQueue->Pop(item);
-    APSARA_TEST_EQUAL(1U, mQueue->mOutItemsCnt->GetValue());
-    APSARA_TEST_EQUAL(0U, mQueue->mQueueSize->GetValue());
-    APSARA_TEST_EQUAL(0U, mQueue->mQueueDataSizeByte->GetValue());
-    APSARA_TEST_EQUAL(1U, mQueue->mValidToPushFlag->GetValue());
+    // mQueue->Pop(item);
+    // APSARA_TEST_EQUAL(1U, mQueue->mOutItemsCnt->GetValue());
+    // APSARA_TEST_EQUAL(0U, mQueue->mQueueSize->GetValue());
+    // APSARA_TEST_EQUAL(0U, mQueue->mQueueDataSizeByte->GetValue());
+    // APSARA_TEST_EQUAL(1U, mQueue->mValidToPushFlag->GetValue());
 }
 
 UNIT_TEST_CASE(BoundedProcessQueueUnittest, TestPush)

--- a/core/unittest/queue/BoundedProcessQueueUnittest.cpp
+++ b/core/unittest/queue/BoundedProcessQueueUnittest.cpp
@@ -117,11 +117,11 @@ void BoundedProcessQueueUnittest::TestPop() {
 }
 
 void BoundedProcessQueueUnittest::TestMetric() {
-    APSARA_TEST_EQUAL(4U, mQueue->mMetricsRecordRef->GetLabels()->size());
-    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_PROJECT, ""));
-    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_CONFIG_NAME, "test_config"));
-    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_COMPONENT_NAME, "process_queue"));
-    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_QUEUE_TYPE, "bounded"));
+    // APSARA_TEST_EQUAL(4U, mQueue->mMetricsRecordRef->GetLabels()->size());
+    // APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_PROJECT, ""));
+    // APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_CONFIG_NAME, "test_config"));
+    // APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_COMPONENT_NAME, "process_queue"));
+    // APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_QUEUE_TYPE, "bounded"));
 
     auto item = GenerateItem();
     auto e = item->mEventGroup.AddLogEvent();

--- a/core/unittest/queue/BoundedProcessQueueUnittest.cpp
+++ b/core/unittest/queue/BoundedProcessQueueUnittest.cpp
@@ -133,11 +133,11 @@ void BoundedProcessQueueUnittest::TestMetric() {
     APSARA_TEST_EQUAL(dataSize, mQueue->mQueueDataSizeByte->GetValue());
     APSARA_TEST_EQUAL(1U, mQueue->mValidToPushFlag->GetValue());
 
-    // mQueue->Pop(item);
-    // APSARA_TEST_EQUAL(1U, mQueue->mOutItemsCnt->GetValue());
-    // APSARA_TEST_EQUAL(0U, mQueue->mQueueSize->GetValue());
-    // APSARA_TEST_EQUAL(0U, mQueue->mQueueDataSizeByte->GetValue());
-    // APSARA_TEST_EQUAL(1U, mQueue->mValidToPushFlag->GetValue());
+    mQueue->Pop(item);
+    APSARA_TEST_EQUAL(1U, mQueue->mOutItemsCnt->GetValue());
+    APSARA_TEST_EQUAL(0U, mQueue->mQueueSize->GetValue());
+    APSARA_TEST_EQUAL(0U, mQueue->mQueueDataSizeByte->GetValue());
+    APSARA_TEST_EQUAL(1U, mQueue->mValidToPushFlag->GetValue());
 }
 
 UNIT_TEST_CASE(BoundedProcessQueueUnittest, TestPush)

--- a/core/unittest/queue/BoundedProcessQueueUnittest.cpp
+++ b/core/unittest/queue/BoundedProcessQueueUnittest.cpp
@@ -128,7 +128,7 @@ void BoundedProcessQueueUnittest::TestMetric() {
     mQueue->Push(std::move(item));
 
     APSARA_TEST_EQUAL(1U, mQueue->mInItemsCnt->GetValue());
-    APSARA_TEST_EQUAL(dataSize, mQueue->mInItemsSizeByte->GetValue());
+    APSARA_TEST_EQUAL(dataSize, mQueue->mInItemDataSizeBytes->GetValue());
     APSARA_TEST_EQUAL(1U, mQueue->mQueueSize->GetValue());
     APSARA_TEST_EQUAL(dataSize, mQueue->mQueueDataSizeByte->GetValue());
     APSARA_TEST_EQUAL(1U, mQueue->mValidToPushFlag->GetValue());

--- a/core/unittest/queue/BoundedProcessQueueUnittest.cpp
+++ b/core/unittest/queue/BoundedProcessQueueUnittest.cpp
@@ -32,10 +32,7 @@ public:
     void TestMetric();
 
 protected:
-    static void SetUpTestCase() {
-        sEventGroup.reset(new PipelineEventGroup(make_shared<SourceBuffer>()));
-        sCtx.SetConfigName("test_config");
-    }
+    static void SetUpTestCase() { sCtx.SetConfigName("test_config"); }
 
     void SetUp() override {
         mQueue.reset(new BoundedProcessQueue(sCap, sLowWatermark, sHighWatermark, sKey, 1, sCtx));
@@ -50,14 +47,16 @@ protected:
     }
 
 private:
-    static unique_ptr<PipelineEventGroup> sEventGroup;
     static PipelineContext sCtx;
     static const QueueKey sKey = 0;
     static const size_t sCap = 6;
     static const size_t sLowWatermark = 2;
     static const size_t sHighWatermark = 4;
 
-    unique_ptr<ProcessQueueItem> GenerateItem() { return make_unique<ProcessQueueItem>(std::move(*sEventGroup), 0); }
+    unique_ptr<ProcessQueueItem> GenerateItem() {
+        PipelineEventGroup g(make_shared<SourceBuffer>());
+        return make_unique<ProcessQueueItem>(std::move(g), 0);
+    }
 
     unique_ptr<BoundedProcessQueue> mQueue;
     unique_ptr<FeedbackInterface> mFeedback1;
@@ -66,7 +65,6 @@ private:
     unique_ptr<BoundedSenderQueueInterface> mSenderQueue2;
 };
 
-unique_ptr<PipelineEventGroup> BoundedProcessQueueUnittest::sEventGroup;
 PipelineContext BoundedProcessQueueUnittest::sCtx;
 
 void BoundedProcessQueueUnittest::TestPush() {

--- a/core/unittest/queue/BoundedProcessQueueUnittest.cpp
+++ b/core/unittest/queue/BoundedProcessQueueUnittest.cpp
@@ -118,8 +118,8 @@ void BoundedProcessQueueUnittest::TestMetric() {
     APSARA_TEST_EQUAL(4U, mQueue->mMetricsRecordRef->GetLabels()->size());
     APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_PROJECT, ""));
     APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_CONFIG_NAME, "test_config"));
-    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_COMPONENT_NAME, "process_queue"));
-    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_QUEUE_TYPE, "bounded"));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_KEY_COMPONENT_NAME, "process_queue"));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_KEY_QUEUE_TYPE, "bounded"));
 
     auto item = GenerateItem();
     auto e = item->mEventGroup.AddLogEvent();

--- a/core/unittest/queue/CircularProcessQueueUnittest.cpp
+++ b/core/unittest/queue/CircularProcessQueueUnittest.cpp
@@ -158,7 +158,7 @@ void CircularProcessQueueUnittest::TestMetric() {
     auto dataSize1 = item->mEventGroup.DataSize();
     mQueue->Push(std::move(item));
     APSARA_TEST_EQUAL(1U, mQueue->mInItemsCnt->GetValue());
-    APSARA_TEST_EQUAL(dataSize1, mQueue->mInItemsSizeByte->GetValue());
+    APSARA_TEST_EQUAL(dataSize1, mQueue->mInItemDataSizeBytes->GetValue());
     APSARA_TEST_EQUAL(2U, mQueue->mQueueSize->GetValue());
     APSARA_TEST_EQUAL(dataSize1, mQueue->mQueueDataSizeByte->GetValue());
 
@@ -166,7 +166,7 @@ void CircularProcessQueueUnittest::TestMetric() {
     auto dataSize2 = item->mEventGroup.DataSize();
     mQueue->Push(std::move(item));
     APSARA_TEST_EQUAL(2U, mQueue->mInItemsCnt->GetValue());
-    APSARA_TEST_EQUAL(dataSize1 + dataSize2, mQueue->mInItemsSizeByte->GetValue());
+    APSARA_TEST_EQUAL(dataSize1 + dataSize2, mQueue->mInItemDataSizeBytes->GetValue());
     APSARA_TEST_EQUAL(1U, mQueue->mQueueSize->GetValue());
     APSARA_TEST_EQUAL(dataSize2, mQueue->mQueueDataSizeByte->GetValue());
     APSARA_TEST_EQUAL(2U, mQueue->mDroppedEventsCnt->GetValue());

--- a/core/unittest/queue/CircularProcessQueueUnittest.cpp
+++ b/core/unittest/queue/CircularProcessQueueUnittest.cpp
@@ -27,17 +27,21 @@ public:
     void TestPush();
     void TestPop();
     void TestReset();
+    void TestMetric();
 
 protected:
-    void SetUp() override {
-        mQueue.reset(new CircularProcessQueue(sCap, sKey, 1, "test_config"));
+    static void SetUpTestCase() { sCtx.SetConfigName("test_config"); }
 
-        mSenderQueue1.reset(new SenderQueue(10, 0, 10, 0));
-        mSenderQueue2.reset(new SenderQueue(10, 0, 10, 0));
+    void SetUp() override {
+        mQueue.reset(new CircularProcessQueue(sCap, sKey, 1, sCtx));
+
+        mSenderQueue1.reset(new SenderQueue(10, 0, 10, 0, "", sCtx));
+        mSenderQueue2.reset(new SenderQueue(10, 0, 10, 0, "", sCtx));
         mQueue->SetDownStreamQueues(vector<BoundedSenderQueueInterface*>{mSenderQueue1.get(), mSenderQueue2.get()});
     }
 
 private:
+    static PipelineContext sCtx;
     static const QueueKey sKey = 0;
     static const size_t sCap = 2;
 
@@ -53,6 +57,8 @@ private:
     unique_ptr<BoundedSenderQueueInterface> mSenderQueue1;
     unique_ptr<BoundedSenderQueueInterface> mSenderQueue2;
 };
+
+PipelineContext CircularProcessQueueUnittest::sCtx;
 
 void CircularProcessQueueUnittest::TestPush() {
     unique_ptr<ProcessQueueItem> res;
@@ -141,9 +147,40 @@ void CircularProcessQueueUnittest::TestReset() {
     }
 }
 
+void CircularProcessQueueUnittest::TestMetric() {
+    APSARA_TEST_EQUAL(4U, mQueue->mMetricsRecordRef->GetLabels()->size());
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_PROJECT, ""));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_CONFIG_NAME, "test_config"));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_COMPONENT_NAME, "process_queue"));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_QUEUE_TYPE, "circular"));
+
+    auto item = GenerateItem(2);
+    auto dataSize1 = item->mEventGroup.DataSize();
+    mQueue->Push(std::move(item));
+    APSARA_TEST_EQUAL(1U, mQueue->mInItemsCnt->GetValue());
+    APSARA_TEST_EQUAL(dataSize1, mQueue->mInItemsSizeByte->GetValue());
+    APSARA_TEST_EQUAL(2U, mQueue->mQueueSize->GetValue());
+    APSARA_TEST_EQUAL(dataSize1, mQueue->mQueueDataSizeByte->GetValue());
+
+    item = GenerateItem(1);
+    auto dataSize2 = item->mEventGroup.DataSize();
+    mQueue->Push(std::move(item));
+    APSARA_TEST_EQUAL(2U, mQueue->mInItemsCnt->GetValue());
+    APSARA_TEST_EQUAL(dataSize1 + dataSize2, mQueue->mInItemsSizeByte->GetValue());
+    APSARA_TEST_EQUAL(1U, mQueue->mQueueSize->GetValue());
+    APSARA_TEST_EQUAL(dataSize2, mQueue->mQueueDataSizeByte->GetValue());
+    APSARA_TEST_EQUAL(2U, mQueue->mDroppedEventsCnt->GetValue());
+
+    mQueue->Pop(item);
+    APSARA_TEST_EQUAL(1U, mQueue->mOutItemsCnt->GetValue());
+    APSARA_TEST_EQUAL(0U, mQueue->mQueueSize->GetValue());
+    APSARA_TEST_EQUAL(0U, mQueue->mQueueDataSizeByte->GetValue());
+}
+
 UNIT_TEST_CASE(CircularProcessQueueUnittest, TestPush)
 UNIT_TEST_CASE(CircularProcessQueueUnittest, TestPop)
 UNIT_TEST_CASE(CircularProcessQueueUnittest, TestReset)
+UNIT_TEST_CASE(CircularProcessQueueUnittest, TestMetric)
 
 } // namespace logtail
 

--- a/core/unittest/queue/CircularProcessQueueUnittest.cpp
+++ b/core/unittest/queue/CircularProcessQueueUnittest.cpp
@@ -151,8 +151,8 @@ void CircularProcessQueueUnittest::TestMetric() {
     APSARA_TEST_EQUAL(4U, mQueue->mMetricsRecordRef->GetLabels()->size());
     APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_PROJECT, ""));
     APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_CONFIG_NAME, "test_config"));
-    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_COMPONENT_NAME, "process_queue"));
-    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_QUEUE_TYPE, "circular"));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_KEY_COMPONENT_NAME, "process_queue"));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_KEY_QUEUE_TYPE, "circular"));
 
     auto item = GenerateItem(2);
     auto dataSize1 = item->mEventGroup.DataSize();

--- a/core/unittest/queue/ExactlyOnceQueueManagerUnittest.cpp
+++ b/core/unittest/queue/ExactlyOnceQueueManagerUnittest.cpp
@@ -14,12 +14,12 @@
 
 #include <memory>
 
-#include "plugin/flusher/sls/FlusherSLS.h"
-#include "plugin/input/InputFeedbackInterfaceRegistry.h"
 #include "models/PipelineEventGroup.h"
 #include "pipeline/queue/ExactlyOnceQueueManager.h"
 #include "pipeline/queue/QueueKeyManager.h"
 #include "pipeline/queue/SLSSenderQueueItem.h"
+#include "plugin/flusher/sls/FlusherSLS.h"
+#include "plugin/input/InputFeedbackInterfaceRegistry.h"
 #include "unittest/Unittest.h"
 
 DECLARE_FLAG_INT32(logtail_queue_gc_threshold_sec);
@@ -71,6 +71,7 @@ private:
     static unique_ptr<PipelineEventGroup> sEventGroup;
     static ExactlyOnceQueueManager* sManager;
     static vector<RangeCheckpointPtr> sCheckpoints;
+    static PipelineContext sCtx;
 
     unique_ptr<ProcessQueueItem> GenerateProcessItem();
     unique_ptr<SenderQueueItem> GenerateSenderItem();
@@ -83,13 +84,14 @@ const size_t ExactlyOnceQueueManagerUnittest::sDataSize;
 unique_ptr<PipelineEventGroup> ExactlyOnceQueueManagerUnittest::sEventGroup;
 ExactlyOnceQueueManager* ExactlyOnceQueueManagerUnittest::sManager;
 vector<RangeCheckpointPtr> ExactlyOnceQueueManagerUnittest::sCheckpoints;
+PipelineContext ExactlyOnceQueueManagerUnittest::sCtx;
 
 void ExactlyOnceQueueManagerUnittest::TestUpdateQueue() {
     QueueKey key = 0;
     {
         // create queue
         size_t queueSize = 5;
-        APSARA_TEST_TRUE(sManager->CreateOrUpdateQueue(key, 0, "test_config", vector<RangeCheckpointPtr>(queueSize)));
+        APSARA_TEST_TRUE(sManager->CreateOrUpdateQueue(key, 0, sCtx, vector<RangeCheckpointPtr>(queueSize)));
         APSARA_TEST_EQUAL(1U, sManager->mSenderQueues.size());
         auto& senderQue = sManager->mSenderQueues.at(key);
         APSARA_TEST_EQUAL(queueSize, senderQue.mCapacity);
@@ -106,7 +108,7 @@ void ExactlyOnceQueueManagerUnittest::TestUpdateQueue() {
     {
         // update queue with the same priority
         size_t queueSize = 8;
-        APSARA_TEST_TRUE(sManager->CreateOrUpdateQueue(key, 0, "test_config", vector<RangeCheckpointPtr>(queueSize)));
+        APSARA_TEST_TRUE(sManager->CreateOrUpdateQueue(key, 0, sCtx, vector<RangeCheckpointPtr>(queueSize)));
         APSARA_TEST_EQUAL(1U, sManager->mSenderQueues.size());
         auto& senderQue = sManager->mSenderQueues.at(key);
         APSARA_TEST_EQUAL(queueSize, senderQue.mCapacity);
@@ -122,7 +124,7 @@ void ExactlyOnceQueueManagerUnittest::TestUpdateQueue() {
     {
         // update queue with different priority
         size_t queueSize = 6;
-        APSARA_TEST_TRUE(sManager->CreateOrUpdateQueue(key, 1, "test_config", vector<RangeCheckpointPtr>(queueSize)));
+        APSARA_TEST_TRUE(sManager->CreateOrUpdateQueue(key, 1, sCtx, vector<RangeCheckpointPtr>(queueSize)));
         APSARA_TEST_EQUAL(1U, sManager->mProcessQueues.size());
         APSARA_TEST_EQUAL(0U, sManager->mProcessPriorityQueue[0].size());
         APSARA_TEST_EQUAL(1U, sManager->mProcessPriorityQueue[1].size());
@@ -141,8 +143,8 @@ void ExactlyOnceQueueManagerUnittest::TestDeleteQueue() {
 
     QueueKey key1 = QueueKeyManager::GetInstance()->GetKey("name_1");
     QueueKey key2 = QueueKeyManager::GetInstance()->GetKey("name_2");
-    sManager->CreateOrUpdateQueue(key1, 1, "test_config_1", sCheckpoints);
-    sManager->CreateOrUpdateQueue(key2, 1, "test_config_2", sCheckpoints);
+    sManager->CreateOrUpdateQueue(key1, 1, sCtx, sCheckpoints);
+    sManager->CreateOrUpdateQueue(key2, 1, sCtx, sCheckpoints);
     sManager->PushProcessQueue(key2, GenerateProcessItem());
 
     // queue exists and not marked deleted
@@ -162,12 +164,12 @@ void ExactlyOnceQueueManagerUnittest::TestDeleteQueue() {
     APSARA_TEST_EQUAL("", QueueKeyManager::GetInstance()->GetName(key1));
 
     // update queue will remove the queue from gc queue
-    sManager->CreateOrUpdateQueue(key2, 0, "test_config_2", sCheckpoints);
+    sManager->CreateOrUpdateQueue(key2, 0, sCtx, sCheckpoints);
     APSARA_TEST_EQUAL(0U, sManager->mQueueDeletionTimeMap.size());
 }
 
 void ExactlyOnceQueueManagerUnittest::TestPushProcessQueue() {
-    sManager->CreateOrUpdateQueue(0, 0, "test_config", sCheckpoints);
+    sManager->CreateOrUpdateQueue(0, 0, sCtx, sCheckpoints);
 
     // queue exists
     APSARA_TEST_TRUE(sManager->IsValidToPushProcessQueue(0));
@@ -184,8 +186,8 @@ void ExactlyOnceQueueManagerUnittest::TestPushProcessQueue() {
 }
 
 void ExactlyOnceQueueManagerUnittest::TestIsAllProcessQueueEmpty() {
-    sManager->CreateOrUpdateQueue(0, 0, "test_config_1", sCheckpoints);
-    sManager->CreateOrUpdateQueue(1, 2, "test_config_2", sCheckpoints);
+    sManager->CreateOrUpdateQueue(0, 0, sCtx, sCheckpoints);
+    sManager->CreateOrUpdateQueue(1, 2, sCtx, sCheckpoints);
     APSARA_TEST_TRUE(sManager->IsAllProcessQueueEmpty());
 
     sManager->PushProcessQueue(0, GenerateProcessItem());
@@ -193,7 +195,7 @@ void ExactlyOnceQueueManagerUnittest::TestIsAllProcessQueueEmpty() {
 }
 
 void ExactlyOnceQueueManagerUnittest::TestPushSenderQueue() {
-    sManager->CreateOrUpdateQueue(0, 0, "test_config", sCheckpoints);
+    sManager->CreateOrUpdateQueue(0, 0, sCtx, sCheckpoints);
 
     // queue exists
     APSARA_TEST_EQUAL(0, sManager->PushSenderQueue(0, GenerateSenderItem()));
@@ -211,7 +213,7 @@ void ExactlyOnceQueueManagerUnittest::TestGetAllAvailableSenderQueueItems() {
         cpt->data.set_sequence_id(0);
         checkpoints1.emplace_back(cpt);
     }
-    sManager->CreateOrUpdateQueue(0, 0, "test_config_1", checkpoints1);
+    sManager->CreateOrUpdateQueue(0, 0, sCtx, checkpoints1);
 
     vector<RangeCheckpointPtr> checkpoints2;
     for (size_t i = 0; i < 2; ++i) {
@@ -221,7 +223,7 @@ void ExactlyOnceQueueManagerUnittest::TestGetAllAvailableSenderQueueItems() {
         cpt->data.set_sequence_id(0);
         checkpoints2.emplace_back(cpt);
     }
-    sManager->CreateOrUpdateQueue(1, 2, "test_config_2", checkpoints2);
+    sManager->CreateOrUpdateQueue(1, 2, sCtx, checkpoints2);
 
     for (size_t i = 0; i <= 2; ++i) {
         sManager->PushSenderQueue(0, GenerateSenderItem());
@@ -250,7 +252,7 @@ void ExactlyOnceQueueManagerUnittest::TestGetAllAvailableSenderQueueItems() {
 }
 
 void ExactlyOnceQueueManagerUnittest::TestRemoveSenderItem() {
-    sManager->CreateOrUpdateQueue(1, 0, "test_config", sCheckpoints);
+    sManager->CreateOrUpdateQueue(1, 0, sCtx, sCheckpoints);
     {
         // queue exists
         auto item = GenerateSenderItem();
@@ -268,8 +270,8 @@ void ExactlyOnceQueueManagerUnittest::TestRemoveSenderItem() {
 }
 
 void ExactlyOnceQueueManagerUnittest::TestIsAllSenderQueueEmpty() {
-    sManager->CreateOrUpdateQueue(0, 0, "test_config_1", sCheckpoints);
-    sManager->CreateOrUpdateQueue(1, 2, "test_config_2", sCheckpoints);
+    sManager->CreateOrUpdateQueue(0, 0, sCtx, sCheckpoints);
+    sManager->CreateOrUpdateQueue(1, 2, sCtx, sCheckpoints);
     APSARA_TEST_TRUE(sManager->IsAllSenderQueueEmpty());
 
     sManager->PushSenderQueue(0, GenerateSenderItem());
@@ -277,8 +279,10 @@ void ExactlyOnceQueueManagerUnittest::TestIsAllSenderQueueEmpty() {
 }
 
 void ExactlyOnceQueueManagerUnittest::OnPipelineUpdate() {
-    sManager->CreateOrUpdateQueue(0, 0, "test_config", sCheckpoints);
-    sManager->CreateOrUpdateQueue(1, 0, "test_config", sCheckpoints);
+    PipelineContext ctx;
+    ctx.SetConfigName("test_config");
+    sManager->CreateOrUpdateQueue(0, 0, ctx, sCheckpoints);
+    sManager->CreateOrUpdateQueue(1, 0, ctx, sCheckpoints);
 
     sManager->InvalidatePopProcessQueue("test_config");
     APSARA_TEST_FALSE(sManager->mProcessQueues[0]->mValidToPop);

--- a/core/unittest/queue/ExactlyOnceQueueManagerUnittest.cpp
+++ b/core/unittest/queue/ExactlyOnceQueueManagerUnittest.cpp
@@ -43,7 +43,6 @@ public:
 protected:
     static void SetUpTestCase() {
         InputFeedbackInterfaceRegistry::GetInstance()->LoadFeedbackInterfaces();
-        sEventGroup.reset(new PipelineEventGroup(make_shared<SourceBuffer>()));
         for (size_t i = 0; i < 5; ++i) {
             auto cpt = make_shared<RangeCheckpoint>();
             cpt->index = i;
@@ -68,7 +67,6 @@ protected:
 private:
     static const size_t sDataSize = 10;
 
-    static unique_ptr<PipelineEventGroup> sEventGroup;
     static ExactlyOnceQueueManager* sManager;
     static vector<RangeCheckpointPtr> sCheckpoints;
     static PipelineContext sCtx;
@@ -81,7 +79,6 @@ private:
 };
 
 const size_t ExactlyOnceQueueManagerUnittest::sDataSize;
-unique_ptr<PipelineEventGroup> ExactlyOnceQueueManagerUnittest::sEventGroup;
 ExactlyOnceQueueManager* ExactlyOnceQueueManagerUnittest::sManager;
 vector<RangeCheckpointPtr> ExactlyOnceQueueManagerUnittest::sCheckpoints;
 PipelineContext ExactlyOnceQueueManagerUnittest::sCtx;
@@ -294,7 +291,8 @@ void ExactlyOnceQueueManagerUnittest::OnPipelineUpdate() {
 }
 
 unique_ptr<ProcessQueueItem> ExactlyOnceQueueManagerUnittest::GenerateProcessItem() {
-    return make_unique<ProcessQueueItem>(std::move(*sEventGroup), 0);
+    PipelineEventGroup g(make_shared<SourceBuffer>());
+    return make_unique<ProcessQueueItem>(std::move(g), 0);
 }
 
 unique_ptr<SenderQueueItem> ExactlyOnceQueueManagerUnittest::GenerateSenderItem() {

--- a/core/unittest/queue/ExactlyOnceSenderQueueUnittest.cpp
+++ b/core/unittest/queue/ExactlyOnceSenderQueueUnittest.cpp
@@ -41,7 +41,7 @@ protected:
     }
 
     void SetUp() override {
-        mQueue.reset(new ExactlyOnceSenderQueue(sCheckpoints, sKey));
+        mQueue.reset(new ExactlyOnceSenderQueue(sCheckpoints, sKey, sCtx));
         mQueue->SetFeedback(&sFeedback);
         mFlusher.mMaxSendRate = 100;
         mFlusher.mRegion = "region";
@@ -51,6 +51,7 @@ protected:
     void TearDown() override { sFeedback.Clear(); }
 
 private:
+    static PipelineContext sCtx;
     static const QueueKey sKey = 0;
     static const size_t sDataSize = 10;
 
@@ -64,6 +65,7 @@ private:
     unique_ptr<ExactlyOnceSenderQueue> mQueue;
 };
 
+PipelineContext ExactlyOnceSenderQueueUnittest::sCtx;
 const size_t ExactlyOnceSenderQueueUnittest::sDataSize;
 FeedbackInterfaceMock ExactlyOnceSenderQueueUnittest::sFeedback;
 vector<RangeCheckpointPtr> ExactlyOnceSenderQueueUnittest::sCheckpoints;

--- a/core/unittest/queue/SenderQueueUnittest.cpp
+++ b/core/unittest/queue/SenderQueueUnittest.cpp
@@ -25,12 +25,16 @@ public:
     void TestPush();
     void TestRemove();
     void TestGetAllAvailableItems();
+    void TestMetric();
 
 protected:
-    static void SetUpTestCase() { sConcurrencyLimiter = make_shared<ConcurrencyLimiter>(); }
+    static void SetUpTestCase() {
+        sConcurrencyLimiter = make_shared<ConcurrencyLimiter>();
+        sCtx.SetConfigName("test_config");
+    }
 
     void SetUp() override {
-        mQueue.reset(new SenderQueue(sCap, sLowWatermark, sHighWatermark, sKey));
+        mQueue.reset(new SenderQueue(sCap, sLowWatermark, sHighWatermark, sKey, sFlusherId, sCtx));
         mQueue->SetConcurrencyLimiters(vector<shared_ptr<ConcurrencyLimiter>>{sConcurrencyLimiter});
         mQueue->mRateLimiter = RateLimiter(100);
         mQueue->SetFeedback(&sFeedback);
@@ -42,7 +46,9 @@ protected:
     }
 
 private:
+    static PipelineContext sCtx;
     static const QueueKey sKey = 0;
+    static const string sFlusherId;
     static const size_t sCap = 2;
     static const size_t sLowWatermark = 1;
     static const size_t sHighWatermark = 2;
@@ -57,7 +63,9 @@ private:
     unique_ptr<SenderQueue> mQueue;
 };
 
+PipelineContext SenderQueueUnittest::sCtx;
 const QueueKey SenderQueueUnittest::sKey;
+const string SenderQueueUnittest::sFlusherId = "1";
 const size_t SenderQueueUnittest::sDataSize;
 shared_ptr<ConcurrencyLimiter> SenderQueueUnittest::sConcurrencyLimiter;
 FeedbackInterfaceMock SenderQueueUnittest::sFeedback;
@@ -162,6 +170,54 @@ void SenderQueueUnittest::TestGetAllAvailableItems() {
     }
 }
 
+void SenderQueueUnittest::TestMetric() {
+    APSARA_TEST_EQUAL(5U, mQueue->mMetricsRecordRef->GetLabels()->size());
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_PROJECT, ""));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_CONFIG_NAME, "test_config"));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_COMPONENT_NAME, "sender_queue"));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_QUEUE_TYPE, "bounded"));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_FLUSHER_PLUGIN_ID, sFlusherId));
+
+    auto item1 = GenerateItem();
+    auto dataSize = item1->mData.size();
+    auto ptr1 = item1.get();
+    mQueue->Push(std::move(item1));
+
+    APSARA_TEST_EQUAL(1U, mQueue->mInItemsCnt->GetValue());
+    APSARA_TEST_EQUAL(dataSize, mQueue->mInItemsSizeByte->GetValue());
+    APSARA_TEST_EQUAL(1U, mQueue->mQueueSize->GetValue());
+    APSARA_TEST_EQUAL(dataSize, mQueue->mQueueDataSizeByte->GetValue());
+    APSARA_TEST_EQUAL(1U, mQueue->mValidToPushFlag->GetValue());
+
+    auto item2 = GenerateItem();
+    auto ptr2 = item2.get();
+    mQueue->Push(std::move(item2));
+
+    mQueue->Push(GenerateItem());
+
+    APSARA_TEST_EQUAL(3U, mQueue->mInItemsCnt->GetValue());
+    APSARA_TEST_EQUAL(dataSize * 3, mQueue->mInItemsSizeByte->GetValue());
+    APSARA_TEST_EQUAL(2U, mQueue->mQueueSize->GetValue());
+    APSARA_TEST_EQUAL(dataSize * 2, mQueue->mQueueDataSizeByte->GetValue());
+    APSARA_TEST_EQUAL(0U, mQueue->mValidToPushFlag->GetValue());
+    APSARA_TEST_EQUAL(1U, mQueue->mExtraBufferCnt->GetValue());
+    APSARA_TEST_EQUAL(dataSize, mQueue->mExtraBufferDataSizeByte->GetValue());
+
+    mQueue->Remove(ptr1);
+    APSARA_TEST_EQUAL(1U, mQueue->mOutItemsCnt->GetValue());
+    APSARA_TEST_EQUAL(2U, mQueue->mQueueSize->GetValue());
+    APSARA_TEST_EQUAL(dataSize * 2, mQueue->mQueueDataSizeByte->GetValue());
+    APSARA_TEST_EQUAL(0U, mQueue->mValidToPushFlag->GetValue());
+    APSARA_TEST_EQUAL(0U, mQueue->mExtraBufferCnt->GetValue());
+    APSARA_TEST_EQUAL(0U, mQueue->mExtraBufferDataSizeByte->GetValue());
+
+    mQueue->Remove(ptr2);
+    APSARA_TEST_EQUAL(2U, mQueue->mOutItemsCnt->GetValue());
+    APSARA_TEST_EQUAL(1U, mQueue->mQueueSize->GetValue());
+    APSARA_TEST_EQUAL(dataSize, mQueue->mQueueDataSizeByte->GetValue());
+    APSARA_TEST_EQUAL(1U, mQueue->mValidToPushFlag->GetValue());
+}
+
 unique_ptr<SenderQueueItem> SenderQueueUnittest::GenerateItem() {
     return make_unique<SenderQueueItem>("content", sDataSize, nullptr, sKey);
 }
@@ -169,6 +225,7 @@ unique_ptr<SenderQueueItem> SenderQueueUnittest::GenerateItem() {
 UNIT_TEST_CASE(SenderQueueUnittest, TestPush)
 UNIT_TEST_CASE(SenderQueueUnittest, TestRemove)
 UNIT_TEST_CASE(SenderQueueUnittest, TestGetAllAvailableItems)
+UNIT_TEST_CASE(SenderQueueUnittest, TestMetric)
 
 } // namespace logtail
 

--- a/core/unittest/queue/SenderQueueUnittest.cpp
+++ b/core/unittest/queue/SenderQueueUnittest.cpp
@@ -184,7 +184,7 @@ void SenderQueueUnittest::TestMetric() {
     mQueue->Push(std::move(item1));
 
     APSARA_TEST_EQUAL(1U, mQueue->mInItemsCnt->GetValue());
-    APSARA_TEST_EQUAL(dataSize, mQueue->mInItemsSizeByte->GetValue());
+    APSARA_TEST_EQUAL(dataSize, mQueue->mInItemDataSizeBytes->GetValue());
     APSARA_TEST_EQUAL(1U, mQueue->mQueueSize->GetValue());
     APSARA_TEST_EQUAL(dataSize, mQueue->mQueueDataSizeByte->GetValue());
     APSARA_TEST_EQUAL(1U, mQueue->mValidToPushFlag->GetValue());
@@ -196,20 +196,20 @@ void SenderQueueUnittest::TestMetric() {
     mQueue->Push(GenerateItem());
 
     APSARA_TEST_EQUAL(3U, mQueue->mInItemsCnt->GetValue());
-    APSARA_TEST_EQUAL(dataSize * 3, mQueue->mInItemsSizeByte->GetValue());
+    APSARA_TEST_EQUAL(dataSize * 3, mQueue->mInItemDataSizeBytes->GetValue());
     APSARA_TEST_EQUAL(2U, mQueue->mQueueSize->GetValue());
     APSARA_TEST_EQUAL(dataSize * 2, mQueue->mQueueDataSizeByte->GetValue());
     APSARA_TEST_EQUAL(0U, mQueue->mValidToPushFlag->GetValue());
-    APSARA_TEST_EQUAL(1U, mQueue->mExtraBufferCnt->GetValue());
-    APSARA_TEST_EQUAL(dataSize, mQueue->mExtraBufferDataSizeByte->GetValue());
+    APSARA_TEST_EQUAL(1U, mQueue->mExtraBufferSize->GetValue());
+    APSARA_TEST_EQUAL(dataSize, mQueue->mExtraBufferDataSizeBytes->GetValue());
 
     mQueue->Remove(ptr1);
     APSARA_TEST_EQUAL(1U, mQueue->mOutItemsCnt->GetValue());
     APSARA_TEST_EQUAL(2U, mQueue->mQueueSize->GetValue());
     APSARA_TEST_EQUAL(dataSize * 2, mQueue->mQueueDataSizeByte->GetValue());
     APSARA_TEST_EQUAL(0U, mQueue->mValidToPushFlag->GetValue());
-    APSARA_TEST_EQUAL(0U, mQueue->mExtraBufferCnt->GetValue());
-    APSARA_TEST_EQUAL(0U, mQueue->mExtraBufferDataSizeByte->GetValue());
+    APSARA_TEST_EQUAL(0U, mQueue->mExtraBufferSize->GetValue());
+    APSARA_TEST_EQUAL(0U, mQueue->mExtraBufferDataSizeBytes->GetValue());
 
     mQueue->Remove(ptr2);
     APSARA_TEST_EQUAL(2U, mQueue->mOutItemsCnt->GetValue());

--- a/core/unittest/queue/SenderQueueUnittest.cpp
+++ b/core/unittest/queue/SenderQueueUnittest.cpp
@@ -176,7 +176,7 @@ void SenderQueueUnittest::TestMetric() {
     APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_CONFIG_NAME, "test_config"));
     APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_COMPONENT_NAME, "sender_queue"));
     APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_QUEUE_TYPE, "bounded"));
-    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_FLUSHER_PLUGIN_ID, sFlusherId));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_FLUSHER_NODE_ID, sFlusherId));
 
     auto item1 = GenerateItem();
     auto dataSize = item1->mData.size();

--- a/core/unittest/queue/SenderQueueUnittest.cpp
+++ b/core/unittest/queue/SenderQueueUnittest.cpp
@@ -174,9 +174,9 @@ void SenderQueueUnittest::TestMetric() {
     APSARA_TEST_EQUAL(5U, mQueue->mMetricsRecordRef->GetLabels()->size());
     APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_PROJECT, ""));
     APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_CONFIG_NAME, "test_config"));
-    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_COMPONENT_NAME, "sender_queue"));
-    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_QUEUE_TYPE, "bounded"));
-    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_FLUSHER_NODE_ID, sFlusherId));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_KEY_COMPONENT_NAME, "sender_queue"));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_KEY_QUEUE_TYPE, "bounded"));
+    APSARA_TEST_TRUE(mQueue->mMetricsRecordRef.HasLabel(METRIC_LABEL_KEY_FLUSHER_NODE_ID, sFlusherId));
 
     auto item1 = GenerateItem();
     auto dataSize = item1->mData.size();

--- a/core/unittest/reader/ForceReadUnittest.cpp
+++ b/core/unittest/reader/ForceReadUnittest.cpp
@@ -118,7 +118,7 @@ protected:
         FileServer::GetInstance()->AddFileDiscoveryConfig(mConfigName, &discoveryOpts, &ctx);
         FileServer::GetInstance()->AddFileReaderConfig(mConfigName, &readerOpts, &ctx);
         FileServer::GetInstance()->AddMultilineConfig(mConfigName, &multilineOpts, &ctx);
-        ProcessQueueManager::GetInstance()->CreateOrUpdateBoundedQueue(0, 0);
+        ProcessQueueManager::GetInstance()->CreateOrUpdateBoundedQueue(0, 0, ctx);
     }
 
     void TearDown() override { remove(utf8File.c_str()); }

--- a/core/unittest/sender/FlusherRunnerUnittest.cpp
+++ b/core/unittest/sender/FlusherRunnerUnittest.cpp
@@ -33,6 +33,9 @@ void FlusherRunnerUnittest::TestDispatch() {
         // http
         auto flusher = make_unique<FlusherHttpMock>();
         Json::Value tmp;
+        PipelineContext ctx;
+        flusher->SetContext(ctx);
+        flusher->SetMetricsRecordRef("name", "pluginId", "nodeId", "childNodeId");
         flusher->Init(Json::Value(), tmp);
 
         auto item = make_unique<SenderQueueItem>("content", 10, flusher.get(), flusher->GetQueueKey());
@@ -49,6 +52,9 @@ void FlusherRunnerUnittest::TestDispatch() {
         // unknown
         auto flusher = make_unique<FlusherMock>();
         Json::Value tmp;
+        PipelineContext ctx;
+        flusher->SetContext(ctx);
+        flusher->SetMetricsRecordRef("name", "pluginId", "nodeId", "childNodeId");
         flusher->Init(Json::Value(), tmp);
 
         auto item = make_unique<SenderQueueItem>("content", 10, flusher.get(), flusher->GetQueueKey());


### PR DESCRIPTION
- 指标框架改动：
1. IntGauge新增Add和Sub接口，以支持非绝对型指标（比如队列元素的size和）
2. 将准备metricrecordref和将metricrecordref加入到链表的操作分开，以支持增加metricrecordref的label

- 新增队列公共指标（除exactly once发送队列）
进入的数量、进入的size、出去的数量、总时延、队列长度、size

- 队列指标公共label
config_name、project、component_name、queue_type