### PR TITLE
Fix the checkContainerType out-of-bounds memory issue

### DIFF
--- a/core/reader/LogFileReader.cpp
+++ b/core/reader/LogFileReader.cpp
@@ -687,7 +687,7 @@ void LogFileReader::SetFilePosBackwardToFixedPos(LogFileOperator& op) {
 
 void LogFileReader::checkContainerType(LogFileOperator& op) {
     // 判断container类型
-    char containerBOMBuffer[1] = {0};
+    char containerBOMBuffer[2] = {0};
     size_t readBOMByte = 1;
     int64_t filePos = 0;
     TruncateInfo* truncateInfo = NULL;


### PR DESCRIPTION
This pull request introduces a small but important change to the `LogFileReader` class in the `core/reader/LogFileReader.cpp` file. The modification adjusts the size of the `containerBOMBuffer` array to ensure correct container type checking and prevent memory overruns.

* [`core/reader/LogFileReader.cpp`](diffhunk://#diff-c4ac3e4e54f269c40ee3c6cfdc4f41148b532ad0aa1b19949c994553c283d6b1L690-R690): Increased the size of the `containerBOMBuffer` array from 1 to 2 in the `checkContainerType` method.