### PR TITLE
optimization: optimize the use of logEvents crated by split-by-lines,  record labels start with "__" in relabel processor

### DIFF
--- a/core/plugin/processor/inner/ProcessorPromParseMetricNative.h
+++ b/core/plugin/processor/inner/ProcessorPromParseMetricNative.h
@@ -21,7 +21,6 @@ protected:
     bool IsSupportedEvent(const PipelineEventPtr&) const override;
 
 private:
-    bool ProcessEvent(PipelineEventPtr&, EventsContainer&, PipelineEventGroup&, TextParser& parser);
     std::unique_ptr<ScrapeConfig> mScrapeConfigPtr;
 
 #ifdef APSARA_UNIT_TEST_MAIN

--- a/core/plugin/processor/inner/ProcessorPromRelabelMetricNative.cpp
+++ b/core/plugin/processor/inner/ProcessorPromRelabelMetricNative.cpp
@@ -86,44 +86,38 @@ bool ProcessorPromRelabelMetricNative::ProcessEvent(PipelineEventPtr& e, const G
         return false;
     }
     auto& sourceEvent = e.Cast<MetricEvent>();
-    if (!mScrapeConfigPtr->mHonorLabels) {
-        // metric event labels is secondary
-        // if confiliction, then rename it exported_<label_name>
-        for (const auto& [k, v] : targetTags) {
-            if (sourceEvent.HasTag(k)) {
+    // delete tag __<label_name>
+    vector<string> toDelete;
+
+    for (const auto& [k, v] : targetTags) {
+        if (sourceEvent.HasTag(k)) {
+            if (!mScrapeConfigPtr->mHonorLabels) {
+                // metric event labels is secondary
+                // if confiliction, then rename it exported_<label_name>
                 auto key = prometheus::EXPORTED_PREFIX + k.to_string();
                 sourceEvent.SetTag(key, sourceEvent.GetTag(k).to_string());
                 sourceEvent.DelTag(k);
-            } else {
-                sourceEvent.SetTag(k, v);
             }
-        }
-    } else {
-        // if mHonorLabels is true, then keep sourceEvent labels
-        for (const auto& [k, v] : targetTags) {
-            if (!sourceEvent.HasTag(k)) {
-                sourceEvent.SetTag(k, v);
+        } else {
+            if (k.starts_with("__")) {
+                toDelete.push_back(k.to_string());
             }
+            sourceEvent.SetTagNoCopy(k, v);
         }
     }
 
     if (!mScrapeConfigPtr->mMetricRelabelConfigs.Empty()
-        && !mScrapeConfigPtr->mMetricRelabelConfigs.Process(sourceEvent)) {
+        && !mScrapeConfigPtr->mMetricRelabelConfigs.Process(sourceEvent, toDelete)) {
         return false;
     }
     // set metricEvent name
     sourceEvent.SetNameNoCopy(sourceEvent.GetTag(prometheus::NAME));
 
 
-    // delete tag __<label_name>
-    vector<StringView> toDelete;
-    for (auto it = sourceEvent.TagsBegin(); it != sourceEvent.TagsEnd(); ++it) {
-        if (it->first.starts_with("__")) {
-            toDelete.push_back(it->first);
-        }
-    }
     for (const auto& k : toDelete) {
-        sourceEvent.DelTag(k);
+        if (sourceEvent.HasTag(k)) {
+            sourceEvent.DelTag(k);
+        }
     }
 
     // set metricEvent name

--- a/core/prometheus/Utils.cpp
+++ b/core/prometheus/Utils.cpp
@@ -124,6 +124,18 @@ void SplitStringView(const std::string& s, char delimiter, std::vector<StringVie
     }
 }
 
+void SplitStringView(StringView s, char delimiter, std::vector<StringView>& result) {
+    size_t start = 0;
+    size_t end = 0;
+    while ((end = s.find(delimiter, start)) != std::string::npos) {
+        result.emplace_back(s.data() + start, end - start);
+        start = end + 1;
+    }
+    if (start < s.size()) {
+        result.emplace_back(s.data() + start, s.size() - start);
+    }
+}
+
 bool IsNumber(const std::string& str) {
     return !str.empty() && str.find_first_not_of("0123456789") == std::string::npos;
 }

--- a/core/prometheus/Utils.h
+++ b/core/prometheus/Utils.h
@@ -16,6 +16,7 @@ uint64_t SizeToByte(const std::string& size);
 
 bool IsValidMetric(const StringView& line);
 void SplitStringView(const std::string& s, char delimiter, std::vector<StringView>& result);
+void SplitStringView(StringView s, char delimiter, std::vector<StringView>& result);
 bool IsNumber(const std::string& str);
 
 uint64_t GetRandSleepMilliSec(const std::string& key, uint64_t intervalSeconds, uint64_t currentMilliSeconds);

--- a/core/prometheus/labels/Relabel.cpp
+++ b/core/prometheus/labels/Relabel.cpp
@@ -116,13 +116,16 @@ bool RelabelConfig::Init(const Json::Value& config) {
     return true;
 }
 
-bool RelabelConfig::Process(Labels& l) const {
+bool RelabelConfig::Process(Labels& l, vector<string>& toDelete) const {
     vector<string> values;
     values.reserve(mSourceLabels.size());
     for (const auto& item : mSourceLabels) {
         values.push_back(l.Get(item));
     }
     string val = boost::algorithm::join(values, mSeparator);
+    if (StartWith(mTargetLabel, "__")) {
+        toDelete.push_back(mTargetLabel);
+    }
 
     switch (mAction) {
         case Action::DROP: {
@@ -161,6 +164,9 @@ bool RelabelConfig::Process(Labels& l) const {
                 l.Del(target);
                 break;
             }
+            if (StartWith(target, "__")) {
+                toDelete.push_back(target);
+            }
             l.Set(target, string(res));
             break;
         }
@@ -190,6 +196,9 @@ bool RelabelConfig::Process(Labels& l) const {
                     string res
                         = boost::regex_replace(key, mRegex, mReplacement, boost::match_default | boost::format_all);
                     l.Set(res, value);
+                    if (StartWith(res, "__")) {
+                        toDelete.push_back(res);
+                    }
                 }
             });
             break;
@@ -241,19 +250,19 @@ bool RelabelConfigList::Init(const Json::Value& relabelConfigs) {
     return true;
 }
 
-bool RelabelConfigList::Process(Labels& l) const {
+bool RelabelConfigList::Process(Labels& l, vector<string>& toDelete) const {
     for (const auto& cfg : mRelabelConfigs) {
-        if (!cfg.Process(l)) {
+        if (!cfg.Process(l, toDelete)) {
             return false;
         }
     }
     return true;
 }
 
-bool RelabelConfigList::Process(MetricEvent& event) const {
+bool RelabelConfigList::Process(MetricEvent& event, vector<string>& toDelete) const {
     Labels labels;
     labels.Reset(&event);
-    return Process(labels);
+    return Process(labels, toDelete);
 }
 
 bool RelabelConfigList::Empty() const {

--- a/core/prometheus/labels/Relabel.h
+++ b/core/prometheus/labels/Relabel.h
@@ -46,7 +46,7 @@ class RelabelConfig {
 public:
     RelabelConfig();
     bool Init(const Json::Value&);
-    bool Process(Labels&) const;
+    bool Process(Labels&, std::vector<std::string>& toDelete) const;
 
     // A list of labels from which values are taken and concatenated
     // with the configured separator in order.
@@ -71,8 +71,8 @@ private:
 class RelabelConfigList {
 public:
     bool Init(const Json::Value& relabelConfigs);
-    bool Process(MetricEvent&) const;
-    bool Process(Labels&) const;
+    bool Process(MetricEvent&, std::vector<std::string>& toDelete) const;
+    bool Process(Labels&, std::vector<std::string>& toDelete) const;
 
     [[nodiscard]] bool Empty() const;
 

--- a/core/prometheus/labels/TextParser.h
+++ b/core/prometheus/labels/TextParser.h
@@ -33,6 +33,7 @@ public:
     void SetDefaultTimestamp(uint64_t defaultTimestamp, uint32_t defaultNanoSec);
 
     PipelineEventGroup Parse(const std::string& content, uint64_t defaultTimestamp, uint32_t defaultNanoSec);
+    bool Parse(StringView content, PipelineEventGroup&);
     PipelineEventGroup BuildLogGroup(const std::string& content);
 
     bool ParseLine(StringView line, MetricEvent& metricEvent);

--- a/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
+++ b/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
@@ -188,11 +188,8 @@ TargetSubscriberScheduler::BuildScrapeSchedulerSet(std::vector<Labels>& targetGr
     for (const auto& labels : targetGroups) {
         // Relabel Config
         Labels resultLabel = labels;
-        // bool keep = prometheus::Process(labels, mScrapeConfigPtr->mRelabelConfigs, resultLabel);
-        // if (!keep) {
-        //     continue;
-        // }
-        if (!mScrapeConfigPtr->mRelabelConfigs.Process(resultLabel)) {
+        vector<string> toDelete;
+        if (!mScrapeConfigPtr->mRelabelConfigs.Process(resultLabel, toDelete)) {
             continue;
         }
         resultLabel.RemoveMetaLabels();


### PR DESCRIPTION
Profiling 数据对指标处理过程进行优化
1. 优化掉中间 LogEvents，带来约 33MB/340MB 的内存优化
2. 降低 Relabel 过程对 MetricEvent 的 Tags 的遍历消耗