### PR TITLE
fix: do not use gtid if gtid is disabled

### DIFF
--- a/plugins/input/canal/input_canal.go
+++ b/plugins/input/canal/input_canal.go
@@ -759,9 +759,13 @@ func (sc *ServiceCanal) Start(c pipeline.Collector) error {
 		startPos.Pos = sc.checkpoint.Offset
 	}
 	if nil == gtid && 0 == len(startPos.Name) && !sc.StartFromBegining {
-		gtid, err = sc.getLatestGTID()
-		if err != nil {
-			logger.Warning(sc.context.GetRuntimeContext(), "CANAL_START_ALARM", "Call getLatestGTID failed, error", err)
+		if sc.isGTIDEnabled {
+			gtid, err = sc.getLatestGTID()
+			if err != nil {
+				logger.Warning(sc.context.GetRuntimeContext(), "CANAL_START_ALARM", "Call getLatestGTID failed, error", err)
+			}
+		}
+		if gtid == nil {
 			startPos = sc.GetBinlogLatestPos()
 		}
 		logger.Infof(sc.context.GetRuntimeContext(), "Get latest checkpoint GTID: %v Position: %v", gtid, startPos)


### PR DESCRIPTION
Fixed an issue where the input_canal plugin used GTID as the sync method even when gtid_enabled was set to false. This led to syncing from the beginning due to receiving an empty GTID set. Syncing from the beginning is usually undesirable as it consumes significant CPU resources on the server side and deviates from the default plugin behavior. This commit ensures that the plugin respects the gtid_enabled switch and the gtid_mode query result.