### PR TITLE
feat: prometheus self monitor metrics

### DIFF
--- a/core/monitor/metric_constants/MetricConstants.h
+++ b/core/monitor/metric_constants/MetricConstants.h
@@ -208,6 +208,9 @@ extern const std::string METRIC_RUNNER_IN_ITEMS_TOTAL;
 extern const std::string METRIC_RUNNER_LAST_RUN_TIME;
 extern const std::string METRIC_RUNNER_OUT_ITEMS_TOTAL;
 extern const std::string METRIC_RUNNER_TOTAL_DELAY_MS;
+extern const std::string METRIC_RUNNER_CLIENT_REGISTER_STATE;
+extern const std::string METRIC_RUNNER_CLIENT_REGISTER_RETRY_TOTAL;
+extern const std::string METRIC_RUNNER_JOB_NUM;
 
 /**********************************************************
  *   http sink
@@ -232,12 +235,5 @@ extern const std::string METRIC_RUNNER_FILE_ENABLE_FILE_INCLUDED_BY_MULTI_CONFIG
 extern const std::string METRIC_RUNNER_FILE_POLLING_MODIFY_CACHE_SIZE;
 extern const std::string METRIC_RUNNER_FILE_POLLING_DIR_CACHE_SIZE;
 extern const std::string METRIC_RUNNER_FILE_POLLING_FILE_CACHE_SIZE;
-
-/**********************************************************
- *   prometheus runner
- **********************************************************/
-extern const std::string METRIC_RUNNER_CLIENT_REGISTER_STATE;
-extern const std::string METRIC_RUNNER_REGISTER_RETRY_TOTAL;
-extern const std::string METRIC_RUNNER_JOB_NUM;
 
 } // namespace logtail

--- a/core/monitor/metric_constants/MetricConstants.h
+++ b/core/monitor/metric_constants/MetricConstants.h
@@ -90,6 +90,24 @@ extern const std::string METRIC_PLUGIN_SOURCE_READ_OFFSET_BYTES;
 extern const std::string METRIC_PLUGIN_SOURCE_SIZE_BYTES;
 
 /**********************************************************
+ *   input_prometheus
+ **********************************************************/
+extern const std::string METRIC_LABEL_KEY_JOB;
+extern const std::string METRIC_LABEL_KEY_POD_NAME;
+extern const std::string METRIC_LABEL_KEY_SERVICE_HOST;
+extern const std::string METRIC_LABEL_KEY_SERVICE_PORT;
+extern const std::string METRIC_LABEL_KEY_STATUS;
+extern const std::string METRIC_LABEL_KEY_INSTANCE;
+
+extern const std::string METRIC_PLUGIN_PROM_SUBSCRIBE_TARGETS;
+extern const std::string METRIC_PLUGIN_PROM_SUBSCRIBE_TOTAL;
+extern const std::string METRIC_PLUGIN_PROM_SUBSCRIBE_TIME_MS;
+extern const std::string METRIC_PLUGIN_PROM_SCRAPE_TOTAL;
+extern const std::string METRIC_PLUGIN_PROM_SCRAPE_BYTES_TOTAL;
+extern const std::string METRIC_PLUGIN_PROM_SCRAPE_TIME_MS;
+extern const std::string METRIC_PLUGIN_PROM_SCRAPE_DELAY_TOTAL;
+
+/**********************************************************
  *   all processor （所有解析类的处理插件通用指标。Todo：目前统计还不全、不准确）
  **********************************************************/
 extern const std::string METRIC_PLUGIN_DISCARDED_EVENTS_TOTAL;
@@ -182,6 +200,7 @@ extern const std::string METRIC_LABEL_VALUE_RUNNER_NAME_FILE_SERVER;
 extern const std::string METRIC_LABEL_VALUE_RUNNER_NAME_FLUSHER;
 extern const std::string METRIC_LABEL_VALUE_RUNNER_NAME_HTTP_SINK;
 extern const std::string METRIC_LABEL_VALUE_RUNNER_NAME_PROCESSOR;
+extern const std::string METRIC_LABEL_VALUE_RUNNER_NAME_PROMETHEUS;
 
 // metric keys
 extern const std::string METRIC_RUNNER_IN_EVENTS_TOTAL;
@@ -215,5 +234,12 @@ extern const std::string METRIC_RUNNER_FILE_ENABLE_FILE_INCLUDED_BY_MULTI_CONFIG
 extern const std::string METRIC_RUNNER_FILE_POLLING_MODIFY_CACHE_SIZE;
 extern const std::string METRIC_RUNNER_FILE_POLLING_DIR_CACHE_SIZE;
 extern const std::string METRIC_RUNNER_FILE_POLLING_FILE_CACHE_SIZE;
+
+/**********************************************************
+ *   prometheus runner
+ **********************************************************/
+extern const std::string METRIC_RUNNER_PROM_REGISTER_STATE;
+extern const std::string METRIC_RUNNER_PROM_REGISTER_RETRY_TOTAL;
+extern const std::string METRIC_RUNNER_PROM_JOB_NUM;
 
 } // namespace logtail

--- a/core/monitor/metric_constants/MetricConstants.h
+++ b/core/monitor/metric_constants/MetricConstants.h
@@ -236,8 +236,8 @@ extern const std::string METRIC_RUNNER_FILE_POLLING_FILE_CACHE_SIZE;
 /**********************************************************
  *   prometheus runner
  **********************************************************/
-extern const std::string METRIC_RUNNER_PROM_REGISTER_STATE;
-extern const std::string METRIC_RUNNER_PROM_REGISTER_RETRY_TOTAL;
-extern const std::string METRIC_RUNNER_PROM_JOB_NUM;
+extern const std::string METRIC_RUNNER_CLIENT_REGISTER_STATE;
+extern const std::string METRIC_RUNNER_REGISTER_RETRY_TOTAL;
+extern const std::string METRIC_RUNNER_JOB_NUM;
 
 } // namespace logtail

--- a/core/monitor/metric_constants/MetricConstants.h
+++ b/core/monitor/metric_constants/MetricConstants.h
@@ -102,8 +102,6 @@ extern const std::string METRIC_LABEL_KEY_INSTANCE;
 extern const std::string METRIC_PLUGIN_PROM_SUBSCRIBE_TARGETS;
 extern const std::string METRIC_PLUGIN_PROM_SUBSCRIBE_TOTAL;
 extern const std::string METRIC_PLUGIN_PROM_SUBSCRIBE_TIME_MS;
-extern const std::string METRIC_PLUGIN_PROM_SCRAPE_TOTAL;
-extern const std::string METRIC_PLUGIN_PROM_SCRAPE_BYTES_TOTAL;
 extern const std::string METRIC_PLUGIN_PROM_SCRAPE_TIME_MS;
 extern const std::string METRIC_PLUGIN_PROM_SCRAPE_DELAY_TOTAL;
 

