### PR TITLE
support custom http response body and body data write callback

### DIFF
--- a/core/common/common.cmake
+++ b/core/common/common.cmake
@@ -28,7 +28,7 @@ endif ()
 list(APPEND THIS_SOURCE_FILES_LIST ${XX_HASH_SOURCE_FILES})
 # add memory in common
 list(APPEND THIS_SOURCE_FILES_LIST ${CMAKE_SOURCE_DIR}/common/memory/SourceBuffer.h)
-list(APPEND THIS_SOURCE_FILES_LIST ${CMAKE_SOURCE_DIR}/common/http/AsynCurlRunner.cpp ${CMAKE_SOURCE_DIR}/common/http/Curl.cpp ${CMAKE_SOURCE_DIR}/common/http/HttpResponse.cpp)
+list(APPEND THIS_SOURCE_FILES_LIST ${CMAKE_SOURCE_DIR}/common/http/AsynCurlRunner.cpp ${CMAKE_SOURCE_DIR}/common/http/Curl.cpp ${CMAKE_SOURCE_DIR}/common/http/HttpResponse.cpp ${CMAKE_SOURCE_DIR}/common/http/HttpRequest.cpp)
 list(APPEND THIS_SOURCE_FILES_LIST ${CMAKE_SOURCE_DIR}/common/timer/Timer.cpp ${CMAKE_SOURCE_DIR}/common/timer/HttpRequestTimerEvent.cpp)
 list(APPEND THIS_SOURCE_FILES_LIST ${CMAKE_SOURCE_DIR}/common/compression/Compressor.cpp ${CMAKE_SOURCE_DIR}/common/compression/CompressorFactory.cpp ${CMAKE_SOURCE_DIR}/common/compression/LZ4Compressor.cpp ${CMAKE_SOURCE_DIR}/common/compression/ZstdCompressor.cpp)
 # remove several files in common

