### PR TITLE
fix deadlock on LogInput and Processor Runner thread

### DIFF
--- a/core/file_server/event/BlockEventManager.cpp
+++ b/core/file_server/event/BlockEventManager.cpp
@@ -12,23 +12,69 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "BlockEventManager.h"
+#include "file_server/event/BlockEventManager.h"
 
+#include "common/Flags.h"
 #include "common/HashUtil.h"
 #include "common/StringTools.h"
-#include "file_server/polling/PollingEventQueue.h"
-#include "pipeline/queue/ProcessQueueManager.h"
 #include "logger/Logger.h"
+#include "pipeline/queue/ProcessQueueManager.h"
 
 DEFINE_FLAG_INT32(max_block_event_timeout, "max block event timeout, seconds", 3);
 
+using namespace std;
+
 namespace logtail {
 
-void BlockedEventManager::UpdateBlockEvent(QueueKey logstoreKey,
-                                           const std::string& configName,
-                                           const Event& event,
-                                           const DevInode& devInode,
-                                           int32_t curTime) {
+BlockedEventManager::BlockedEvent::BlockedEvent() : mInvalidTime(time(NULL)) {
+}
+
+void BlockedEventManager::BlockedEvent::Update(QueueKey key, Event* pEvent, int32_t curTime) {
+    if (mEvent != NULL) {
+        // There are only two situations where event coverage is possible
+        // 1. the new event is not timeout event
+        // 2. old event is timeout event
+        if (!pEvent->IsReaderFlushTimeout() || mEvent->IsReaderFlushTimeout()) {
+            delete mEvent;
+        } else {
+            return;
+        }
+    }
+    mEvent = pEvent;
+    mQueueKey = key;
+    // will become traditional block event if processor queue is not ready
+    if (mEvent->IsReaderFlushTimeout()) {
+        mTimeout = curTime - mInvalidTime;
+    } else {
+        mTimeout = (curTime - mInvalidTime) * 2 + 1;
+        if (mTimeout > INT32_FLAG(max_block_event_timeout)) {
+            mTimeout = INT32_FLAG(max_block_event_timeout);
+        }
+    }
+}
+
+void BlockedEventManager::BlockedEvent::SetInvalidAgain() {
+    mTimeout *= 2;
+    if (mTimeout > INT32_FLAG(max_block_event_timeout)) {
+        mTimeout = INT32_FLAG(max_block_event_timeout);
+    }
+}
+
+BlockedEventManager::~BlockedEventManager() {
+    for (auto iter = mEventMap.begin(); iter != mEventMap.end(); ++iter) {
+        if (iter->second.mEvent != nullptr) {
+            delete iter->second.mEvent;
+        }
+    }
+}
+
+void BlockedEventManager::Feedback(int64_t key) {
+    lock_guard<mutex> lock(mFeedbackQueueLock);
+    mFeedbackQueue.emplace_back(key);
+}
+
+void BlockedEventManager::UpdateBlockEvent(
+    QueueKey logstoreKey, const string& configName, const Event& event, const DevInode& devInode, int32_t curTime) {
     // need to create a new event
     Event* pEvent = new Event(event);
     int64_t hashKey = pEvent->GetHashKey();
@@ -38,7 +84,7 @@ void BlockedEventManager::UpdateBlockEvent(QueueKey logstoreKey,
         pEvent->SetConfigName(configName);
         pEvent->SetDev(devInode.dev);
         pEvent->SetInode(devInode.inode);
-        std::string key;
+        string key;
         key.append(pEvent->GetSource())
             .append(">")
             .append(pEvent->GetObject())
@@ -53,65 +99,45 @@ void BlockedEventManager::UpdateBlockEvent(QueueKey logstoreKey,
     LOG_DEBUG(sLogger,
               ("Add block event ", pEvent->GetSource())(pEvent->GetObject(),
                                                         pEvent->GetInode())(pEvent->GetConfigName(), hashKey));
-    ScopedSpinLock lock(mLock);
-    mBlockEventMap[hashKey].Update(logstoreKey, pEvent, curTime);
+    lock_guard<mutex> lock(mEventMapLock);
+    mEventMap[hashKey].Update(logstoreKey, pEvent, curTime);
 }
 
-void BlockedEventManager::GetTimeoutEvent(std::vector<Event*>& eventVec, int32_t curTime) {
-    ScopedSpinLock lock(mLock);
-    for (std::unordered_map<int64_t, BlockedEvent>::iterator iter = mBlockEventMap.begin();
-         iter != mBlockEventMap.end();) {
-        BlockedEvent& blockedEvent = iter->second;
-        if (blockedEvent.mEvent != NULL && blockedEvent.mInvalidTime + blockedEvent.mTimeout <= curTime) {
-            if (ProcessQueueManager::GetInstance()->IsValidToPush(blockedEvent.mQueueKey)) {
-                eventVec.push_back(blockedEvent.mEvent);
-                // LOG_DEBUG(sLogger, ("Get timeout block event  ",
-                // blockedEvent.mEvent->GetSource())(blockedEvent.mEvent->GetObject(),
-                // blockedEvent.mEvent->GetConfigName()));
-                iter = mBlockEventMap.erase(iter);
+void BlockedEventManager::GetTimeoutEvent(vector<Event*>& res, int32_t curTime) {
+    lock_guard<mutex> lock(mEventMapLock);
+    for (auto iter = mEventMap.begin(); iter != mEventMap.end();) {
+        auto& e = iter->second;
+        if (e.mEvent != nullptr && e.mInvalidTime + e.mTimeout <= curTime) {
+            if (ProcessQueueManager::GetInstance()->IsValidToPush(e.mQueueKey)) {
+                res.push_back(e.mEvent);
+                iter = mEventMap.erase(iter);
                 continue;
             } else {
-                blockedEvent.SetInvalidAgain(curTime);
+                e.SetInvalidAgain();
             }
         }
         ++iter;
     }
 }
 
-void BlockedEventManager::Feedback(int64_t key) {
-    // LOG_DEBUG(sLogger, ("Get feedback block event  ", key));
-    std::vector<Event*> eventVec;
+void BlockedEventManager::GetFeedbackEvent(vector<Event*>& res) {
+    vector<int64_t> keys;
     {
-        ScopedSpinLock lock(mLock);
-        for (std::unordered_map<int64_t, BlockedEvent>::iterator iter = mBlockEventMap.begin();
-             iter != mBlockEventMap.end();) {
-            BlockedEvent& blockedEvent = iter->second;
-            if (blockedEvent.mEvent != NULL && blockedEvent.mQueueKey == key) {
-                eventVec.push_back(blockedEvent.mEvent);
-                // LOG_DEBUG(sLogger, ("Get feedback block event  ",
-                // blockedEvent.mEvent->GetSource())(blockedEvent.mEvent->GetObject(),
-                // blockedEvent.mEvent->GetConfigName()));
-                iter = mBlockEventMap.erase(iter);
-            } else {
-                ++iter;
+        lock_guard<mutex> lock(mFeedbackQueueLock);
+        keys.swap(mFeedbackQueue);
+    }
+    {
+        lock_guard<mutex> lock(mEventMapLock);
+        for (auto& key : keys) {
+            for (auto iter = mEventMap.begin(); iter != mEventMap.end();) {
+                auto& e = iter->second;
+                if (e.mEvent != nullptr && e.mQueueKey == key) {
+                    res.push_back(e.mEvent);
+                    iter = mEventMap.erase(iter);
+                } else {
+                    ++iter;
+                }
             }
-        }
-    }
-    if (eventVec.size() > 0) {
-        // use polling event queue, it is thread safe
-        PollingEventQueue::GetInstance()->PushEvent(eventVec);
-    }
-}
-
-BlockedEventManager::BlockedEventManager() {
-}
-
-BlockedEventManager::~BlockedEventManager() {
-    for (std::unordered_map<int64_t, BlockedEvent>::iterator iter = mBlockEventMap.begin();
-         iter != mBlockEventMap.end();
-         ++iter) {
-        if (iter->second.mEvent != NULL) {
-            delete iter->second.mEvent;
         }
     }
 }

--- a/core/file_server/event/BlockEventManager.h
+++ b/core/file_server/event/BlockEventManager.h
@@ -64,9 +64,11 @@ private:
     BlockedEventManager() = default;
     ~BlockedEventManager();
 
-    std::mutex mEventMapMux; // currently not needed
+    // only used by LogInput thread, so currently no need
+    std::mutex mEventMapMux;
     std::unordered_map<int64_t, BlockedEvent> mEventMap;
 
+    // race condition from Processor Runner threads and LogInput thread
     std::mutex mFeedbackQueueMux;
     std::vector<int64_t> mFeedbackQueue;
 

--- a/core/file_server/event/BlockEventManager.h
+++ b/core/file_server/event/BlockEventManager.h
@@ -64,8 +64,7 @@ private:
     BlockedEventManager() = default;
     ~BlockedEventManager();
 
-    // only used by LogInput thread, so currently no need
-    std::mutex mEventMapMux;
+    // only used by LogInput thread
     std::unordered_map<int64_t, BlockedEvent> mEventMap;
 
     // race condition from Processor Runner threads and LogInput thread
@@ -74,6 +73,7 @@ private:
 
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class ForceReadUnittest;
+    friend class BlockedEventManagerUnittest;
 #endif
 };
 

--- a/core/file_server/event/BlockEventManager.h
+++ b/core/file_server/event/BlockEventManager.h
@@ -64,10 +64,10 @@ private:
     BlockedEventManager() = default;
     ~BlockedEventManager();
 
-    std::mutex mEventMapLock; // currently not needed
+    std::mutex mEventMapMux; // currently not needed
     std::unordered_map<int64_t, BlockedEvent> mEventMap;
 
-    std::mutex mFeedbackQueueLock;
+    std::mutex mFeedbackQueueMux;
     std::vector<int64_t> mFeedbackQueue;
 
 #ifdef APSARA_UNIT_TEST_MAIN

--- a/core/file_server/event_handler/LogInput.cpp
+++ b/core/file_server/event_handler/LogInput.cpp
@@ -134,6 +134,12 @@ void LogInput::TryReadEvents(bool forceRead) {
         PushEventQueue(inotifyEvents);
     }
 
+    vector<Event*> feedbackEvents;
+    BlockedEventManager::GetInstance()->GetFeedbackEvent(feedbackEvents);
+    if (feedbackEvents.size() > 0) {
+        PushEventQueue(feedbackEvents);
+    }
+
     vector<Event*> pollingEvents;
     PollingEventQueue::GetInstance()->PopAllEvents(pollingEvents);
     if (pollingEvents.size() > 0) {

--- a/core/unittest/event/BlockedEventManagerUnittest.cpp
+++ b/core/unittest/event/BlockedEventManagerUnittest.cpp
@@ -1,0 +1,49 @@
+// Copyright 2023 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "event/BlockEventManager.h"
+#include "unittest/Unittest.h"
+
+using namespace std;
+
+namespace logtail {
+
+class BlockedEventManagerUnittest : public testing::Test {
+public:
+    void OnFeedback() const;
+};
+
+void BlockedEventManagerUnittest::OnFeedback() const {
+    DevInode devInode(1, 2);
+    Event e("dir", "file", EVENT_MODIFY, 0);
+
+    BlockedEventManager::GetInstance()->UpdateBlockEvent(2, "test_config_2", e, devInode, 0);
+    BlockedEventManager::GetInstance()->UpdateBlockEvent(0, "test_config_0", e, devInode, 12345678901);
+    BlockedEventManager::GetInstance()->Feedback(1);
+    BlockedEventManager::GetInstance()->UpdateBlockEvent(0, "test_config_0", e, devInode, time(nullptr));
+    BlockedEventManager::GetInstance()->Feedback(0);
+
+    vector<Event*> res;
+    BlockedEventManager::GetInstance()->GetFeedbackEvent(res);
+    APSARA_TEST_EQUAL(1U, res.size());
+    APSARA_TEST_EQUAL("dir", res[0]->GetSource());
+    APSARA_TEST_EQUAL("file", res[0]->GetObject());
+    APSARA_TEST_EQUAL(1U, BlockedEventManager::GetInstance()->mEventMap.size());
+}
+
+UNIT_TEST_CASE(BlockedEventManagerUnittest, OnFeedback)
+
+} // namespace logtail
+
+UNIT_TEST_MAIN

--- a/core/unittest/event/CMakeLists.txt
+++ b/core/unittest/event/CMakeLists.txt
@@ -18,5 +18,9 @@ project(event_unittest)
 add_executable(event_unittest EventUnittest.cpp)
 target_link_libraries(event_unittest ${UT_BASE_TARGET})
 
+add_executable(blocked_event_manager_unittest BlockedEventManagerUnittest.cpp)
+target_link_libraries(blocked_event_manager_unittest ${UT_BASE_TARGET})
+
 include(GoogleTest)
 gtest_discover_tests(event_unittest)
+gtest_discover_tests(blocked_event_manager_unittest)

--- a/core/unittest/reader/ForceReadUnittest.cpp
+++ b/core/unittest/reader/ForceReadUnittest.cpp
@@ -348,8 +348,8 @@ void ForceReadUnittest::TestAddTimeoutEvent() {
         reader.InitReader(true, LogFileReader::BACKWARD_TO_BEGINNING);
         reader.CheckFileSignatureAndOffset(true);
         LogFileReader::BUFFER_SIZE = 10;
-        BlockedEventManager::GetInstance()->mBlockEventMap.clear();
-        APSARA_TEST_EQUAL_FATAL(BlockedEventManager::GetInstance()->mBlockEventMap.size(), 0U);
+        BlockedEventManager::GetInstance()->mEventMap.clear();
+        APSARA_TEST_EQUAL_FATAL(BlockedEventManager::GetInstance()->mEventMap.size(), 0U);
 
         ModifyHandler* pHanlder = new ModifyHandler(mConfigName, mConfig);
         pHanlder->mReadFileTimeSlice = 0; // force one read for one event
@@ -362,7 +362,7 @@ void ForceReadUnittest::TestAddTimeoutEvent() {
                          reader.mDevInode.dev,
                          reader.mDevInode.inode);
         pHanlder->Handle(e1);
-        APSARA_TEST_EQUAL_FATAL(BlockedEventManager::GetInstance()->mBlockEventMap.size(), 0U);
+        APSARA_TEST_EQUAL_FATAL(BlockedEventManager::GetInstance()->mEventMap.size(), 0U);
     }
     {
         // read all -> add timeout event
@@ -373,8 +373,8 @@ void ForceReadUnittest::TestAddTimeoutEvent() {
         reader.InitReader(true, LogFileReader::BACKWARD_TO_BEGINNING);
         reader.CheckFileSignatureAndOffset(true);
         LogFileReader::BUFFER_SIZE = 1024 * 512;
-        BlockedEventManager::GetInstance()->mBlockEventMap.clear();
-        APSARA_TEST_EQUAL_FATAL(BlockedEventManager::GetInstance()->mBlockEventMap.size(), 0U);
+        BlockedEventManager::GetInstance()->mEventMap.clear();
+        APSARA_TEST_EQUAL_FATAL(BlockedEventManager::GetInstance()->mEventMap.size(), 0U);
 
         ModifyHandler* pHanlder = new ModifyHandler(mConfigName, mConfig);
         pHanlder->mReadFileTimeSlice = 0; // force one read for one event
@@ -387,7 +387,7 @@ void ForceReadUnittest::TestAddTimeoutEvent() {
                          reader.mDevInode.dev,
                          reader.mDevInode.inode);
         pHanlder->Handle(e1);
-        APSARA_TEST_EQUAL_FATAL(BlockedEventManager::GetInstance()->mBlockEventMap.size(), 1U);
+        APSARA_TEST_EQUAL_FATAL(BlockedEventManager::GetInstance()->mEventMap.size(), 1U);
     }
 }
 


### PR DESCRIPTION
- 问题：在压测的时候小概率出现LogInput和Processor线程同时死锁
- 原因：两个线程获取两把锁的顺序相反
  - 处理线程：先获取处理队列的锁（ProcessQueueManager::mQueueMux），然后pop数据。如果队列变成低水位了，会调用BlockedEventManager::Feedback函数，该函数会对BlockEventMap加锁（BlockedEventManager::mLock）；
  - input线程：在定时调用GetTimeoutEvent函数时，首先对BlockEventMap加锁，然后通过ProcessQueueManager::IsValidToPush函数判断event对应的队列是否可用，这个时候会对处理队列加锁。
- 影响范围：仅main分支，2.0旧版实现在启用优先级队列后也有概率触发
- 解决方案：Feedback函数里仅保存信息，在LogInput线程里去消费这些feedback。