### PR TITLE
update: remove enable-compression config temporarily

### DIFF
--- a/core/prometheus/schedulers/ScrapeConfig.cpp
+++ b/core/prometheus/schedulers/ScrapeConfig.cpp
@@ -56,9 +56,9 @@ bool ScrapeConfig::Init(const Json::Value& scrapeConfig) {
 
     if (scrapeConfig.isMember(prometheus::ENABLE_COMPRESSION)
         && scrapeConfig[prometheus::ENABLE_COMPRESSION].isBool()) {
-        InitEnableCompression(scrapeConfig[prometheus::ENABLE_COMPRESSION].asBool());
+        // InitEnableCompression(scrapeConfig[prometheus::ENABLE_COMPRESSION].asBool());
     } else {
-        InitEnableCompression(true);
+        // InitEnableCompression(true);
     }
 
     if (scrapeConfig.isMember(prometheus::METRICS_PATH) && scrapeConfig[prometheus::METRICS_PATH].isString()) {

--- a/core/unittest/prometheus/ScrapeConfigUnittest.cpp
+++ b/core/unittest/prometheus/ScrapeConfigUnittest.cpp
@@ -107,7 +107,7 @@ void ScrapeConfigUnittest::TestInit() {
                       "application/openmetrics-text;version=0.0.1;q=0.2,*/*;q=0.1");
 
     // disable compression
-    APSARA_TEST_EQUAL(scrapeConfig.mRequestHeaders["Accept-Encoding"], "identity");
+    // APSARA_TEST_EQUAL(scrapeConfig.mRequestHeaders["Accept-Encoding"], "identity");
 
     // basic auth
     APSARA_TEST_EQUAL(scrapeConfig.mRequestHeaders["Authorization"], "Basic dGVzdF91c2VyOnRlc3RfcGFzc3dvcmQ=");
@@ -379,7 +379,7 @@ void ScrapeConfigUnittest::TestEnableCompression() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, config, errorMsg));
     scrapeConfig.mRequestHeaders.clear();
     APSARA_TEST_TRUE(scrapeConfig.Init(config));
-    APSARA_TEST_EQUAL("gzip", scrapeConfig.mRequestHeaders["Accept-Encoding"]);
+    // APSARA_TEST_EQUAL("gzip", scrapeConfig.mRequestHeaders["Accept-Encoding"]);
 
     // disable
     configStr = R"JSON({
@@ -393,7 +393,7 @@ void ScrapeConfigUnittest::TestEnableCompression() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, config, errorMsg));
     scrapeConfig.mRequestHeaders.clear();
     APSARA_TEST_TRUE(scrapeConfig.Init(config));
-    APSARA_TEST_EQUAL("identity", scrapeConfig.mRequestHeaders["Accept-Encoding"]);
+    // APSARA_TEST_EQUAL("identity", scrapeConfig.mRequestHeaders["Accept-Encoding"]);
 
     // enable
     configStr = R"JSON({
@@ -407,7 +407,7 @@ void ScrapeConfigUnittest::TestEnableCompression() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, config, errorMsg));
     scrapeConfig.mRequestHeaders.clear();
     APSARA_TEST_TRUE(scrapeConfig.Init(config));
-    APSARA_TEST_EQUAL("gzip", scrapeConfig.mRequestHeaders["Accept-Encoding"]);
+    // APSARA_TEST_EQUAL("gzip", scrapeConfig.mRequestHeaders["Accept-Encoding"]);
 }
 
 UNIT_TEST_CASE(ScrapeConfigUnittest, TestInit);


### PR DESCRIPTION
enable-compression 依赖 libcurl 中的 Accpet-Encoding option，短时间先关掉这个配置