--- a/core/monitor/metric_constants/PluginMetrics.cpp
+++ b/core/monitor/metric_constants/PluginMetrics.cpp
@@ -45,6 +45,24 @@ const string METRIC_PLUGIN_SOURCE_READ_OFFSET_BYTES = "plugin_source_read_offset
 const string METRIC_PLUGIN_SOURCE_SIZE_BYTES = "plugin_source_size_bytes";
 
 /**********************************************************
+ *   input_prometheus
+ **********************************************************/
+const std::string METRIC_LABEL_KEY_JOB = "job";
+const std::string METRIC_LABEL_KEY_POD_NAME = "pod_name";
+const std::string METRIC_LABEL_KEY_SERVICE_HOST = "service_host";
+const std::string METRIC_LABEL_KEY_SERVICE_PORT = "service_port";
+const std::string METRIC_LABEL_KEY_STATUS = "status";
+const std::string METRIC_LABEL_KEY_INSTANCE = "instance";
+
+const std::string METRIC_PLUGIN_PROM_SUBSCRIBE_TARGETS = "plugin_prom_subscribe_targets";
+const std::string METRIC_PLUGIN_PROM_SUBSCRIBE_TOTAL = "plugin_prom_subscribe_total";
+const std::string METRIC_PLUGIN_PROM_SUBSCRIBE_TIME_MS = "plugin_prom_subscribe_time_ms";
+const std::string METRIC_PLUGIN_PROM_SCRAPE_TOTAL = "plugin_prom_scrape_total";
+const std::string METRIC_PLUGIN_PROM_SCRAPE_BYTES_TOTAL = "plugin_prom_scrape_bytes_total";
+const std::string METRIC_PLUGIN_PROM_SCRAPE_TIME_MS = "plugin_prom_scrape_time_ms";
+const std::string METRIC_PLUGIN_PROM_SCRAPE_DELAY_TOTAL = "plugin_prom_scrape_delay_total";
+
+/**********************************************************
  *   all processor （所有解析类的处理插件通用指标。Todo：目前统计还不全、不准确）
  **********************************************************/
 const string METRIC_PLUGIN_DISCARDED_EVENTS_TOTAL = "plugin_discarded_events_total";

--- a/core/monitor/metric_constants/PluginMetrics.cpp
+++ b/core/monitor/metric_constants/PluginMetrics.cpp
@@ -57,8 +57,6 @@ const std::string METRIC_LABEL_KEY_INSTANCE = "instance";
 const std::string METRIC_PLUGIN_PROM_SUBSCRIBE_TARGETS = "plugin_prom_subscribe_targets";
 const std::string METRIC_PLUGIN_PROM_SUBSCRIBE_TOTAL = "plugin_prom_subscribe_total";
 const std::string METRIC_PLUGIN_PROM_SUBSCRIBE_TIME_MS = "plugin_prom_subscribe_time_ms";
-const std::string METRIC_PLUGIN_PROM_SCRAPE_TOTAL = "plugin_prom_scrape_total";
-const std::string METRIC_PLUGIN_PROM_SCRAPE_BYTES_TOTAL = "plugin_prom_scrape_bytes_total";
 const std::string METRIC_PLUGIN_PROM_SCRAPE_TIME_MS = "plugin_prom_scrape_time_ms";
 const std::string METRIC_PLUGIN_PROM_SCRAPE_DELAY_TOTAL = "plugin_prom_scrape_delay_total";
 

--- a/core/monitor/metric_constants/RunnerMetrics.cpp
+++ b/core/monitor/metric_constants/RunnerMetrics.cpp
@@ -36,6 +36,9 @@ const string METRIC_RUNNER_IN_ITEMS_TOTAL = "runner_in_items_total";
 const string METRIC_RUNNER_LAST_RUN_TIME = "runner_last_run_time";
 const string METRIC_RUNNER_OUT_ITEMS_TOTAL = "runner_out_items_total";
 const string METRIC_RUNNER_TOTAL_DELAY_MS = "runner_total_delay_ms";
+const string METRIC_RUNNER_CLIENT_REGISTER_STATE = "runner_client_register_state";
+const string METRIC_RUNNER_CLIENT_REGISTER_RETRY_TOTAL = "runner_client_register_retry_total";
+const string METRIC_RUNNER_JOB_NUM = "runner_job_num";
 
 /**********************************************************
  *   http sink
@@ -61,12 +64,5 @@ const string METRIC_RUNNER_FILE_ENABLE_FILE_INCLUDED_BY_MULTI_CONFIGS_FLAG
 const string METRIC_RUNNER_FILE_POLLING_MODIFY_CACHE_SIZE = "runner_polling_modify_cache_size";
 const string METRIC_RUNNER_FILE_POLLING_DIR_CACHE_SIZE = "runner_polling_dir_cache_size";
 const string METRIC_RUNNER_FILE_POLLING_FILE_CACHE_SIZE = "runner_polling_file_cache_size";
-
-/**********************************************************
- *   prometheus server
- **********************************************************/
-const std::string METRIC_RUNNER_CLIENT_REGISTER_STATE = "runner_client_register_state";
-const std::string METRIC_RUNNER_REGISTER_RETRY_TOTAL = "runner_register_retry_total";
-const std::string METRIC_RUNNER_JOB_NUM = "runner_job_num";
 
 } // namespace logtail

--- a/core/monitor/metric_constants/RunnerMetrics.cpp
+++ b/core/monitor/metric_constants/RunnerMetrics.cpp
@@ -65,8 +65,8 @@ const string METRIC_RUNNER_FILE_POLLING_FILE_CACHE_SIZE = "runner_polling_file_c
 /**********************************************************
  *   prometheus server
  **********************************************************/
-const std::string METRIC_RUNNER_PROM_REGISTER_STATE = "runner_prom_register_state";
-const std::string METRIC_RUNNER_PROM_REGISTER_RETRY_TOTAL = "runner_prom_register_retry_total";
-const std::string METRIC_RUNNER_PROM_JOB_NUM = "runner_prom_job_num";
+const std::string METRIC_RUNNER_CLIENT_REGISTER_STATE = "runner_client_register_state";
+const std::string METRIC_RUNNER_REGISTER_RETRY_TOTAL = "runner_register_retry_total";
+const std::string METRIC_RUNNER_JOB_NUM = "runner_job_num";
 
 } // namespace logtail

--- a/core/monitor/metric_constants/RunnerMetrics.cpp
+++ b/core/monitor/metric_constants/RunnerMetrics.cpp
@@ -26,6 +26,7 @@ const string METRIC_LABEL_VALUE_RUNNER_NAME_FILE_SERVER = "file_server";
 const string METRIC_LABEL_VALUE_RUNNER_NAME_FLUSHER = "flusher_runner";
 const string METRIC_LABEL_VALUE_RUNNER_NAME_HTTP_SINK = "http_sink";
 const string METRIC_LABEL_VALUE_RUNNER_NAME_PROCESSOR = "processor_runner";
+const string METRIC_LABEL_VALUE_RUNNER_NAME_PROMETHEUS = "prometheus_runner";
 
 // metric keys
 const string METRIC_RUNNER_IN_EVENTS_TOTAL = "runner_in_events_total";
@@ -60,5 +61,12 @@ const string METRIC_RUNNER_FILE_ENABLE_FILE_INCLUDED_BY_MULTI_CONFIGS_FLAG
 const string METRIC_RUNNER_FILE_POLLING_MODIFY_CACHE_SIZE = "runner_polling_modify_cache_size";
 const string METRIC_RUNNER_FILE_POLLING_DIR_CACHE_SIZE = "runner_polling_dir_cache_size";
 const string METRIC_RUNNER_FILE_POLLING_FILE_CACHE_SIZE = "runner_polling_file_cache_size";
+
+/**********************************************************
+ *   prometheus server
+ **********************************************************/
+const std::string METRIC_RUNNER_PROM_REGISTER_STATE = "runner_prom_register_state";
+const std::string METRIC_RUNNER_PROM_REGISTER_RETRY_TOTAL = "runner_prom_register_retry_total";
+const std::string METRIC_RUNNER_PROM_JOB_NUM = "runner_prom_job_num";
 
 } // namespace logtail

