### PR TITLE
Fixed an issue where the pipeline would get stuck during configuration changes.

### DIFF
--- a/core/go_pipeline/LogtailPlugin.cpp
+++ b/core/go_pipeline/LogtailPlugin.cpp
@@ -135,7 +135,7 @@ int LogtailPlugin::IsValidToSend(long long logstoreKey) {
     // therefore, we assume true here. This could be a potential problem if network is not available for profile info.
     // However, since go profile pipeline will be stopped only during process exit, it should be fine.
     if (logstoreKey == -1) {
-        return true;
+        return 0;
     }
     return SenderQueueManager::GetInstance()->IsValidToPush(logstoreKey) ? 0 : -1;
 }


### PR DESCRIPTION
# 现象

当前main分支编译出的ilogtail，当满足：

1. 运行时间较长
2. 配置中存在go pipeline

的条件时，如果变更配置，会导致流水线卡死

# 原因

根本原因：go向c++ flusher发送自监控数据会失败，发送队列不可用。

为什么会导致卡死：当运行了足够长时间，自监控go pipeline的数据因为一直发不出去，堵塞到aggregator时，进行配置变更，会卡死在自监控go pipeline的aggregator stop处。这里有一个循环会一直等待数据能发送出去，但由于下游flusher发送不成功，导致整个循环退不出、进而导致死循环卡住。

# 代码改动

之前的PR https://github.com/alibaba/ilogtail/pull/1709 已经尝试修复了这个问题，但是有一个地方的返回值错了，导致修复没有成功