--- a/core/common/http/AsynCurlRunner.cpp
+++ b/core/common/http/AsynCurlRunner.cpp
@@ -189,7 +189,7 @@ void AsynCurlRunner::HandleCompletedRequests(int& runningHandlers) {
                 case CURLE_OK: {
                     long statusCode = 0;
                     curl_easy_getinfo(handler, CURLINFO_RESPONSE_CODE, &statusCode);
-                    request->mResponse.mStatusCode = (int32_t)statusCode;
+                    request->mResponse.SetStatusCode(statusCode);
                     request->OnSendDone(request->mResponse);
                     LOG_DEBUG(sLogger,
                               ("send http request succeeded, request address",

--- a/core/common/http/HttpRequest.cpp
+++ b/core/common/http/HttpRequest.cpp
@@ -1,0 +1,22 @@
+// Copyright 2024 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/http/HttpRequest.h"
+
+DEFINE_FLAG_INT32(default_http_request_timeout_secs, "", 15);
+DEFINE_FLAG_INT32(default_http_request_max_try_cnt, "", 3);
+
+using namespace std;
+
+namespace logtail {} // namespace logtail

--- a/core/common/http/HttpRequest.h
+++ b/core/common/http/HttpRequest.h
@@ -21,12 +21,13 @@
 #include <map>
 #include <string>
 
+#include "common/Flags.h"
 #include "common/http/HttpResponse.h"
 
-namespace logtail {
+DECLARE_FLAG_INT32(default_http_request_timeout_secs);
+DECLARE_FLAG_INT32(default_http_request_max_try_cnt);
 
-static constexpr uint32_t sDefaultTimeoutSec = 15;
-static constexpr uint32_t sDefaultMaxTryCnt = 3;
+namespace logtail {
 
 struct HttpRequest {
     std::string mMethod;
@@ -40,8 +41,8 @@ struct HttpRequest {
     std::string mBody;
     std::string mHost;
     int32_t mPort;
-    uint32_t mTimeout = sDefaultTimeoutSec;
-    uint32_t mMaxTryCnt = sDefaultMaxTryCnt;
+    uint32_t mTimeout = static_cast<uint32_t>(INT32_FLAG(default_http_request_timeout_secs));
+    uint32_t mMaxTryCnt = static_cast<uint32_t>(INT32_FLAG(default_http_request_max_try_cnt));
 
     uint32_t mTryCnt = 1;
     std::chrono::system_clock::time_point mLastSendTime;
@@ -54,8 +55,8 @@ struct HttpRequest {
                 const std::string& query,
                 const std::map<std::string, std::string>& header,
                 const std::string& body,
-                uint32_t timeout = sDefaultTimeoutSec,
-                uint32_t maxTryCnt = sDefaultMaxTryCnt)
+                uint32_t timeout = static_cast<uint32_t>(INT32_FLAG(default_http_request_timeout_secs)),
+                uint32_t maxTryCnt = static_cast<uint32_t>(INT32_FLAG(default_http_request_max_try_cnt)))
         : mMethod(method),
           mHTTPSFlag(httpsFlag),
           mUrl(url),
@@ -82,12 +83,14 @@ struct AsynHttpRequest : public HttpRequest {
                     const std::string& query,
                     const std::map<std::string, std::string>& header,
                     const std::string& body,
-                    uint32_t timeout = sDefaultTimeoutSec,
-                    uint32_t maxTryCnt = sDefaultMaxTryCnt)
-        : HttpRequest(method, httpsFlag, host, port, url, query, header, body, timeout, maxTryCnt) {}
+                    HttpResponse&& response = HttpResponse(),
+                    uint32_t timeout = static_cast<uint32_t>(INT32_FLAG(default_http_request_timeout_secs)),
+                    uint32_t maxTryCnt = static_cast<uint32_t>(INT32_FLAG(default_http_request_max_try_cnt)))
+        : HttpRequest(method, httpsFlag, host, port, url, query, header, body, timeout, maxTryCnt),
+          mResponse(std::move(response)) {}
 
     virtual bool IsContextValid() const = 0;
-    virtual void OnSendDone(const HttpResponse& response) = 0;
+    virtual void OnSendDone(HttpResponse& response) = 0;
 };
 
 

--- a/core/common/http/HttpResponse.cpp
+++ b/core/common/http/HttpResponse.cpp
@@ -26,4 +26,15 @@ bool compareHeader(const std::string& lhs, const std::string& rhs) {
     return lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), caseInsensitiveComp);
 }
 
+size_t DefaultWriteCallback(char* buffer, size_t size, size_t nmemb, void* data) {
+    unsigned long sizes = size * nmemb;
+
+    if (buffer == NULL) {
+        return 0;
+    }
+
+    static_cast<string*>(data)->append(buffer, sizes);
+    return sizes;
+}
+
 } // namespace logtail

--- a/core/common/http/HttpResponse.h
+++ b/core/common/http/HttpResponse.h
@@ -17,8 +17,12 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <map>
+#include <memory>
 #include <string>
+
+class curl_slist;
 
 namespace logtail {
 
@@ -26,12 +30,53 @@ bool caseInsensitiveComp(const char lhs, const char rhs);
 
 bool compareHeader(const std::string& lhs, const std::string& rhs);
 
-struct HttpResponse {
+size_t DefaultWriteCallback(char* buffer, size_t size, size_t nmemb, void* data);
+
+class HttpResponse {
+    friend void* CreateCurlHandler(const std::string& method,
+                                   bool httpsFlag,
+                                   const std::string& host,
+                                   int32_t port,
+                                   const std::string& url,
+                                   const std::string& queryString,
+                                   const std::map<std::string, std::string>& header,
+                                   const std::string& body,
+                                   HttpResponse& response,
+                                   curl_slist*& headers,
+                                   uint32_t timeout,
+                                   bool replaceHostWithIp,
+                                   const std::string& intf);
+
+public:
+    HttpResponse()
+        : mHeader(compareHeader),
+          mBody(new std::string(), [](void* p) { delete static_cast<std::string*>(p); }),
+          mWriteCallback(DefaultWriteCallback) {};
+    HttpResponse(void* body,
+                 const std::function<void(void*)>& bodyDeleter,
+                 size_t (*callback)(char*, size_t, size_t, void*))
+        : mHeader(compareHeader), mBody(body, bodyDeleter), mWriteCallback(callback) {}
+
+    int32_t GetStatusCode() const { return mStatusCode; }
+    const std::map<std::string, std::string, decltype(compareHeader)*>& GetHeader() const { return mHeader; }
+
+    template <class T>
+    const T* GetBody() const {
+        return static_cast<const T*>(mBody.get());
+    }
+
+    template <class T>
+    T* GetBody() {
+        return static_cast<T*>(mBody.get());
+    }
+
+    void SetStatusCode(int32_t code) { mStatusCode = code; }
+
+private:
     int32_t mStatusCode = 0; // 0 means no response from server
     std::map<std::string, std::string, decltype(compareHeader)*> mHeader;
-    std::string mBody;
-
-    HttpResponse(): mHeader(compareHeader) {}
+    std::unique_ptr<void, std::function<void(void*)>> mBody;
+    size_t (*mWriteCallback)(char*, size_t, size_t, void*) = nullptr;
 };
 
 } // namespace logtail

--- a/core/metadata/K8sMetadata.cpp
+++ b/core/metadata/K8sMetadata.cpp
@@ -11,211 +11,213 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific l
 
-#include <ctime>
-#include <chrono>
-#include <thread>
 #include "K8sMetadata.h"
+
+#include <chrono>
+#include <ctime>
+#include <thread>
+
 #include "common/MachineInfoUtil.h"
-#include "logger/Logger.h"
+#include "common/http/Curl.h"
 #include "common/http/HttpRequest.h"
 #include "common/http/HttpResponse.h"
-#include "common/http/Curl.h"
+#include "logger/Logger.h"
 
 using namespace std;
 
 namespace logtail {
 
-    size_t WriteCallback(void* contents, size_t size, size_t nmemb, void* userp) {
-        ((std::string*)userp)->append((char*)contents, size * nmemb);
-        return size * nmemb;
-    }
+size_t WriteCallback(void* contents, size_t size, size_t nmemb, void* userp) {
+    ((std::string*)userp)->append((char*)contents, size * nmemb);
+    return size * nmemb;
+}
 
-    bool K8sMetadata::FromInfoJson(const Json::Value& json, k8sContainerInfo& info) {
-        if (!json.isMember(imageKey) || !json.isMember(labelsKey) ||
-            !json.isMember(namespaceKey) ||
-            !json.isMember(workloadKindKey) || !json.isMember(workloadNameKey)) {
-            return false;
-        }
-
-        for (const auto& key : json[imageKey].getMemberNames()) {
-            if (json[imageKey].isMember(key)) {
-                info.images[key] = json[imageKey][key].asString();
-            }
-        }
-        for (const auto& key : json[labelsKey].getMemberNames()) {
-            if (json[labelsKey].isMember(key)) {
-                info.labels[key] = json[labelsKey][key].asString();
-                
-                if (key == appIdKey) {
-                    info.appId = json[labelsKey][key].asString();
-                }
-            
-            }
-        }
-
-        info.k8sNamespace = json[namespaceKey].asString();
-        if (json.isMember(serviceNameKey)) {
-            info.serviceName = json[serviceNameKey].asString();
-        }
-        info.workloadKind = json[workloadKindKey].asString();
-        info.workloadName = json[workloadNameKey].asString();
-        info.timestamp = std::time(0);
-        return true;
-    }
-
-    bool ContainerInfoIsExpired(std::shared_ptr<k8sContainerInfo> info) {
-        if (info == nullptr) {
-            return false;
-        }
-        std::time_t now = std::time(0);
-        std::chrono::system_clock::time_point th1 = std::chrono::system_clock::from_time_t(info->timestamp);
-        std::chrono::system_clock::time_point th2 = std::chrono::system_clock::from_time_t(now);
-        std::chrono::duration<double> diff = th2 - th1;
-        double seconds_diff = diff.count();
-        if (seconds_diff > 600) { // 10 minutes in seconds
-            return true;
-        }
+bool K8sMetadata::FromInfoJson(const Json::Value& json, k8sContainerInfo& info) {
+    if (!json.isMember(imageKey) || !json.isMember(labelsKey) || !json.isMember(namespaceKey)
+        || !json.isMember(workloadKindKey) || !json.isMember(workloadNameKey)) {
         return false;
-    }  
+    }
 
-    bool K8sMetadata::FromContainerJson(const Json::Value& json, std::shared_ptr<ContainerData> data) {
-        if (!json.isObject()) {
-            return false;
+    for (const auto& key : json[imageKey].getMemberNames()) {
+        if (json[imageKey].isMember(key)) {
+            info.images[key] = json[imageKey][key].asString();
         }
-        for (const auto& key : json.getMemberNames()) {
-            k8sContainerInfo info;
-            bool fromJsonIsOk = FromInfoJson(json[key], info);
-            if (!fromJsonIsOk) {
-                continue;
+    }
+    for (const auto& key : json[labelsKey].getMemberNames()) {
+        if (json[labelsKey].isMember(key)) {
+            info.labels[key] = json[labelsKey][key].asString();
+
+            if (key == appIdKey) {
+                info.appId = json[labelsKey][key].asString();
             }
-            data->containers[key] = info;
         }
+    }
+
+    info.k8sNamespace = json[namespaceKey].asString();
+    if (json.isMember(serviceNameKey)) {
+        info.serviceName = json[serviceNameKey].asString();
+    }
+    info.workloadKind = json[workloadKindKey].asString();
+    info.workloadName = json[workloadNameKey].asString();
+    info.timestamp = std::time(0);
+    return true;
+}
+
+bool ContainerInfoIsExpired(std::shared_ptr<k8sContainerInfo> info) {
+    if (info == nullptr) {
+        return false;
+    }
+    std::time_t now = std::time(0);
+    std::chrono::system_clock::time_point th1 = std::chrono::system_clock::from_time_t(info->timestamp);
+    std::chrono::system_clock::time_point th2 = std::chrono::system_clock::from_time_t(now);
+    std::chrono::duration<double> diff = th2 - th1;
+    double seconds_diff = diff.count();
+    if (seconds_diff > 600) { // 10 minutes in seconds
         return true;
     }
+    return false;
+}
 
-    bool K8sMetadata::SendRequestToOperator(const std::string& urlHost, const std::string& output, containerInfoType infoType) {    
-        std::unique_ptr<HttpRequest> request;
-        HttpResponse res;
-        std::string path = "/metadata/containerid";
-        if (infoType == containerInfoType::IpInfo) {
-            path = "/metadata/ip";
+bool K8sMetadata::FromContainerJson(const Json::Value& json, std::shared_ptr<ContainerData> data) {
+    if (!json.isObject()) {
+        return false;
+    }
+    for (const auto& key : json.getMemberNames()) {
+        k8sContainerInfo info;
+        bool fromJsonIsOk = FromInfoJson(json[key], info);
+        if (!fromJsonIsOk) {
+            continue;
         }
-        request = std::make_unique<HttpRequest>("GET", false, mServiceHost, mServicePort, path, "", map<std::string, std::string>(), output, 30, 3);
-        bool success = SendHttpRequest(std::move(request), res);
-        if (success) {
-            if (res.mStatusCode != 200) {
-                LOG_DEBUG(sLogger, ("fetch k8s meta from one operator fail, code is ", res.mStatusCode));
-                return false;
-            }
-            Json::CharReaderBuilder readerBuilder;
-            Json::CharReader* reader = readerBuilder.newCharReader();
-            Json::Value root;
-            std::string errors;
+        data->containers[key] = info;
+    }
+    return true;
+}
 
-            if (reader->parse(res.mBody.c_str(), res.mBody.c_str() + res.mBody.size(), &root, &errors)) {
-                if (infoType == containerInfoType::ContainerIdInfo) {
-                    SetContainerCache(root);
-                } else {
-                    SetIpCache(root);
-                }
-            } else {
-                LOG_DEBUG(sLogger, ("JSON parse error:", errors));
-                delete reader;
-                return false;
-            }
-
-            delete reader;
-            return true;
-        } else {
-            LOG_DEBUG(sLogger, ("fetch k8s meta from one operator fail", urlHost));
+bool K8sMetadata::SendRequestToOperator(const std::string& urlHost,
+                                        const std::string& output,
+                                        containerInfoType infoType) {
+    std::unique_ptr<HttpRequest> request;
+    HttpResponse res;
+    std::string path = "/metadata/containerid";
+    if (infoType == containerInfoType::IpInfo) {
+        path = "/metadata/ip";
+    }
+    request = std::make_unique<HttpRequest>(
+        "GET", false, mServiceHost, mServicePort, path, "", map<std::string, std::string>(), output, 30, 3);
+    bool success = SendHttpRequest(std::move(request), res);
+    if (success) {
+        if (res.GetStatusCode() != 200) {
+            LOG_DEBUG(sLogger, ("fetch k8s meta from one operator fail, code is ", res.GetStatusCode()));
             return false;
         }
-        
-    }
+        Json::CharReaderBuilder readerBuilder;
+        Json::CharReader* reader = readerBuilder.newCharReader();
+        Json::Value root;
+        std::string errors;
 
-    bool K8sMetadata::GetByContainerIdsFromServer(std::vector<std::string> containerIds) {
-        Json::Value jsonObj;
-        for (auto& str : containerIds) {
-            jsonObj["keys"].append(str);
-        }
-        Json::StreamWriterBuilder writer;
-        std::string output = Json::writeString(writer, jsonObj);
-        return SendRequestToOperator(mServiceHost, output, containerInfoType::ContainerIdInfo);
-    }
-
-    void K8sMetadata::GetByLocalHostFromServer() {
-        std::string hostIp = GetHostIp();
-        std::list<std::string> strList{hostIp};
-        Json::Value jsonObj;
-        for (const auto& str : strList) {
-            jsonObj["keys"].append(str);
-        }
-        Json::StreamWriterBuilder writer;
-        std::string output = Json::writeString(writer, jsonObj);
-        std::string urlHost = mServiceHost;
-        SendRequestToOperator(urlHost, output, containerInfoType::ContainerIdInfo);
-        SendRequestToOperator(urlHost, output, containerInfoType::IpInfo);
-    }
-
-    void K8sMetadata::SetContainerCache(const Json::Value& root) {
-        std::shared_ptr<ContainerData> data = std::make_shared<ContainerData>();
-        if (data == nullptr) {
-            return;
-        }
-        if (!FromContainerJson(root, data)) {
-            LOG_DEBUG(sLogger, ("from container json error:", "SetContainerCache"));
-        } else {
-            for (const auto& pair : data->containers) {
-              containerCache.insert(pair.first, std::make_shared<k8sContainerInfo>(pair.second));
+        auto& responseBody = *res.GetBody<std::string>();
+        if (reader->parse(responseBody.c_str(), responseBody.c_str() + responseBody.size(), &root, &errors)) {
+            if (infoType == containerInfoType::ContainerIdInfo) {
+                SetContainerCache(root);
+            } else {
+                SetIpCache(root);
             }
-        }
-        
-    }
-
-    void K8sMetadata::SetIpCache(const Json::Value& root) {
-        std::shared_ptr<ContainerData> data = std::make_shared<ContainerData>();
-        if (data == nullptr) {
-            return;
-        }
-       if (!FromContainerJson(root, data)) {
-            LOG_DEBUG(sLogger, ("from container json error:", "SetIpCache"));
         } else {
-            for (const auto& pair : data->containers) {
-           ipCache.insert(pair.first, std::make_shared<k8sContainerInfo>(pair.second));
+            LOG_DEBUG(sLogger, ("JSON parse error:", errors));
+            delete reader;
+            return false;
         }
-        }
-    }
 
-    bool K8sMetadata::GetByIpsFromServer(std::vector<std::string> ips) {
-        Json::Value jsonObj;
-        for (auto& str : ips) {
-            jsonObj["keys"].append(str);
-        }
-        Json::StreamWriterBuilder writer;
-        std::string output = Json::writeString(writer, jsonObj);
-        std::string urlHost = mServiceHost;
-        return SendRequestToOperator(urlHost, output, containerInfoType::IpInfo);
+        delete reader;
+        return true;
+    } else {
+        LOG_DEBUG(sLogger, ("fetch k8s meta from one operator fail", urlHost));
+        return false;
     }
+}
 
-    std::shared_ptr<k8sContainerInfo> K8sMetadata::GetInfoByContainerIdFromCache(const std::string& containerId) {
-         if (containerId.empty()) {
-            return nullptr;
-         }
-         return containerCache.get(containerId);
+bool K8sMetadata::GetByContainerIdsFromServer(std::vector<std::string> containerIds) {
+    Json::Value jsonObj;
+    for (auto& str : containerIds) {
+        jsonObj["keys"].append(str);
     }
-    
-    std::shared_ptr<k8sContainerInfo> K8sMetadata::GetInfoByIpFromCache(const std::string& ip) {
-        if (ip.empty()){
-            return nullptr;
-        }
-        std::shared_ptr<k8sContainerInfo> ip_info =  ipCache.get(ip);
-        if (ip_info == nullptr) {
-            return nullptr;
-        }
-        if (ContainerInfoIsExpired(ip_info)) {
-            return nullptr;
-        }
-        return ip_info;
+    Json::StreamWriterBuilder writer;
+    std::string output = Json::writeString(writer, jsonObj);
+    return SendRequestToOperator(mServiceHost, output, containerInfoType::ContainerIdInfo);
+}
+
+void K8sMetadata::GetByLocalHostFromServer() {
+    std::string hostIp = GetHostIp();
+    std::list<std::string> strList{hostIp};
+    Json::Value jsonObj;
+    for (const auto& str : strList) {
+        jsonObj["keys"].append(str);
     }
-    
+    Json::StreamWriterBuilder writer;
+    std::string output = Json::writeString(writer, jsonObj);
+    std::string urlHost = mServiceHost;
+    SendRequestToOperator(urlHost, output, containerInfoType::ContainerIdInfo);
+    SendRequestToOperator(urlHost, output, containerInfoType::IpInfo);
+}
+
+void K8sMetadata::SetContainerCache(const Json::Value& root) {
+    std::shared_ptr<ContainerData> data = std::make_shared<ContainerData>();
+    if (data == nullptr) {
+        return;
+    }
+    if (!FromContainerJson(root, data)) {
+        LOG_DEBUG(sLogger, ("from container json error:", "SetContainerCache"));
+    } else {
+        for (const auto& pair : data->containers) {
+            containerCache.insert(pair.first, std::make_shared<k8sContainerInfo>(pair.second));
+        }
+    }
+}
+
+void K8sMetadata::SetIpCache(const Json::Value& root) {
+    std::shared_ptr<ContainerData> data = std::make_shared<ContainerData>();
+    if (data == nullptr) {
+        return;
+    }
+    if (!FromContainerJson(root, data)) {
+        LOG_DEBUG(sLogger, ("from container json error:", "SetIpCache"));
+    } else {
+        for (const auto& pair : data->containers) {
+            ipCache.insert(pair.first, std::make_shared<k8sContainerInfo>(pair.second));
+        }
+    }
+}
+
+bool K8sMetadata::GetByIpsFromServer(std::vector<std::string> ips) {
+    Json::Value jsonObj;
+    for (auto& str : ips) {
+        jsonObj["keys"].append(str);
+    }
+    Json::StreamWriterBuilder writer;
+    std::string output = Json::writeString(writer, jsonObj);
+    std::string urlHost = mServiceHost;
+    return SendRequestToOperator(urlHost, output, containerInfoType::IpInfo);
+}
+
+std::shared_ptr<k8sContainerInfo> K8sMetadata::GetInfoByContainerIdFromCache(const std::string& containerId) {
+    if (containerId.empty()) {
+        return nullptr;
+    }
+    return containerCache.get(containerId);
+}
+
+std::shared_ptr<k8sContainerInfo> K8sMetadata::GetInfoByIpFromCache(const std::string& ip) {
+    if (ip.empty()) {
+        return nullptr;
+    }
+    std::shared_ptr<k8sContainerInfo> ip_info = ipCache.get(ip);
+    if (ip_info == nullptr) {
+        return nullptr;
+    }
+    if (ContainerInfoIsExpired(ip_info)) {
+        return nullptr;
+    }
+    return ip_info;
+}
+
 } // namespace logtail

--- a/core/plugin/flusher/sls/SLSResponse.cpp
+++ b/core/plugin/flusher/sls/SLSResponse.cpp
@@ -27,18 +27,18 @@ using namespace std;
 namespace logtail {
 
 bool SLSResponse::Parse(const HttpResponse& response) {
-    const auto iter = response.mHeader.find(sdk::X_LOG_REQUEST_ID);
-    if (iter != response.mHeader.end()) {
+    const auto iter = response.GetHeader().find(sdk::X_LOG_REQUEST_ID);
+    if (iter != response.GetHeader().end()) {
         mRequestId = iter->second;
     }
-    mStatusCode = response.mStatusCode;
+    mStatusCode = response.GetStatusCode();
 
     if (mStatusCode == 0) {
         mErrorCode = sdk::LOG_REQUEST_TIMEOUT;
         mErrorMsg = "Request timeout";
     } else if (mStatusCode != 200) {
         try {
-            sdk::ErrorCheck(response.mBody, mRequestId, response.mStatusCode);
+            sdk::ErrorCheck(*response.GetBody<string>(), mRequestId, response.GetStatusCode());
         } catch (sdk::LOGException& e) {
             mErrorCode = e.GetErrorCode();
             mErrorMsg = e.GetMessage_();
@@ -48,8 +48,8 @@ bool SLSResponse::Parse(const HttpResponse& response) {
 }
 
 bool IsSLSResponse(const HttpResponse& response) {
-    const auto iter = response.mHeader.find(sdk::X_LOG_REQUEST_ID);
-    if (iter == response.mHeader.end()) {
+    const auto iter = response.GetHeader().find(sdk::X_LOG_REQUEST_ID);
+    if (iter == response.GetHeader().end()) {
         return false;
     }
     return !iter->second.empty();
@@ -60,8 +60,8 @@ time_t GetServerTime(const HttpResponse& response) {
     // Priority: x-log-time -> Date
     string errMsg;
     try {
-        const auto iter = response.mHeader.find("x-log-time");
-        if (iter != response.mHeader.end()) {
+        const auto iter = response.GetHeader().find("x-log-time");
+        if (iter != response.GetHeader().end()) {
             return StringTo<time_t>(iter->second);
         }
     } catch (const exception& e) {
@@ -73,8 +73,8 @@ time_t GetServerTime(const HttpResponse& response) {
         LOG_ERROR(sLogger, METHOD_LOG_PATTERN("parse x-log-time error", errMsg));
     }
 
-    const auto iter = response.mHeader.find("Date");
-    if (iter == response.mHeader.end()) {
+    const auto iter = response.GetHeader().find("Date");
+    if (iter == response.GetHeader().end()) {
         LOG_WARNING(sLogger, METHOD_LOG_PATTERN("no Date in HTTP header", ""));
         return 0;
     }

--- a/core/prometheus/async/PromFuture.cpp
+++ b/core/prometheus/async/PromFuture.cpp
@@ -32,7 +32,7 @@ void PromFuture<Args...>::Cancel() {
     mState = PromFutureState::Done;
 }
 
-template class PromFuture<const HttpResponse&, uint64_t>;
+template class PromFuture<HttpResponse&, uint64_t>;
 template class PromFuture<>;
 
 } // namespace logtail

--- a/core/prometheus/async/PromHttpRequest.cpp
+++ b/core/prometheus/async/PromHttpRequest.cpp
@@ -5,8 +5,48 @@
 #include <string>
 
 #include "common/http/HttpRequest.h"
+#include "prometheus/Constants.h"
 
 namespace logtail {
+
+// size_t PromWriteCallback(char* buffer, size_t size, size_t nmemb, void* data) {
+//     unsigned long sizes = size * nmemb;
+
+//     if (buffer == nullptr) {
+//         return 0;
+//     }
+
+//     PromResponseBody* body = static_cast<PromResponseBody*>(data);
+
+//     size_t begin = 0;
+//     while (begin < sizes) {
+//         for (size_t end = begin; end < sizes; ++end) {
+//             if (buffer[end] == '\n') {
+//                 if (begin == 0) {
+//                     body->mCache.append(buffer, end);
+//                     if (!body->mCache.empty()) {
+//                         auto e = body->mEventGroup.AddLogEvent();
+//                         auto sb = body->mEventGroup.GetSourceBuffer()->CopyString(body->mCache);
+//                         body->mCache.clear();
+//                         e->SetContentNoCopy(prometheus::PROMETHEUS, StringView(sb.data, sb.size));
+//                     }
+//                 } else if (begin != end) {
+//                     auto e = body->mEventGroup.AddLogEvent();
+//                     auto sb = body->mEventGroup.GetSourceBuffer()->CopyString(buffer + begin, end - begin);
+//                     e->SetContentNoCopy(prometheus::PROMETHEUS, StringView(sb.data, sb.size));
+//                 }
+//                 begin += end - begin + 1;
+//                 continue;
+//             }
+//         }
+//         break;
+//     }
+//     if (begin < sizes) {
+//         body->mCache.append(buffer + begin, sizes - begin);
+//     }
+//     body->mRawSize += sizes;
+//     return sizes;
+// }
 
 PromHttpRequest::PromHttpRequest(const std::string& method,
                                  bool httpsFlag,
@@ -18,14 +58,27 @@ PromHttpRequest::PromHttpRequest(const std::string& method,
                                  const std::string& body,
                                  uint32_t timeout,
                                  uint32_t maxTryCnt,
-                                 std::shared_ptr<PromFuture<const HttpResponse&, uint64_t>> future,
+                                 std::shared_ptr<PromFuture<HttpResponse&, uint64_t>> future,
                                  std::shared_ptr<PromFuture<>> isContextValidFuture)
-    : AsynHttpRequest(method, httpsFlag, host, port, url, query, header, body, timeout, maxTryCnt),
+    : AsynHttpRequest(method,
+                      httpsFlag,
+                      host,
+                      port,
+                      url,
+                      query,
+                      header,
+                      body,
+                      //   HttpResponse(
+                      //       new PromResponseBody(), [](void* ptr) { delete static_cast<PromResponseBody*>(ptr); },
+                      //       PromWriteCallback),
+                      HttpResponse(),
+                      timeout,
+                      maxTryCnt),
       mFuture(std::move(future)),
       mIsContextValidFuture(std::move(isContextValidFuture)) {
 }
 
-void PromHttpRequest::OnSendDone(const HttpResponse& response) {
+void PromHttpRequest::OnSendDone(HttpResponse& response) {
     if (mFuture != nullptr) {
         mFuture->Process(
             response, std::chrono::duration_cast<std::chrono::milliseconds>(mLastSendTime.time_since_epoch()).count());

--- a/core/prometheus/async/PromHttpRequest.h
+++ b/core/prometheus/async/PromHttpRequest.h
@@ -1,10 +1,11 @@
 #pragma once
+
 #include <cstdint>
 #include <string>
 
 #include "common/http/HttpRequest.h"
+#include "models/PipelineEventGroup.h"
 #include "prometheus/async/PromFuture.h"
-
 
 namespace logtail {
 
@@ -20,19 +21,27 @@ public:
                     const std::string& body,
                     uint32_t timeout,
                     uint32_t maxTryCnt,
-                    std::shared_ptr<PromFuture<const HttpResponse&, uint64_t>> future,
+                    std::shared_ptr<PromFuture<HttpResponse&, uint64_t>> future,
                     std::shared_ptr<PromFuture<>> isContextValidFuture = nullptr);
     PromHttpRequest(const PromHttpRequest&) = default;
     ~PromHttpRequest() override = default;
 
-    void OnSendDone(const HttpResponse& response) override;
+    void OnSendDone(HttpResponse& response) override;
     [[nodiscard]] bool IsContextValid() const override;
 
 private:
     void SetNextExecTime(std::chrono::steady_clock::time_point execTime);
 
-    std::shared_ptr<PromFuture<const HttpResponse&, uint64_t>> mFuture;
+    std::shared_ptr<PromFuture<HttpResponse&, uint64_t>> mFuture;
     std::shared_ptr<PromFuture<>> mIsContextValidFuture;
+};
+
+struct PromResponseBody {
+    PipelineEventGroup mEventGroup;
+    std::string mCache;
+    size_t mRawSize = 0;
+
+    PromResponseBody() : mEventGroup(std::make_shared<SourceBuffer>()) {};
 };
 
 } // namespace logtail

--- a/core/prometheus/schedulers/BaseScheduler.h
+++ b/core/prometheus/schedulers/BaseScheduler.h
@@ -33,7 +33,7 @@ protected:
 
     ReadWriteLock mLock;
     bool mValidState = true;
-    std::shared_ptr<PromFuture<const HttpResponse&, uint64_t>> mFuture;
+    std::shared_ptr<PromFuture<HttpResponse&, uint64_t>> mFuture;
     std::shared_ptr<PromFuture<>> mIsContextValidFuture;
 };
 } // namespace logtail

--- a/core/prometheus/schedulers/ScrapeScheduler.h
+++ b/core/prometheus/schedulers/ScrapeScheduler.h
@@ -46,7 +46,7 @@ public:
     ScrapeScheduler(const ScrapeScheduler&) = default;
     ~ScrapeScheduler() override = default;
 
-    void OnMetricResult(const HttpResponse&, uint64_t timestampMilliSec);
+    void OnMetricResult(HttpResponse&, uint64_t timestampMilliSec);
     void SetTimer(std::shared_ptr<Timer> timer);
 
     std::string GetId() const;

--- a/core/prometheus/schedulers/TargetSubscriberScheduler.h
+++ b/core/prometheus/schedulers/TargetSubscriberScheduler.h
@@ -40,7 +40,7 @@ public:
     bool Init(const Json::Value& scrapeConfig);
     bool operator<(const TargetSubscriberScheduler& other) const;
 
-    void OnSubscription(const HttpResponse&, uint64_t);
+    void OnSubscription(HttpResponse&, uint64_t);
     void SetTimer(std::shared_ptr<Timer> timer);
     void SubscribeOnce(std::chrono::steady_clock::time_point execTime);
 

--- a/core/runner/sink/http/HttpSink.cpp
+++ b/core/runner/sink/http/HttpSink.cpp
@@ -237,7 +237,7 @@ void HttpSink::HandleCompletedRequests(int& runningHandlers) {
                 case CURLE_OK: {
                     long statusCode = 0;
                     curl_easy_getinfo(handler, CURLINFO_RESPONSE_CODE, &statusCode);
-                    request->mResponse.mStatusCode = (int32_t)statusCode;
+                    request->mResponse.SetStatusCode(statusCode);
                     static_cast<HttpFlusher*>(request->mItem->mFlusher)->OnSendDone(request->mResponse, request->mItem);
                     FlusherRunner::GetInstance()->DecreaseHttpSendingCnt();
                     mOutSuccessfulItemsTotal->Add(1);

--- a/core/runner/sink/http/HttpSinkRequest.h
+++ b/core/runner/sink/http/HttpSinkRequest.h
@@ -36,7 +36,7 @@ struct HttpSinkRequest : public AsynHttpRequest {
         : AsynHttpRequest(method, httpsFlag, host, port, url, query, header, body), mItem(item) {}
 
     bool IsContextValid() const override { return true; }
-    void OnSendDone(const HttpResponse& response) override {}
+    void OnSendDone(HttpResponse& response) override {}
 };
 
 } // namespace logtail

--- a/core/unittest/common/http/CurlUnittest.cpp
+++ b/core/unittest/common/http/CurlUnittest.cpp
@@ -34,7 +34,7 @@ void CurlUnittest::TestSendHttpRequest() {
     request = std::make_unique<HttpRequest>("GET", false, "example.com", 80, "/path", "", map<string, string>(), "", 10, 3);
     bool success = SendHttpRequest(std::move(request), res);
     APSARA_TEST_TRUE(success);
-    APSARA_TEST_EQUAL(404, res.mStatusCode);
+    APSARA_TEST_EQUAL(404, res.GetStatusCode());
 }
 
 UNIT_TEST_CASE(CurlUnittest, TestSendHttpRequest)

--- a/core/unittest/common/timer/HttpRequestTimerEventUnittest.cpp
+++ b/core/unittest/common/timer/HttpRequestTimerEventUnittest.cpp
@@ -32,7 +32,7 @@ struct AsynHttpRequestMock : public AsynHttpRequest {
         : AsynHttpRequest(method, httpsFlag, host, port, url, query, header, body) {}
 
     bool IsContextValid() const override { return true; };
-    void OnSendDone(const HttpResponse& response){};
+    void OnSendDone(HttpResponse& response){};
 };
 
 class HttpRequestTimerEventUnittest : public ::testing::Test {

--- a/core/unittest/prometheus/PromAsynUnittest.cpp
+++ b/core/unittest/prometheus/PromAsynUnittest.cpp
@@ -13,10 +13,10 @@ public:
 };
 
 void PromAsynUnittest::TestExecTime() {
-    auto future = std::make_shared<PromFuture<const HttpResponse&, uint64_t>>();
+    auto future = std::make_shared<PromFuture<HttpResponse&, uint64_t>>();
     auto now = std::chrono::system_clock::now();
     bool exec = false;
-    future->AddDoneCallback([&exec, now](const HttpResponse&, uint64_t timestampMilliSec) {
+    future->AddDoneCallback([&exec, now](HttpResponse&, uint64_t timestampMilliSec) {
         APSARA_TEST_EQUAL(timestampMilliSec,
                           std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count());
 

--- a/core/unittest/prometheus/TargetSubscriberSchedulerUnittest.cpp
+++ b/core/unittest/prometheus/TargetSubscriberSchedulerUnittest.cpp
@@ -73,9 +73,9 @@ protected:
             std::cerr << "JSON parsing failed." << std::endl;
         }
 
-        mHttpResponse.mStatusCode = 200;
+        mHttpResponse.SetStatusCode(200);
         {
-            mHttpResponse.mBody = R"JSON([
+            *mHttpResponse.GetBody<string>() = R"JSON([
         {
             "targets": [
                 "192.168.22.7:8080"
@@ -153,12 +153,12 @@ void TargetSubscriberSchedulerUnittest::TestProcess() {
     targetSubscriber->InitSelfMonitor(metricLabels);
 
     // if status code is not 200
-    mHttpResponse.mStatusCode = 404;
+    mHttpResponse.SetStatusCode(404);
     targetSubscriber->OnSubscription(mHttpResponse, 0);
     APSARA_TEST_EQUAL(0UL, targetSubscriber->mScrapeSchedulerMap.size());
 
     // if status code is 200
-    mHttpResponse.mStatusCode = 200;
+    mHttpResponse.SetStatusCode(200);
     targetSubscriber->OnSubscription(mHttpResponse, 0);
     APSARA_TEST_EQUAL(2UL, targetSubscriber->mScrapeSchedulerMap.size());
 }
@@ -168,7 +168,7 @@ void TargetSubscriberSchedulerUnittest::TestParseTargetGroups() {
     APSARA_TEST_TRUE(targetSubscriber->Init(mConfig["ScrapeConfig"]));
 
     std::vector<Labels> newScrapeSchedulerSet;
-    APSARA_TEST_TRUE(targetSubscriber->ParseScrapeSchedulerGroup(mHttpResponse.mBody, newScrapeSchedulerSet));
+    APSARA_TEST_TRUE(targetSubscriber->ParseScrapeSchedulerGroup(*mHttpResponse.GetBody<string>(), newScrapeSchedulerSet));
     APSARA_TEST_EQUAL(2UL, newScrapeSchedulerSet.size());
 }
 


### PR DESCRIPTION
- 背景：在Prometheus抓取场景，对于大流量的target（一次抓取有30MB），从http请求到生成event group会经历多次字符串拷贝：
  1. http response body是分批写入目标字符串的，因此会不可避免的经历多次内存重新分配。使用stringstream能够避免写入时的再分配，但是最终转成string时仍需要进行一次完整的分配；
  2. 对于获取的body，在完成按行切分生成Log event时，仍然需要将对应的内容拷贝到event group的source buffer里；
内存profile结果表明，这两步占了近40%的内存开销，因此需要优化。
- 方案：
  1. 放开response body的stirng类型限制，改成void*，即任意类型，同时支持自定义的body data回调函数。
  2. 对于Prometheus抓取场景，可自定义body类型PromHttpResponse，其中记录event group和string cache。同时在自定义的body data回调函数中（PromDataWriteCallback）对数据流进行实时按行切分并生成Log Event。通过这种方式，能够基本避免前面所说的多次无效内存拷贝，提升整体效率。