--- a/core/plugin/input/InputPrometheus.cpp
+++ b/core/plugin/input/InputPrometheus.cpp
@@ -68,8 +68,9 @@ bool InputPrometheus::Start() {
     PrometheusInputRunner::GetInstance()->Init();
 
     mTargetSubscirber->mQueueKey = mContext->GetProcessQueueKey();
+    auto defaultLabels = GetMetricsRecordRef()->GetLabels();
 
-    PrometheusInputRunner::GetInstance()->UpdateScrapeInput(std::move(mTargetSubscirber));
+    PrometheusInputRunner::GetInstance()->UpdateScrapeInput(std::move(mTargetSubscirber), *defaultLabels);
     return true;
 }
 

--- a/core/plugin/input/InputPrometheus.cpp
+++ b/core/plugin/input/InputPrometheus.cpp
@@ -70,7 +70,7 @@ bool InputPrometheus::Start() {
     mTargetSubscirber->mQueueKey = mContext->GetProcessQueueKey();
     auto defaultLabels = GetMetricsRecordRef()->GetLabels();
 
-    PrometheusInputRunner::GetInstance()->UpdateScrapeInput(std::move(mTargetSubscirber), *defaultLabels);
+    PrometheusInputRunner::GetInstance()->UpdateScrapeInput(std::move(mTargetSubscirber), *defaultLabels, mContext->GetProjectName());
     return true;
 }
 

--- a/core/prometheus/Constants.h
+++ b/core/prometheus/Constants.h
@@ -24,11 +24,6 @@ const char* const MODULUS = "modulus";
 const char* const NAME = "__name__";
 const std::string EXPORTED_PREFIX = "exported_";
 
-// prometheus env
-const char* const OPERATOR_HOST = "OPERATOR_HOST";
-const char* const OPERATOR_PORT = "OPERATOR_PORT";
-const char* const POD_NAME = "POD_NAME";
-
 // prometheus api
 const char* const PROMETHEUS_PREFIX = "prometheus_";
 const char* const REGISTER_COLLECTOR_PATH = "/register_collector";

--- a/core/prometheus/PromSelfMonitor.cpp
+++ b/core/prometheus/PromSelfMonitor.cpp
@@ -1,0 +1,71 @@
+#include "prometheus/PromSelfMonitor.h"
+
+#include <map>
+#include <string>
+#include <unordered_map>
+
+#include "monitor/LoongCollectorMetricTypes.h"
+#include "monitor/metric_constants/MetricConstants.h"
+using namespace std;
+
+namespace logtail {
+
+void PromSelfMonitor::InitMetricManager(const std::unordered_map<std::string, MetricType>& metricKeys,
+                                        const MetricLabels& labels) {
+    auto metricLabels = std::make_shared<MetricLabels>(labels);
+    mPluginMetricManagerPtr = std::make_shared<PluginMetricManager>(metricLabels, metricKeys);
+}
+
+void PromSelfMonitor::CounterAdd(const std::string& metricName, uint64_t statusCode, uint64_t val) {
+    auto& status = StatusToString(statusCode);
+    if (!mMetricsCounterMap.count(metricName) || !mMetricsCounterMap[metricName].count(status)) {
+        mMetricsCounterMap[metricName][status] = GetOrCreateReentrantMetricsRecordRef(status)->GetCounter(metricName);
+    }
+    mMetricsCounterMap[metricName][status]->Add(val);
+}
+
+void PromSelfMonitor::IntGaugeSet(const std::string& metricName, uint64_t statusCode, uint64_t value) {
+    auto& status = StatusToString(statusCode);
+    if (!mMetricsIntGaugeMap.count(metricName) || !mMetricsIntGaugeMap[metricName].count(status)) {
+        mMetricsIntGaugeMap[metricName][status] = GetOrCreateReentrantMetricsRecordRef(status)->GetIntGauge(metricName);
+    }
+    mMetricsIntGaugeMap[metricName][status]->Set(value);
+}
+
+ReentrantMetricsRecordRef PromSelfMonitor::GetOrCreateReentrantMetricsRecordRef(const std::string& status) {
+    if (mPluginMetricManagerPtr == nullptr) {
+        return nullptr;
+    }
+    if (!mPromStatusMap.count(status)) {
+        mPromStatusMap[status]
+            = mPluginMetricManagerPtr->GetOrCreateReentrantMetricsRecordRef({{METRIC_LABEL_KEY_STATUS, status}});
+    }
+    return mPromStatusMap[status];
+}
+
+std::string& PromSelfMonitor::StatusToString(uint64_t status) {
+    static string sHttp0XX = "0XX";
+    static string sHttp1XX = "1XX";
+    static string sHttp2XX = "2XX";
+    static string sHttp3XX = "3XX";
+    static string sHttp4XX = "4XX";
+    static string sHttp5XX = "5XX";
+    static string sHttpOther = "other";
+    if (status < 100) {
+        return sHttp0XX;
+    } else if (status < 200) {
+        return sHttp1XX;
+    } else if (status < 300) {
+        return sHttp2XX;
+    } else if (status < 400) {
+        return sHttp3XX;
+    } else if (status < 500) {
+        return sHttp4XX;
+    } else if (status < 500) {
+        return sHttp5XX;
+    } else {
+        return sHttpOther;
+    }
+}
+
+} // namespace logtail

