### PR TITLE
fix: metric input v2 not started and extension id

### DIFF
--- a/pkg/pipeline/plugin.go
+++ b/pkg/pipeline/plugin.go
@@ -14,6 +14,8 @@
 
 package pipeline
 
+import "fmt"
+
 // logtail plugin type define
 const (
 	MetricInputType  = iota
@@ -30,11 +32,22 @@ type PluginContext struct {
 }
 
 type PluginMeta struct {
+	PluginTypeWithID string
+	PluginType       string
+	PluginName       string // optional, used for extension plugin
 	PluginID         string
 	NodeID           string
 	ChildNodeID      string
-	PluginType       string
-	PluginTypeWithID string
+}
+
+// GetExtensionKey returns the key in context map for an extension plugin.
+// If plugin name is set, the key is "<plugin_type>/<plugin_name>", and other plugins can reuse it by the same key.
+// otherwise the key is "<plugin_type>/<plugin_id>".
+func (p *PluginMeta) GetExtensionKey() string {
+	if p.PluginName != "" {
+		return fmt.Sprintf("%s/%s", p.PluginType, p.PluginName)
+	}
+	return fmt.Sprintf("%s/%s", p.PluginType, p.PluginID)
 }
 
 type MetricCreator func() MetricInput

--- a/pluginmanager/context_imp.go
+++ b/pluginmanager/context_imp.go
@@ -43,6 +43,9 @@ func (p *ContextImp) GetRuntimeContext() context.Context {
 	return p.ctx
 }
 
+// GetExtension returns the extension by name.
+// name can be a plugin type with instance name, i.e., ext_basicauth/1, ext_basicauth/shared
+// name can be also just a plugin type, i.e., ext_basicauth
 func (p *ContextImp) GetExtension(name string, cfg any) (pipeline.Extension, error) {
 	if p.logstoreC == nil || p.logstoreC.PluginRunner == nil {
 		return nil, fmt.Errorf("pipeline not initialized")

--- a/pluginmanager/context_imp.go
+++ b/pluginmanager/context_imp.go
@@ -57,19 +57,19 @@ func (p *ContextImp) GetExtension(name string, cfg any) (pipeline.Extension, err
 	}
 
 	// if it's a naming extension, we won't do further create
-	if isPluginTypeWithID(name) {
+	if pluginHasName(name, false) {
 		return nil, fmt.Errorf("not found extension: %s", name)
 	}
 
 	// create if not found
-	pluginMeta := p.logstoreC.genPluginMeta(name, false, false)
+	pluginMeta := p.logstoreC.genPluginMeta(name, false, false, false)
 	err := loadExtension(pluginMeta, p.logstoreC, cfg)
 	if err != nil {
 		return nil, err
 	}
 
 	// get the new created extension
-	exists, ok = p.logstoreC.PluginRunner.GetExtension(getPluginTypeAndName(pluginMeta.PluginTypeWithID))
+	exists, ok = p.logstoreC.PluginRunner.GetExtension(pluginMeta.GetExtensionKey())
 	if !ok {
 		return nil, fmt.Errorf("failed to load extension: %s", pluginMeta.PluginTypeWithID)
 	}

--- a/pluginmanager/context_imp.go
+++ b/pluginmanager/context_imp.go
@@ -69,7 +69,7 @@ func (p *ContextImp) GetExtension(name string, cfg any) (pipeline.Extension, err
 	}
 
 	// get the new created extension
-	exists, ok = p.logstoreC.PluginRunner.GetExtension(pluginMeta.PluginTypeWithID)
+	exists, ok = p.logstoreC.PluginRunner.GetExtension(getPluginTypeAndName(pluginMeta.PluginTypeWithID))
 	if !ok {
 		return nil, fmt.Errorf("failed to load extension: %s", pluginMeta.PluginTypeWithID)
 	}

--- a/pluginmanager/logstore_config_test.go
+++ b/pluginmanager/logstore_config_test.go
@@ -527,7 +527,7 @@ func TestLogstoreConfig_ProcessRawLogV2(t *testing.T) {
 func Test_genPluginMeta(t *testing.T) {
 	l := new(LogstoreConfig)
 	{
-		result := l.genPluginMeta("testPlugin", false, false)
+		result := l.genPluginMeta("testPlugin", true, false, false)
 		assert.Equal(t, "testPlugin", result.PluginType)
 		assert.Regexp(t, `testPlugin/\d+`, result.PluginTypeWithID)
 		assert.Regexp(t, `\d+`, result.PluginID)
@@ -535,7 +535,7 @@ func Test_genPluginMeta(t *testing.T) {
 		assert.Equal(t, "", result.ChildNodeID)
 	}
 	{
-		result := l.genPluginMeta("testPlugin", true, false)
+		result := l.genPluginMeta("testPlugin", true, true, false)
 		assert.Equal(t, "testPlugin", result.PluginType)
 		assert.Regexp(t, `testPlugin/\d+`, result.PluginTypeWithID)
 		assert.Regexp(t, `\d+`, result.PluginID)
@@ -543,7 +543,7 @@ func Test_genPluginMeta(t *testing.T) {
 		assert.Regexp(t, `\d+`, result.ChildNodeID)
 	}
 	{
-		result := l.genPluginMeta("testPlugin", true, true)
+		result := l.genPluginMeta("testPlugin", true, true, true)
 		assert.Equal(t, "testPlugin", result.PluginType)
 		assert.Regexp(t, `testPlugin/\d+`, result.PluginTypeWithID)
 		assert.Regexp(t, `\d+`, result.PluginID)
@@ -551,7 +551,7 @@ func Test_genPluginMeta(t *testing.T) {
 		assert.Regexp(t, `-1`, result.ChildNodeID)
 	}
 	{
-		result := l.genPluginMeta("testPlugin/customID", false, false)
+		result := l.genPluginMeta("testPlugin/customID", true, false, false)
 		assert.Equal(t, "testPlugin", result.PluginType)
 		assert.Equal(t, "testPlugin/customID", result.PluginTypeWithID)
 		assert.Equal(t, "customID", result.PluginID)
@@ -559,7 +559,7 @@ func Test_genPluginMeta(t *testing.T) {
 		assert.Equal(t, "", result.ChildNodeID)
 	}
 	{
-		result := l.genPluginMeta("testPlugin/customID", true, false)
+		result := l.genPluginMeta("testPlugin/customID", true, true, false)
 		assert.Equal(t, "testPlugin", result.PluginType)
 		assert.Equal(t, "testPlugin/customID", result.PluginTypeWithID)
 		assert.Equal(t, "customID", result.PluginID)
@@ -567,7 +567,7 @@ func Test_genPluginMeta(t *testing.T) {
 		assert.Regexp(t, `\d+`, result.ChildNodeID)
 	}
 	{
-		result := l.genPluginMeta("testPlugin/customID", true, true)
+		result := l.genPluginMeta("testPlugin/customID", true, true, true)
 		assert.Equal(t, "testPlugin", result.PluginType)
 		assert.Equal(t, "testPlugin/customID", result.PluginTypeWithID)
 		assert.Equal(t, "customID", result.PluginID)
@@ -580,22 +580,44 @@ func Test_getPluginTypeWithID(t *testing.T) {
 	{
 		input := "ext_basicauth/123"
 		assert.Equal(t, "ext_basicauth", getPluginType(input))
-		assert.Equal(t, "123", getPluginID(input))
-		assert.Equal(t, "ext_basicauth", getPluginTypeAndName(input))
-		assert.Equal(t, true, isPluginTypeWithID(input))
+		assert.Equal(t, "123", getPluginID(input, true))
+		assert.Equal(t, "ext_basicauth", getPluginTypeAndName(input, true))
+		assert.Equal(t, true, pluginHasID(input, true))
+		assert.Equal(t, false, pluginHasName(input, true))
+
+		assert.Equal(t, "ext_basicauth", getPluginType(input))
+		assert.Equal(t, "1", getPluginID(input, false))
+		assert.Equal(t, "ext_basicauth/123", getPluginTypeAndName(input, false))
+		assert.Equal(t, false, pluginHasID(input, false))
+		assert.Equal(t, true, pluginHasName(input, true))
+
 	}
 	{
 		input := "ext_basicauth"
 		assert.Equal(t, "ext_basicauth", getPluginType(input))
-		assert.Equal(t, "", getPluginID(input))
-		assert.Equal(t, "ext_basicauth", getPluginTypeAndName(input))
-		assert.Equal(t, false, isPluginTypeWithID(input))
+		assert.Equal(t, "", getPluginID(input, true))
+		assert.Equal(t, "ext_basicauth", getPluginTypeAndName(input, true))
+		assert.Equal(t, false, pluginHasID(input, true))
+		assert.Equal(t, false, pluginHasName(input, true))
+
+		assert.Equal(t, "ext_basicauth", getPluginType(input))
+		assert.Equal(t, "", getPluginID(input, false))
+		assert.Equal(t, "ext_basicauth", getPluginTypeAndName(input, false))
+		assert.Equal(t, false, pluginHasID(input, false))
+		assert.Equal(t, false, pluginHasName(input, true))
 	}
 	{
 		input := "ext_basicauth/name/123"
 		assert.Equal(t, "ext_basicauth", getPluginType(input))
-		assert.Equal(t, "123", getPluginID(input))
-		assert.Equal(t, "ext_basicauth/name", getPluginTypeAndName(input))
-		assert.Equal(t, true, isPluginTypeWithID(input))
+		assert.Equal(t, "123", getPluginID(input, true))
+		assert.Equal(t, "ext_basicauth/name", getPluginTypeAndName(input, true))
+		assert.Equal(t, true, pluginHasID(input, true))
+		assert.Equal(t, true, pluginHasName(input, true))
+
+		assert.Equal(t, "ext_basicauth", getPluginType(input))
+		assert.Equal(t, "", getPluginID(input, false))
+		assert.Equal(t, "ext_basicauth/name/123", getPluginTypeAndName(input, false))
+		assert.Equal(t, false, pluginHasID(input, false))
+		assert.Equal(t, true, pluginHasName(input, false))
 	}
 }

--- a/pluginmanager/logstore_config_test.go
+++ b/pluginmanager/logstore_config_test.go
@@ -575,3 +575,28 @@ func Test_genPluginMeta(t *testing.T) {
 		assert.Regexp(t, `-1`, result.ChildNodeID)
 	}
 }
+
+func Test_getPluginTypeWithID(t *testing.T) {
+	{
+		input := "ext_basicauth/123"
+		assert.Equal(t, "ext_basicauth", getPluginType(input))
+		assert.Equal(t, "123", getPluginID(input))
+		assert.Equal(t, "ext_basicauth", getPluginTypeAndName(input))
+		assert.Equal(t, false, isPluginTypeWithID(input))
+
+	}
+	{
+		input := "ext_basicauth"
+		assert.Equal(t, "ext_basicauth", getPluginType(input))
+		assert.Equal(t, "", getPluginID(input))
+		assert.Equal(t, "ext_basicauth", getPluginTypeAndName(input))
+		assert.Equal(t, false, isPluginTypeWithID(input))
+	}
+	{
+		input := "ext_basicauth/name/123"
+		assert.Equal(t, "ext_basicauth", getPluginType(input))
+		assert.Equal(t, "123", getPluginID(input))
+		assert.Equal(t, "ext_basicauth/name", getPluginTypeAndName(input))
+		assert.Equal(t, true, isPluginTypeWithID(input))
+	}
+}

--- a/pluginmanager/logstore_config_test.go
+++ b/pluginmanager/logstore_config_test.go
@@ -582,8 +582,7 @@ func Test_getPluginTypeWithID(t *testing.T) {
 		assert.Equal(t, "ext_basicauth", getPluginType(input))
 		assert.Equal(t, "123", getPluginID(input))
 		assert.Equal(t, "ext_basicauth", getPluginTypeAndName(input))
-		assert.Equal(t, false, isPluginTypeWithID(input))
-
+		assert.Equal(t, true, isPluginTypeWithID(input))
 	}
 	{
 		input := "ext_basicauth"

--- a/pluginmanager/plugin_runner_v1.go
+++ b/pluginmanager/plugin_runner_v1.go
@@ -65,7 +65,7 @@ func (p *pluginv1Runner) Init(inputQueueSize int, flushQueueSize int) error {
 
 func (p *pluginv1Runner) AddDefaultAggregatorIfEmpty() error {
 	if len(p.AggregatorPlugins) == 0 {
-		pluginMeta := p.LogstoreConfig.genPluginMeta("aggregator_default", true, false)
+		pluginMeta := p.LogstoreConfig.genPluginMeta("aggregator_default", true, true, false)
 		logger.Debug(p.LogstoreConfig.Context.GetRuntimeContext(), "add default aggregator")
 		if err := loadAggregator(pluginMeta, p.LogstoreConfig, nil); err != nil {
 			return err
@@ -78,7 +78,7 @@ func (p *pluginv1Runner) AddDefaultFlusherIfEmpty() error {
 	if len(p.FlusherPlugins) == 0 {
 		logger.Debug(p.LogstoreConfig.Context.GetRuntimeContext(), "add default flusher")
 		category, options := flags.GetFlusherConfiguration()
-		pluginMeta := p.LogstoreConfig.genPluginMeta(category, true, true)
+		pluginMeta := p.LogstoreConfig.genPluginMeta(category, true, true, true)
 		if err := loadFlusher(pluginMeta, p.LogstoreConfig, options); err != nil {
 			return err
 		}
@@ -110,7 +110,7 @@ func (p *pluginv1Runner) AddPlugin(pluginMeta *pipeline.PluginMeta, category plu
 		}
 	case pluginExtension:
 		if extension, ok := plugin.(pipeline.Extension); ok {
-			return p.addExtension(getPluginTypeAndName(pluginMeta.PluginTypeWithID), extension)
+			return p.addExtension(pluginMeta.GetExtensionKey(), extension)
 		}
 	default:
 		return pluginCategoryUndefinedError(category)

--- a/pluginmanager/plugin_runner_v1.go
+++ b/pluginmanager/plugin_runner_v1.go
@@ -110,7 +110,7 @@ func (p *pluginv1Runner) AddPlugin(pluginMeta *pipeline.PluginMeta, category plu
 		}
 	case pluginExtension:
 		if extension, ok := plugin.(pipeline.Extension); ok {
-			return p.addExtension(pluginMeta.PluginTypeWithID, extension)
+			return p.addExtension(getPluginTypeAndName(pluginMeta.PluginTypeWithID), extension)
 		}
 	default:
 		return pluginCategoryUndefinedError(category)

--- a/pluginmanager/plugin_runner_v2.go
+++ b/pluginmanager/plugin_runner_v2.go
@@ -228,7 +228,7 @@ func (p *pluginv2Runner) runInput() {
 
 func (p *pluginv2Runner) runMetricInput(control *pipeline.AsyncControl) {
 	for _, t := range p.TimerRunner {
-		if plugin, ok := t.state.(*MetricWrapperV2); ok {
+		if plugin, ok := t.state.(pipeline.MetricInputV2); ok {
 			metric := plugin
 			timer := t
 			control.Run(func(cc *pipeline.AsyncControl) {
@@ -236,6 +236,8 @@ func (p *pluginv2Runner) runMetricInput(control *pipeline.AsyncControl) {
 					return metric.Read(p.InputPipeContext)
 				}, cc)
 			})
+		} else {
+			logger.Error(p.LogstoreConfig.Context.GetRuntimeContext(), "METRIC_INPUT_V2_START_FAILURE", "type assertion", "failure")
 		}
 	}
 }

--- a/pluginmanager/plugin_runner_v2.go
+++ b/pluginmanager/plugin_runner_v2.go
@@ -153,7 +153,7 @@ func (p *pluginv2Runner) addMetricInput(pluginMeta *pipeline.PluginMeta, input p
 	p.MetricPlugins = append(p.MetricPlugins, &wrapper)
 	p.TimerRunner = append(p.TimerRunner, &timerRunner{
 		state:         input,
-		interval:      wrapper.Interval * time.Millisecond,
+		interval:      wrapper.Interval,
 		context:       p.LogstoreConfig.Context,
 		latencyMetric: p.LogstoreConfig.Statistics.CollecLatencytMetric,
 	})

--- a/pluginmanager/plugin_runner_v2.go
+++ b/pluginmanager/plugin_runner_v2.go
@@ -114,7 +114,7 @@ func (p *pluginv2Runner) AddPlugin(pluginMeta *pipeline.PluginMeta, category plu
 		}
 	case pluginExtension:
 		if extension, ok := plugin.(pipeline.Extension); ok {
-			return p.addExtension(pluginMeta.PluginTypeWithID, extension)
+			return p.addExtension(getPluginTypeAndName(pluginMeta.PluginTypeWithID), extension)
 		}
 	default:
 		return pluginCategoryUndefinedError(category)

--- a/pluginmanager/plugin_runner_v2.go
+++ b/pluginmanager/plugin_runner_v2.go
@@ -77,7 +77,7 @@ func (p *pluginv2Runner) Init(inputQueueSize int, flushQueueSize int) error {
 
 func (p *pluginv2Runner) AddDefaultAggregatorIfEmpty() error {
 	if len(p.AggregatorPlugins) == 0 {
-		pluginMeta := p.LogstoreConfig.genPluginMeta("aggregator_default", true, false)
+		pluginMeta := p.LogstoreConfig.genPluginMeta("aggregator_default", true, true, false)
 		logger.Debug(p.LogstoreConfig.Context.GetRuntimeContext(), "add default aggregator")
 		if err := loadAggregator(pluginMeta, p.LogstoreConfig, nil); err != nil {
 			return err
@@ -114,7 +114,7 @@ func (p *pluginv2Runner) AddPlugin(pluginMeta *pipeline.PluginMeta, category plu
 		}
 	case pluginExtension:
 		if extension, ok := plugin.(pipeline.Extension); ok {
-			return p.addExtension(getPluginTypeAndName(pluginMeta.PluginTypeWithID), extension)
+			return p.addExtension(pluginMeta.GetExtensionKey(), extension)
 		}
 	default:
 		return pluginCategoryUndefinedError(category)

--- a/pluginmanager/plugin_runner_v2.go
+++ b/pluginmanager/plugin_runner_v2.go
@@ -189,7 +189,7 @@ func (p *pluginv2Runner) addAggregator(pluginMeta *pipeline.PluginMeta, aggregat
 	p.AggregatorPlugins = append(p.AggregatorPlugins, &wrapper)
 	p.TimerRunner = append(p.TimerRunner, &timerRunner{
 		state:         aggregator,
-		interval:      time.Millisecond * wrapper.Interval,
+		interval:      wrapper.Interval,
 		context:       p.LogstoreConfig.Context,
 		latencyMetric: p.LogstoreConfig.Statistics.CollecLatencytMetric,
 	})


### PR DESCRIPTION
bug fix:
修复 go pipeline MetricInputV2 断言类型不匹配导致插件不启动的问题
修复 go pipeline v2 插件 timer 多乘了一个 time.Millisecond的问题

优化：
当 extension 插件被多个组件共享时，由于 c++添加了插件id，所以每次都会初始化一个 extension 实例。