--- a/core/prometheus/PromSelfMonitor.cpp
+++ b/core/prometheus/PromSelfMonitor.cpp
@@ -10,13 +10,13 @@ using namespace std;
 
 namespace logtail {
 
-void PromSelfMonitor::InitMetricManager(const std::unordered_map<std::string, MetricType>& metricKeys,
+void PromSelfMonitorUnsafe::InitMetricManager(const std::unordered_map<std::string, MetricType>& metricKeys,
                                         const MetricLabels& labels) {
     auto metricLabels = std::make_shared<MetricLabels>(labels);
     mPluginMetricManagerPtr = std::make_shared<PluginMetricManager>(metricLabels, metricKeys);
 }
 
-void PromSelfMonitor::CounterAdd(const std::string& metricName, uint64_t statusCode, uint64_t val) {
+void PromSelfMonitorUnsafe::AddCounter(const std::string& metricName, uint64_t statusCode, uint64_t val) {
     auto& status = StatusToString(statusCode);
     if (!mMetricsCounterMap.count(metricName) || !mMetricsCounterMap[metricName].count(status)) {
         mMetricsCounterMap[metricName][status] = GetOrCreateReentrantMetricsRecordRef(status)->GetCounter(metricName);
@@ -24,7 +24,7 @@ void PromSelfMonitor::CounterAdd(const std::string& metricName, uint64_t statusC
     mMetricsCounterMap[metricName][status]->Add(val);
 }
 
-void PromSelfMonitor::IntGaugeSet(const std::string& metricName, uint64_t statusCode, uint64_t value) {
+void PromSelfMonitorUnsafe::SetIntGauge(const std::string& metricName, uint64_t statusCode, uint64_t value) {
     auto& status = StatusToString(statusCode);
     if (!mMetricsIntGaugeMap.count(metricName) || !mMetricsIntGaugeMap[metricName].count(status)) {
         mMetricsIntGaugeMap[metricName][status] = GetOrCreateReentrantMetricsRecordRef(status)->GetIntGauge(metricName);
@@ -32,7 +32,7 @@ void PromSelfMonitor::IntGaugeSet(const std::string& metricName, uint64_t status
     mMetricsIntGaugeMap[metricName][status]->Set(value);
 }
 
-ReentrantMetricsRecordRef PromSelfMonitor::GetOrCreateReentrantMetricsRecordRef(const std::string& status) {
+ReentrantMetricsRecordRef PromSelfMonitorUnsafe::GetOrCreateReentrantMetricsRecordRef(const std::string& status) {
     if (mPluginMetricManagerPtr == nullptr) {
         return nullptr;
     }
@@ -43,7 +43,7 @@ ReentrantMetricsRecordRef PromSelfMonitor::GetOrCreateReentrantMetricsRecordRef(
     return mPromStatusMap[status];
 }
 
-std::string& PromSelfMonitor::StatusToString(uint64_t status) {
+std::string& PromSelfMonitorUnsafe::StatusToString(uint64_t status) {
     static string sHttp0XX = "0XX";
     static string sHttp1XX = "1XX";
     static string sHttp2XX = "2XX";

--- a/core/prometheus/PromSelfMonitor.h
+++ b/core/prometheus/PromSelfMonitor.h
@@ -9,16 +9,16 @@
 
 namespace logtail {
 
-// manage status metrics
-class PromSelfMonitor {
+// manage status metrics, thread unsafe
+class PromSelfMonitorUnsafe {
 public:
-    PromSelfMonitor() = default;
+    PromSelfMonitorUnsafe() = default;
 
     void InitMetricManager(const std::unordered_map<std::string, MetricType>& metricKeys, const MetricLabels& labels);
 
-    void CounterAdd(const std::string& metricName, uint64_t status, uint64_t val = 1);
+    void AddCounter(const std::string& metricName, uint64_t status, uint64_t val = 1);
 
-    void IntGaugeSet(const std::string& metricName, uint64_t status, uint64_t value);
+    void SetIntGauge(const std::string& metricName, uint64_t status, uint64_t value);
 
 private:
     ReentrantMetricsRecordRef GetOrCreateReentrantMetricsRecordRef(const std::string& status);

--- a/core/prometheus/PromSelfMonitor.h
+++ b/core/prometheus/PromSelfMonitor.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <unordered_map>
+
+#include "monitor/LogtailMetric.h"
+#include "monitor/PluginMetricManager.h"
+
+namespace logtail {
+
+// manage status metrics
+class PromSelfMonitor {
+public:
+    PromSelfMonitor() = default;
+
+    void InitMetricManager(const std::unordered_map<std::string, MetricType>& metricKeys, const MetricLabels& labels);
+
+    void CounterAdd(const std::string& metricName, uint64_t status, uint64_t val = 1);
+
+    void IntGaugeSet(const std::string& metricName, uint64_t status, uint64_t value);
+
+private:
+    ReentrantMetricsRecordRef GetOrCreateReentrantMetricsRecordRef(const std::string& status);
+    std::string& StatusToString(uint64_t status);
+
+    PluginMetricManagerPtr mPluginMetricManagerPtr;
+    std::map<std::string, ReentrantMetricsRecordRef> mPromStatusMap;
+    std::map<std::string, std::map<std::string, CounterPtr>> mMetricsCounterMap;
+    std::map<std::string, std::map<std::string, IntGaugePtr>> mMetricsIntGaugeMap;
+    MetricLabelsPtr mDefaultLabels;
+
+#ifdef APSARA_UNIT_TEST_MAIN
+    friend class PromSelfMonitorUnittest;
+#endif
+};
+
+} // namespace logtail

--- a/core/prometheus/PrometheusInputRunner.cpp
+++ b/core/prometheus/PrometheusInputRunner.cpp
@@ -67,7 +67,7 @@ PrometheusInputRunner::PrometheusInputRunner()
 
     mPromRegisterState = mMetricsRecordRef.CreateIntGauge(METRIC_RUNNER_CLIENT_REGISTER_STATE);
     mPromJobNum = mMetricsRecordRef.CreateIntGauge(METRIC_RUNNER_JOB_NUM);
-    mPromRegisterRetryTotal = mMetricsRecordRef.CreateCounter(METRIC_RUNNER_REGISTER_RETRY_TOTAL);
+    mPromRegisterRetryTotal = mMetricsRecordRef.CreateCounter(METRIC_RUNNER_CLIENT_REGISTER_RETRY_TOTAL);
 }
 
 /// @brief receive scrape jobs from input plugins and update scrape jobs

--- a/core/prometheus/PrometheusInputRunner.cpp
+++ b/core/prometheus/PrometheusInputRunner.cpp
@@ -65,9 +65,9 @@ PrometheusInputRunner::PrometheusInputRunner()
     WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
         mMetricsRecordRef, std::move(labels), std::move(dynamicLabels));
 
-    mPromRegisterState = mMetricsRecordRef.CreateIntGauge(METRIC_RUNNER_PROM_REGISTER_STATE);
-    mPromJobNum = mMetricsRecordRef.CreateIntGauge(METRIC_RUNNER_PROM_JOB_NUM);
-    mPromRegisterRetryTotal = mMetricsRecordRef.CreateCounter(METRIC_RUNNER_PROM_REGISTER_RETRY_TOTAL);
+    mPromRegisterState = mMetricsRecordRef.CreateIntGauge(METRIC_RUNNER_CLIENT_REGISTER_STATE);
+    mPromJobNum = mMetricsRecordRef.CreateIntGauge(METRIC_RUNNER_JOB_NUM);
+    mPromRegisterRetryTotal = mMetricsRecordRef.CreateCounter(METRIC_RUNNER_REGISTER_RETRY_TOTAL);
 }
 
 /// @brief receive scrape jobs from input plugins and update scrape jobs

--- a/core/prometheus/PrometheusInputRunner.h
+++ b/core/prometheus/PrometheusInputRunner.h
@@ -22,6 +22,8 @@
 
 #include "common/Lock.h"
 #include "common/timer/Timer.h"
+#include "monitor/LogtailMetric.h"
+#include "monitor/LoongCollectorMetricTypes.h"
 #include "prometheus/schedulers/TargetSubscriberScheduler.h"
 #include "runner/InputRunner.h"
 #include "sdk/Common.h"
@@ -42,7 +44,8 @@ public:
     }
 
     // input plugin update
-    void UpdateScrapeInput(std::shared_ptr<TargetSubscriberScheduler> targetSubscriber);
+    void UpdateScrapeInput(std::shared_ptr<TargetSubscriberScheduler> targetSubscriber,
+                           const MetricLabels& defaultLabels);
     void RemoveScrapeInput(const std::string& jobName);
 
     // target discover and scrape
@@ -75,6 +78,11 @@ private:
     std::map<std::string, std::shared_ptr<TargetSubscriberScheduler>> mTargetSubscriberSchedulerMap;
 
     std::atomic<uint64_t> mUnRegisterMs;
+
+    // self monitor
+    MetricsRecordRef mMetricsRecordRef;
+    std::unordered_map<std::string, CounterPtr> mCounters;
+    std::unordered_map<std::string, IntGaugePtr> mIntGauges;
 
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class PrometheusInputRunnerUnittest;

--- a/core/prometheus/PrometheusInputRunner.h
+++ b/core/prometheus/PrometheusInputRunner.h
@@ -45,7 +45,8 @@ public:
 
     // input plugin update
     void UpdateScrapeInput(std::shared_ptr<TargetSubscriberScheduler> targetSubscriber,
-                           const MetricLabels& defaultLabels);
+                           const MetricLabels& defaultLabels,
+                           const std::string& projectName);
     void RemoveScrapeInput(const std::string& jobName);
 
     // target discover and scrape
@@ -59,6 +60,8 @@ private:
 
     void CancelAllTargetSubscriber();
     void SubscribeOnce();
+
+    std::string GetAllProjects();
 
     bool mIsStarted = false;
     std::mutex mStartMutex;
@@ -80,9 +83,12 @@ private:
     std::atomic<uint64_t> mUnRegisterMs;
 
     // self monitor
+    ReadWriteLock mProjectRWLock;
+    std::map<std::string, std::string> mJobNameToProjectNameMap;
     MetricsRecordRef mMetricsRecordRef;
-    std::unordered_map<std::string, CounterPtr> mCounters;
-    std::unordered_map<std::string, IntGaugePtr> mIntGauges;
+    CounterPtr mPromRegisterRetryTotal;
+    IntGaugePtr mPromRegisterState;
+    IntGaugePtr mPromJobNum;
 
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class PrometheusInputRunnerUnittest;

--- a/core/prometheus/schedulers/ScrapeScheduler.cpp
+++ b/core/prometheus/schedulers/ScrapeScheduler.cpp
@@ -61,9 +61,9 @@ ScrapeScheduler::ScrapeScheduler(std::shared_ptr<ScrapeConfig> scrapeConfigPtr,
 }
 
 void ScrapeScheduler::OnMetricResult(const HttpResponse& response, uint64_t timestampMilliSec) {
-    mSelfMonitor->CounterAdd(METRIC_PLUGIN_OUT_EVENTS_TOTAL, response.mStatusCode);
-    mSelfMonitor->CounterAdd(METRIC_PLUGIN_OUT_SIZE_BYTES, response.mStatusCode, response.mBody.size());
-    mSelfMonitor->CounterAdd(
+    mSelfMonitor->AddCounter(METRIC_PLUGIN_OUT_EVENTS_TOTAL, response.mStatusCode);
+    mSelfMonitor->AddCounter(METRIC_PLUGIN_OUT_SIZE_BYTES, response.mStatusCode, response.mBody.size());
+    mSelfMonitor->AddCounter(
         METRIC_PLUGIN_PROM_SCRAPE_TIME_MS, response.mStatusCode, GetCurrentTimeInMilliSeconds() - timestampMilliSec);
 
     mScrapeTimestampMilliSec = timestampMilliSec;
@@ -205,7 +205,7 @@ void ScrapeScheduler::SetTimer(std::shared_ptr<Timer> timer) {
 }
 
 void ScrapeScheduler::InitSelfMonitor(const MetricLabels& defaultLabels) {
-    mSelfMonitor = std::make_shared<PromSelfMonitor>();
+    mSelfMonitor = std::make_shared<PromSelfMonitorUnsafe>();
     MetricLabels labels = defaultLabels;
     labels.emplace_back(METRIC_LABEL_KEY_INSTANCE, mInstance);
 

--- a/core/prometheus/schedulers/ScrapeScheduler.h
+++ b/core/prometheus/schedulers/ScrapeScheduler.h
@@ -89,6 +89,7 @@ private:
     std::shared_ptr<PromSelfMonitor> mSelfMonitor;
     MetricsRecordRef mMetricsRecordRef;
     CounterPtr mPromDelayTotal;
+    CounterPtr mPluginTotalDelayMs;
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class ProcessorParsePrometheusMetricUnittest;
     friend class ScrapeSchedulerUnittest;

--- a/core/prometheus/schedulers/ScrapeScheduler.h
+++ b/core/prometheus/schedulers/ScrapeScheduler.h
@@ -86,7 +86,7 @@ private:
     bool mUpState = true;
 
     // self monitor
-    std::shared_ptr<PromSelfMonitor> mSelfMonitor;
+    std::shared_ptr<PromSelfMonitorUnsafe> mSelfMonitor;
     MetricsRecordRef mMetricsRecordRef;
     CounterPtr mPromDelayTotal;
     CounterPtr mPluginTotalDelayMs;

--- a/core/prometheus/schedulers/ScrapeScheduler.h
+++ b/core/prometheus/schedulers/ScrapeScheduler.h
@@ -23,9 +23,11 @@
 #include "common/http/HttpResponse.h"
 #include "common/timer/Timer.h"
 #include "models/PipelineEventGroup.h"
+#include "monitor/LoongCollectorMetricTypes.h"
+#include "pipeline/queue/QueueKey.h"
+#include "prometheus/PromSelfMonitor.h"
 #include "prometheus/labels/TextParser.h"
 #include "prometheus/schedulers/ScrapeConfig.h"
-#include "pipeline/queue/QueueKey.h"
 
 #ifdef APSARA_UNIT_TEST_MAIN
 #include "pipeline/queue/ProcessQueueItem.h"
@@ -52,6 +54,7 @@ public:
     void ScheduleNext() override;
     void ScrapeOnce(std::chrono::steady_clock::time_point execTime);
     void Cancel() override;
+    void InitSelfMonitor(const MetricLabels&);
 
 private:
     void PushEventGroup(PipelineEventGroup&&);
@@ -81,6 +84,11 @@ private:
     double mScrapeDurationSeconds = 0;
     uint64_t mScrapeResponseSizeBytes = 0;
     bool mUpState = true;
+
+    // self monitor
+    std::shared_ptr<PromSelfMonitor> mSelfMonitor;
+    MetricsRecordRef mMetricsRecordRef;
+    CounterPtr mPromDelayTotal;
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class ProcessorParsePrometheusMetricUnittest;
     friend class ScrapeSchedulerUnittest;

--- a/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
+++ b/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
@@ -80,6 +80,7 @@ void TargetSubscriberScheduler::OnSubscription(const HttpResponse& response, uin
         = BuildScrapeSchedulerSet(targetGroup);
     UpdateScrapeScheduler(newScrapeSchedulerSet);
     mPromSubscriberTargets->Set(mScrapeSchedulerMap.size());
+    mTotalDelayMs->Add(GetCurrentTimeInMilliSeconds() - timestampMilliSec);
 }
 
 void TargetSubscriberScheduler::UpdateScrapeScheduler(
@@ -335,6 +336,7 @@ void TargetSubscriberScheduler::InitSelfMonitor(const MetricLabels& defaultLabel
 
     WriteMetrics::GetInstance()->PrepareMetricsRecordRef(mMetricsRecordRef, std::move(mDefaultLabels));
     mPromSubscriberTargets = mMetricsRecordRef.CreateIntGauge(METRIC_PLUGIN_PROM_SUBSCRIBE_TARGETS);
+    mTotalDelayMs = mMetricsRecordRef.CreateCounter(METRIC_PLUGIN_TOTAL_DELAY_MS);
 }
 
 } // namespace logtail

--- a/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
+++ b/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
@@ -58,8 +58,8 @@ bool TargetSubscriberScheduler::operator<(const TargetSubscriberScheduler& other
 }
 
 void TargetSubscriberScheduler::OnSubscription(const HttpResponse& response, uint64_t timestampMilliSec) {
-    mSelfMonitor->CounterAdd(METRIC_PLUGIN_PROM_SUBSCRIBE_TOTAL, response.mStatusCode);
-    mSelfMonitor->CounterAdd(
+    mSelfMonitor->AddCounter(METRIC_PLUGIN_PROM_SUBSCRIBE_TOTAL, response.mStatusCode);
+    mSelfMonitor->AddCounter(
         METRIC_PLUGIN_PROM_SUBSCRIBE_TIME_MS, response.mStatusCode, GetCurrentTimeInMilliSeconds() - timestampMilliSec);
     if (response.mStatusCode == 304) {
         // not modified
@@ -331,7 +331,7 @@ void TargetSubscriberScheduler::InitSelfMonitor(const MetricLabels& defaultLabel
         {METRIC_PLUGIN_PROM_SUBSCRIBE_TIME_MS, MetricType::METRIC_TYPE_COUNTER},
     };
 
-    mSelfMonitor = std::make_shared<PromSelfMonitor>();
+    mSelfMonitor = std::make_shared<PromSelfMonitorUnsafe>();
     mSelfMonitor->InitMetricManager(sSubscriberMetricKeys, mDefaultLabels);
 
     WriteMetrics::GetInstance()->PrepareMetricsRecordRef(mMetricsRecordRef, std::move(mDefaultLabels));

--- a/core/prometheus/schedulers/TargetSubscriberScheduler.h
+++ b/core/prometheus/schedulers/TargetSubscriberScheduler.h
@@ -87,6 +87,7 @@ private:
     std::shared_ptr<PromSelfMonitor> mSelfMonitor;
     MetricsRecordRef mMetricsRecordRef;
     IntGaugePtr mPromSubscriberTargets;
+    CounterPtr mTotalDelayMs;
     MetricLabels mDefaultLabels;
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class TargetSubscriberSchedulerUnittest;

--- a/core/prometheus/schedulers/TargetSubscriberScheduler.h
+++ b/core/prometheus/schedulers/TargetSubscriberScheduler.h
@@ -24,11 +24,11 @@
 
 #include "common/http/HttpResponse.h"
 #include "common/timer/Timer.h"
+#include "pipeline/queue/QueueKey.h"
+#include "prometheus/PromSelfMonitor.h"
 #include "prometheus/schedulers/BaseScheduler.h"
 #include "prometheus/schedulers/ScrapeConfig.h"
 #include "prometheus/schedulers/ScrapeScheduler.h"
-#include "pipeline/queue/QueueKey.h"
-
 
 namespace logtail {
 
@@ -48,6 +48,7 @@ public:
 
     void ScheduleNext() override;
     void Cancel() override;
+    void InitSelfMonitor(const MetricLabels&);
 
     // from pipeline context
     QueueKey mQueueKey;
@@ -82,6 +83,11 @@ private:
 
     std::string mETag;
 
+    // self monitor
+    std::shared_ptr<PromSelfMonitor> mSelfMonitor;
+    MetricsRecordRef mMetricsRecordRef;
+    IntGaugePtr mPromSubscriberTargets;
+    MetricLabels mDefaultLabels;
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class TargetSubscriberSchedulerUnittest;
     friend class InputPrometheusUnittest;

--- a/core/prometheus/schedulers/TargetSubscriberScheduler.h
+++ b/core/prometheus/schedulers/TargetSubscriberScheduler.h
@@ -84,7 +84,7 @@ private:
     std::string mETag;
 
     // self monitor
-    std::shared_ptr<PromSelfMonitor> mSelfMonitor;
+    std::shared_ptr<PromSelfMonitorUnsafe> mSelfMonitor;
     MetricsRecordRef mMetricsRecordRef;
     IntGaugePtr mPromSubscriberTargets;
     CounterPtr mTotalDelayMs;

--- a/core/unittest/input/InputPrometheusUnittest.cpp
+++ b/core/unittest/input/InputPrometheusUnittest.cpp
@@ -42,10 +42,6 @@ public:
 
 protected:
     static void SetUpTestCase() {
-        setenv("POD_NAME", "prometheus-test", 1);
-        setenv("OPERATOR_HOST", "127.0.0.1", 1);
-        setenv("OPERATOR_PORT", "12345", 1);
-
         AppConfig::GetInstance()->mPurageContainerMode = true;
         PluginRegistry::GetInstance()->LoadPlugins();
     }
@@ -55,9 +51,6 @@ protected:
         ctx.SetPipeline(p);
     }
     static void TearDownTestCase() {
-        unsetenv("POD_NAME");
-        unsetenv("OPERATOR_HOST");
-        unsetenv("OPERATOR_PORT");
         PluginRegistry::GetInstance()->UnloadPlugins();
     }
 

--- a/core/unittest/prometheus/CMakeLists.txt
+++ b/core/unittest/prometheus/CMakeLists.txt
@@ -15,8 +15,10 @@
 cmake_minimum_required(VERSION 3.22)
 project(prometheus_unittest)
 
+add_executable(prom_self_monitor_unittest PromSelfMonitorUnittest.cpp)
+target_link_libraries(prom_self_monitor_unittest ${UT_BASE_TARGET})
+
 add_executable(labels_unittest LabelsUnittest.cpp)
-target_link_libraries(labels_unittest ${UT_BASE_TARGET})
 target_link_libraries(labels_unittest ${UT_BASE_TARGET})
 
 add_executable(relabel_unittest RelabelUnittest.cpp)
@@ -48,6 +50,7 @@ target_link_libraries(prom_asyn_unittest ${UT_BASE_TARGET})
 
 include(GoogleTest)
 
+gtest_discover_tests(prom_self_monitor_unittest)
 gtest_discover_tests(labels_unittest)
 gtest_discover_tests(relabel_unittest)
 gtest_discover_tests(scrape_scheduler_unittest)

--- a/core/unittest/prometheus/PromSelfMonitorUnittest.cpp
+++ b/core/unittest/prometheus/PromSelfMonitorUnittest.cpp
@@ -1,0 +1,56 @@
+
+#include "monitor/metric_constants/MetricConstants.h"
+#include "prometheus/Constants.h"
+#include "prometheus/PromSelfMonitor.h"
+#include "unittest/Unittest.h"
+using namespace std;
+
+namespace logtail {
+class PromSelfMonitorUnittest : public ::testing::Test {
+public:
+    void TestCounterAdd();
+    void TestIntGaugeSet();
+};
+
+void PromSelfMonitorUnittest::TestCounterAdd() {
+    auto selfMonitor = std::make_shared<PromSelfMonitor>();
+    std::unordered_map<std::string, MetricType> testMetricKeys = {
+        {METRIC_PLUGIN_PROM_SUBSCRIBE_TOTAL, MetricType::METRIC_TYPE_COUNTER},
+    };
+    selfMonitor->InitMetricManager(testMetricKeys, MetricLabels{});
+
+    selfMonitor->CounterAdd(METRIC_PLUGIN_PROM_SUBSCRIBE_TOTAL, 200, 999);
+
+    // check result
+    auto metric = selfMonitor->mPromStatusMap["2XX"]->GetCounter(METRIC_PLUGIN_PROM_SUBSCRIBE_TOTAL);
+    APSARA_TEST_EQUAL("plugin_prom_subscribe_total", metric->GetName());
+    APSARA_TEST_EQUAL(999ULL, metric->GetValue());
+    selfMonitor->CounterAdd(METRIC_PLUGIN_PROM_SUBSCRIBE_TOTAL, 200);
+    APSARA_TEST_EQUAL(1000ULL, metric->GetValue());
+}
+
+void PromSelfMonitorUnittest::TestIntGaugeSet() {
+    auto selfMonitor = std::make_shared<PromSelfMonitor>();
+    std::unordered_map<std::string, MetricType> testMetricKeys = {
+        {METRIC_PLUGIN_PROM_SUBSCRIBE_TARGETS, MetricType::METRIC_TYPE_INT_GAUGE},
+    };
+    selfMonitor->InitMetricManager(testMetricKeys, MetricLabels{});
+
+    auto metricLabels = std::map<std::string, std::string>({{"test-label", "test-value"}});
+    selfMonitor->IntGaugeSet(METRIC_PLUGIN_PROM_SUBSCRIBE_TARGETS, 200, 999);
+
+    // check result
+    auto metric = selfMonitor->mPromStatusMap["2XX"]->GetIntGauge(METRIC_PLUGIN_PROM_SUBSCRIBE_TARGETS);
+    APSARA_TEST_EQUAL("plugin_prom_subscribe_targets", metric->GetName());
+    APSARA_TEST_EQUAL(999ULL, metric->GetValue());
+    selfMonitor->IntGaugeSet(METRIC_PLUGIN_PROM_SUBSCRIBE_TARGETS, 200, 0);
+    APSARA_TEST_EQUAL(0ULL, metric->GetValue());
+}
+
+
+UNIT_TEST_CASE(PromSelfMonitorUnittest, TestCounterAdd)
+UNIT_TEST_CASE(PromSelfMonitorUnittest, TestIntGaugeSet)
+
+} // namespace logtail
+
+UNIT_TEST_MAIN

--- a/core/unittest/prometheus/PromSelfMonitorUnittest.cpp
+++ b/core/unittest/prometheus/PromSelfMonitorUnittest.cpp
@@ -13,37 +13,37 @@ public:
 };
 
 void PromSelfMonitorUnittest::TestCounterAdd() {
-    auto selfMonitor = std::make_shared<PromSelfMonitor>();
+    auto selfMonitor = std::make_shared<PromSelfMonitorUnsafe>();
     std::unordered_map<std::string, MetricType> testMetricKeys = {
         {METRIC_PLUGIN_PROM_SUBSCRIBE_TOTAL, MetricType::METRIC_TYPE_COUNTER},
     };
     selfMonitor->InitMetricManager(testMetricKeys, MetricLabels{});
 
-    selfMonitor->CounterAdd(METRIC_PLUGIN_PROM_SUBSCRIBE_TOTAL, 200, 999);
+    selfMonitor->AddCounter(METRIC_PLUGIN_PROM_SUBSCRIBE_TOTAL, 200, 999);
 
     // check result
     auto metric = selfMonitor->mPromStatusMap["2XX"]->GetCounter(METRIC_PLUGIN_PROM_SUBSCRIBE_TOTAL);
     APSARA_TEST_EQUAL("plugin_prom_subscribe_total", metric->GetName());
     APSARA_TEST_EQUAL(999ULL, metric->GetValue());
-    selfMonitor->CounterAdd(METRIC_PLUGIN_PROM_SUBSCRIBE_TOTAL, 200);
+    selfMonitor->AddCounter(METRIC_PLUGIN_PROM_SUBSCRIBE_TOTAL, 200);
     APSARA_TEST_EQUAL(1000ULL, metric->GetValue());
 }
 
 void PromSelfMonitorUnittest::TestIntGaugeSet() {
-    auto selfMonitor = std::make_shared<PromSelfMonitor>();
+    auto selfMonitor = std::make_shared<PromSelfMonitorUnsafe>();
     std::unordered_map<std::string, MetricType> testMetricKeys = {
         {METRIC_PLUGIN_PROM_SUBSCRIBE_TARGETS, MetricType::METRIC_TYPE_INT_GAUGE},
     };
     selfMonitor->InitMetricManager(testMetricKeys, MetricLabels{});
 
     auto metricLabels = std::map<std::string, std::string>({{"test-label", "test-value"}});
-    selfMonitor->IntGaugeSet(METRIC_PLUGIN_PROM_SUBSCRIBE_TARGETS, 200, 999);
+    selfMonitor->SetIntGauge(METRIC_PLUGIN_PROM_SUBSCRIBE_TARGETS, 200, 999);
 
     // check result
     auto metric = selfMonitor->mPromStatusMap["2XX"]->GetIntGauge(METRIC_PLUGIN_PROM_SUBSCRIBE_TARGETS);
     APSARA_TEST_EQUAL("plugin_prom_subscribe_targets", metric->GetName());
     APSARA_TEST_EQUAL(999ULL, metric->GetValue());
-    selfMonitor->IntGaugeSet(METRIC_PLUGIN_PROM_SUBSCRIBE_TARGETS, 200, 0);
+    selfMonitor->SetIntGauge(METRIC_PLUGIN_PROM_SUBSCRIBE_TARGETS, 200, 0);
     APSARA_TEST_EQUAL(0ULL, metric->GetValue());
 }
 

--- a/core/unittest/prometheus/PrometheusInputRunnerUnittest.cpp
+++ b/core/unittest/prometheus/PrometheusInputRunnerUnittest.cpp
@@ -63,8 +63,9 @@ void PrometheusInputRunnerUnittest::OnSuccessfulStartAndStop() {
     std::unique_ptr<TargetSubscriberScheduler> scrapeJobPtr = make_unique<TargetSubscriberScheduler>();
     APSARA_TEST_TRUE(scrapeJobPtr->Init(config));
 
+    auto defaultLabels = MetricLabels();
     // update scrapeJob
-    PrometheusInputRunner::GetInstance()->UpdateScrapeInput(std::move(scrapeJobPtr));
+    PrometheusInputRunner::GetInstance()->UpdateScrapeInput(std::move(scrapeJobPtr), defaultLabels);
 
     PrometheusInputRunner::GetInstance()->Init();
     APSARA_TEST_TRUE(PrometheusInputRunner::GetInstance()->mTargetSubscriberSchedulerMap.find("test_job")
@@ -104,7 +105,8 @@ void PrometheusInputRunnerUnittest::TestHasRegisteredPlugins() {
 
     std::unique_ptr<TargetSubscriberScheduler> scrapeJobPtr = make_unique<TargetSubscriberScheduler>();
     APSARA_TEST_TRUE(scrapeJobPtr->Init(config));
-    PrometheusInputRunner::GetInstance()->UpdateScrapeInput(std::move(scrapeJobPtr));
+    auto defaultLabels = MetricLabels();
+    PrometheusInputRunner::GetInstance()->UpdateScrapeInput(std::move(scrapeJobPtr), defaultLabels);
     APSARA_TEST_TRUE(PrometheusInputRunner::GetInstance()->HasRegisteredPlugins());
     PrometheusInputRunner::GetInstance()->Stop();
 }

--- a/core/unittest/prometheus/PrometheusInputRunnerUnittest.cpp
+++ b/core/unittest/prometheus/PrometheusInputRunnerUnittest.cpp
@@ -15,10 +15,9 @@
  */
 
 #include <json/json.h>
+#include <json/value.h>
 
-#include "Common.h"
-#include "JsonUtil.h"
-#include "json/value.h"
+#include "common/JsonUtil.h"
 #include "prometheus/PrometheusInputRunner.h"
 #include "unittest/Unittest.h"
 
@@ -31,6 +30,7 @@ public:
     void OnSuccessfulStartAndStop();
     void TestHasRegisteredPlugins();
     void TestMulitStartAndStop();
+    void TestGetAllProjects();
 
 protected:
     void SetUp() override {
@@ -64,13 +64,14 @@ void PrometheusInputRunnerUnittest::OnSuccessfulStartAndStop() {
     APSARA_TEST_TRUE(scrapeJobPtr->Init(config));
 
     auto defaultLabels = MetricLabels();
+    string defaultProject = "default_project";
     // update scrapeJob
-    PrometheusInputRunner::GetInstance()->UpdateScrapeInput(std::move(scrapeJobPtr), defaultLabels);
+    PrometheusInputRunner::GetInstance()->UpdateScrapeInput(std::move(scrapeJobPtr), defaultLabels, defaultProject);
 
     PrometheusInputRunner::GetInstance()->Init();
     APSARA_TEST_TRUE(PrometheusInputRunner::GetInstance()->mTargetSubscriberSchedulerMap.find("test_job")
                      != PrometheusInputRunner::GetInstance()->mTargetSubscriberSchedulerMap.end());
-
+    APSARA_TEST_EQUAL(PrometheusInputRunner::GetInstance()->mJobNameToProjectNameMap["test_job"], defaultProject);
 
     // remove
     PrometheusInputRunner::GetInstance()->RemoveScrapeInput("test_job");
@@ -106,7 +107,8 @@ void PrometheusInputRunnerUnittest::TestHasRegisteredPlugins() {
     std::unique_ptr<TargetSubscriberScheduler> scrapeJobPtr = make_unique<TargetSubscriberScheduler>();
     APSARA_TEST_TRUE(scrapeJobPtr->Init(config));
     auto defaultLabels = MetricLabels();
-    PrometheusInputRunner::GetInstance()->UpdateScrapeInput(std::move(scrapeJobPtr), defaultLabels);
+    string defaultProject = "default_project";
+    PrometheusInputRunner::GetInstance()->UpdateScrapeInput(std::move(scrapeJobPtr), defaultLabels, defaultProject);
     APSARA_TEST_TRUE(PrometheusInputRunner::GetInstance()->HasRegisteredPlugins());
     PrometheusInputRunner::GetInstance()->Stop();
 }
@@ -139,9 +141,56 @@ void PrometheusInputRunnerUnittest::TestMulitStartAndStop() {
     }
 }
 
+void PrometheusInputRunnerUnittest::TestGetAllProjects() {
+    // build scrape job and target
+    string errorMsg;
+    string configStr;
+    Json::Value config;
+
+    // test_job1
+    configStr = R"JSON(
+    {
+        "job_name": "test_job1",
+        "scheme": "http",
+        "metrics_path": "/metrics",
+        "scrape_interval": "30s",
+        "scrape_timeout": "30s"
+    }
+    )JSON";
+    APSARA_TEST_TRUE(ParseJsonTable(configStr, config, errorMsg));
+
+    std::unique_ptr<TargetSubscriberScheduler> scrapeJobPtr1 = make_unique<TargetSubscriberScheduler>();
+    APSARA_TEST_TRUE(scrapeJobPtr1->Init(config));
+    auto defaultLabels = MetricLabels();
+    string defaultProject = "default_project";
+    // update scrapeJob
+    PrometheusInputRunner::GetInstance()->UpdateScrapeInput(std::move(scrapeJobPtr1), defaultLabels, defaultProject);
+
+    // test_job2
+    configStr = R"JSON(
+    {
+        "job_name": "test_job2",
+        "scheme": "http",
+        "metrics_path": "/metrics",
+        "scrape_interval": "30s",
+        "scrape_timeout": "30s"
+    }
+    )JSON";
+    APSARA_TEST_TRUE(ParseJsonTable(configStr, config, errorMsg));
+    std::unique_ptr<TargetSubscriberScheduler> scrapeJobPtr2 = make_unique<TargetSubscriberScheduler>();
+    APSARA_TEST_TRUE(scrapeJobPtr2->Init(config));
+    defaultProject = "default_project2";
+    // update scrapeJob
+    PrometheusInputRunner::GetInstance()->UpdateScrapeInput(std::move(scrapeJobPtr2), defaultLabels, defaultProject);
+
+    // Runner use map to store scrape job, so the order is test_job1, test_job2
+    APSARA_TEST_TRUE(PrometheusInputRunner::GetInstance()->GetAllProjects() == "default_project default_project2");
+}
+
 UNIT_TEST_CASE(PrometheusInputRunnerUnittest, OnSuccessfulStartAndStop)
-// UNIT_TEST_CASE(PrometheusInputRunnerUnittest, TestHasRegisteredPlugins)
-// UNIT_TEST_CASE(PrometheusInputRunnerUnittest, TestMulitStartAndStop)
+UNIT_TEST_CASE(PrometheusInputRunnerUnittest, TestHasRegisteredPlugins)
+UNIT_TEST_CASE(PrometheusInputRunnerUnittest, TestMulitStartAndStop)
+UNIT_TEST_CASE(PrometheusInputRunnerUnittest, TestGetAllProjects)
 
 } // namespace logtail
 

--- a/core/unittest/prometheus/ScrapeSchedulerUnittest.cpp
+++ b/core/unittest/prometheus/ScrapeSchedulerUnittest.cpp
@@ -94,6 +94,8 @@ void ScrapeSchedulerUnittest::TestProcess() {
     labels.Set(prometheus::ADDRESS_LABEL_NAME, "localhost:8080");
     labels.Set(prometheus::ADDRESS_LABEL_NAME, "localhost:8080");
     ScrapeScheduler event(mScrapeConfig, "localhost", 8080, labels, 0, 0);
+    auto defaultLabels = MetricLabels();
+    event.InitSelfMonitor(defaultLabels);
     APSARA_TEST_EQUAL(event.GetId(), "test_jobhttp://localhost:8080/metrics" + ToString(labels.Hash()));
     // if status code is not 200, no data will be processed
     // but will continue running, sending self-monitoring metrics
@@ -175,6 +177,8 @@ void ScrapeSchedulerUnittest::TestQueueIsFull() {
     Labels labels;
     labels.Set(prometheus::ADDRESS_LABEL_NAME, "localhost:8080");
     ScrapeScheduler event(mScrapeConfig, "localhost", 8080, labels, 0, 0);
+    auto defaultLabels = MetricLabels();
+    event.InitSelfMonitor(defaultLabels);
     auto timer = make_shared<Timer>();
     event.SetTimer(timer);
     auto now = std::chrono::steady_clock::now();

--- a/core/unittest/prometheus/TargetSubscriberSchedulerUnittest.cpp
+++ b/core/unittest/prometheus/TargetSubscriberSchedulerUnittest.cpp
@@ -37,9 +37,6 @@ public:
 
 protected:
     void SetUp() override {
-        setenv("POD_NAME", "prometheus-test", 1);
-        setenv("OPERATOR_HOST", "127.0.0.1", 1);
-        setenv("OPERATOR_PORT", "12345", 1);
         {
             mConfigString = R"JSON(
 {
@@ -133,9 +130,6 @@ protected:
         }
     }
     void TearDown() override {
-        unsetenv("POD_NAME");
-        unsetenv("OPERATOR_HOST");
-        unsetenv("OPERATOR_PORT");
     }
 
 private:

--- a/core/unittest/prometheus/TargetSubscriberSchedulerUnittest.cpp
+++ b/core/unittest/prometheus/TargetSubscriberSchedulerUnittest.cpp
@@ -129,8 +129,7 @@ protected:
     ])JSON";
         }
     }
-    void TearDown() override {
-    }
+    void TearDown() override {}
 
 private:
     HttpResponse mHttpResponse;
@@ -149,7 +148,9 @@ void TargetSubscriberSchedulerUnittest::OnInitScrapeJobEvent() {
 
 void TargetSubscriberSchedulerUnittest::TestProcess() {
     std::shared_ptr<TargetSubscriberScheduler> targetSubscriber = std::make_shared<TargetSubscriberScheduler>();
+    auto metricLabels = MetricLabels();
     APSARA_TEST_TRUE(targetSubscriber->Init(mConfig["ScrapeConfig"]));
+    targetSubscriber->InitSelfMonitor(metricLabels);
 
     // if status code is not 200
     mHttpResponse.mStatusCode = 404;


### PR DESCRIPTION

指标 | 描述 | labels | 类型
-- | -- | -- | --
prom_register_state | 注册状态 | pod_name,operator_host,operator_port | IntGauge
prom_register_retry_total | 注册重试 | status,pod_name,... | Counter
prom_job_num | 输入插件（Job）数量 | pod_name,... | IntGauge
prom_subsricbe_targets | 订阅的 Targets 数量 | job,pod_name,... | IntGauge
prom_subsricbe_total | 订阅次数总量 | status,job,pod_name,... | Counter
prom_subsricbe_time_ms | 订阅耗时（分布） | status,job,pod_name,... | IntGauge
prom_scrape_total | 采集次数总量 | status,target,job,pod_name,... | Counter
prom_scrape_bytes_total | 采集总字节数 | status,target,job,pod_name,... | Counter
prom_scrape_time_ms | 采集耗时（分布） | status,target,job,pod_name,... | IntGauge
prom_scrape_delay_total | 采集延迟总量  | status,target,job,pod_name,... | Counter
