### PR TITLE
optimize: 1. reserve metric events before parse log events, 2. use SetTagNoCopy in Relabel, 3. optimize the logic of delete labels which starts with "__"

### DIFF
--- a/core/plugin/processor/inner/ProcessorPromParseMetricNative.cpp
+++ b/core/plugin/processor/inner/ProcessorPromParseMetricNative.cpp
@@ -26,6 +26,7 @@ bool ProcessorPromParseMetricNative::Init(const Json::Value& config) {
 void ProcessorPromParseMetricNative::Process(PipelineEventGroup& eGroup) {
     EventsContainer& events = eGroup.MutableEvents();
     EventsContainer newEvents;
+    newEvents.reserve(events.size());
 
     StringView scrapeTimestampMilliSecStr = eGroup.GetMetadata(EventGroupMetaKey::PROMETHEUS_SCRAPE_TIMESTAMP_MILLISEC);
     auto timestampMilliSec = StringTo<uint64_t>(scrapeTimestampMilliSecStr.to_string());

--- a/core/plugin/processor/inner/ProcessorPromRelabelMetricNative.h
+++ b/core/plugin/processor/inner/ProcessorPromRelabelMetricNative.h
@@ -36,7 +36,7 @@ protected:
     bool IsSupportedEvent(const PipelineEventPtr& e) const override;
 
 private:
-    bool ProcessEvent(PipelineEventPtr& e, const GroupTags& targetTags);
+    bool ProcessEvent(PipelineEventPtr& e, const GroupTags& targetTags, const std::vector<StringView>& toDelete);
 
     void AddAutoMetrics(PipelineEventGroup& metricGroup);
     void AddMetric(PipelineEventGroup& metricGroup,

--- a/core/plugin/processor/inner/ProcessorPromRelabelMetricNative.h
+++ b/core/plugin/processor/inner/ProcessorPromRelabelMetricNative.h
@@ -37,6 +37,7 @@ protected:
 
 private:
     bool ProcessEvent(PipelineEventPtr& e, const GroupTags& targetTags, const std::vector<StringView>& toDelete);
+    std::vector<StringView> GetToDeleteTargetLabels(const GroupTags& targetTags) const;
 
     void AddAutoMetrics(PipelineEventGroup& metricGroup);
     void AddMetric(PipelineEventGroup& metricGroup,

--- a/core/prometheus/labels/Relabel.cpp
+++ b/core/prometheus/labels/Relabel.cpp
@@ -31,11 +31,9 @@
 
 using namespace std;
 
-#define ENUM_TO_STRING_CASE(EnumValue) \
-    { Action::EnumValue, ToLowerCaseString(#EnumValue) }
+#define ENUM_TO_STRING_CASE(EnumValue) {Action::EnumValue, ToLowerCaseString(#EnumValue)}
 
-#define STRING_TO_ENUM_CASE(EnumValue) \
-    { ToLowerCaseString(#EnumValue), Action::EnumValue }
+#define STRING_TO_ENUM_CASE(EnumValue) {ToLowerCaseString(#EnumValue), Action::EnumValue}
 
 namespace logtail {
 
@@ -116,14 +114,16 @@ bool RelabelConfig::Init(const Json::Value& config) {
     return true;
 }
 
-bool RelabelConfig::Process(Labels& l) const {
+bool RelabelConfig::Process(Labels& l, vector<string>& toDelete) const {
     vector<string> values;
     values.reserve(mSourceLabels.size());
     for (const auto& item : mSourceLabels) {
         values.push_back(l.Get(item));
     }
     string val = boost::algorithm::join(values, mSeparator);
-
+    if (StartWith(mTargetLabel, "__")) {
+        toDelete.push_back(mTargetLabel);
+    }
     switch (mAction) {
         case Action::DROP: {
             if (boost::regex_match(val, mRegex)) {
@@ -162,6 +162,9 @@ bool RelabelConfig::Process(Labels& l) const {
                 break;
             }
             l.Set(target, string(res));
+            if (StartWith(target, "__")) {
+                toDelete.push_back(target);
+            }
             break;
         }
         case Action::LOWERCASE: {
@@ -190,6 +193,9 @@ bool RelabelConfig::Process(Labels& l) const {
                     string res
                         = boost::regex_replace(key, mRegex, mReplacement, boost::match_default | boost::format_all);
                     l.Set(res, value);
+                    if (StartWith(res, "__")) {
+                        toDelete.push_back(res);
+                    }
                 }
             });
             break;
@@ -241,19 +247,19 @@ bool RelabelConfigList::Init(const Json::Value& relabelConfigs) {
     return true;
 }
 
-bool RelabelConfigList::Process(Labels& l) const {
+bool RelabelConfigList::Process(Labels& l, vector<string>& toDelete) const {
     for (const auto& cfg : mRelabelConfigs) {
-        if (!cfg.Process(l)) {
+        if (!cfg.Process(l, toDelete)) {
             return false;
         }
     }
     return true;
 }
 
-bool RelabelConfigList::Process(MetricEvent& event) const {
+bool RelabelConfigList::Process(MetricEvent& event, vector<string>& toDelete) const {
     Labels labels;
     labels.Reset(&event);
-    return Process(labels);
+    return Process(labels, toDelete);
 }
 
 bool RelabelConfigList::Empty() const {

--- a/core/prometheus/labels/Relabel.cpp
+++ b/core/prometheus/labels/Relabel.cpp
@@ -121,9 +121,7 @@ bool RelabelConfig::Process(Labels& l, vector<string>& toDelete) const {
         values.push_back(l.Get(item));
     }
     string val = boost::algorithm::join(values, mSeparator);
-    if (StartWith(mTargetLabel, "__")) {
-        toDelete.push_back(mTargetLabel);
-    }
+    CollectLabelsToDelete(mTargetLabel, toDelete);
     switch (mAction) {
         case Action::DROP: {
             if (boost::regex_match(val, mRegex)) {
@@ -162,9 +160,7 @@ bool RelabelConfig::Process(Labels& l, vector<string>& toDelete) const {
                 break;
             }
             l.Set(target, string(res));
-            if (StartWith(target, "__")) {
-                toDelete.push_back(target);
-            }
+            CollectLabelsToDelete(target, toDelete);
             break;
         }
         case Action::LOWERCASE: {
@@ -193,9 +189,7 @@ bool RelabelConfig::Process(Labels& l, vector<string>& toDelete) const {
                     string res
                         = boost::regex_replace(key, mRegex, mReplacement, boost::match_default | boost::format_all);
                     l.Set(res, value);
-                    if (StartWith(res, "__")) {
-                        toDelete.push_back(res);
-                    }
+                    CollectLabelsToDelete(res, toDelete);
                 }
             });
             break;
@@ -230,6 +224,12 @@ bool RelabelConfig::Process(Labels& l, vector<string>& toDelete) const {
             break;
     }
     return true;
+}
+
+void RelabelConfig::CollectLabelsToDelete(const string& labelName, vector<string>& toDelete) const {
+    if (StartWith(labelName, "__")) {
+        toDelete.push_back(labelName);
+    }
 }
 
 bool RelabelConfigList::Init(const Json::Value& relabelConfigs) {

--- a/core/prometheus/labels/Relabel.h
+++ b/core/prometheus/labels/Relabel.h
@@ -66,6 +66,7 @@ public:
     Action mAction;
 
 private:
+    void CollectLabelsToDelete(const std::string& labelName, std::vector<std::string>& toDelete) const;
 };
 
 class RelabelConfigList {

--- a/core/prometheus/labels/Relabel.h
+++ b/core/prometheus/labels/Relabel.h
@@ -46,7 +46,7 @@ class RelabelConfig {
 public:
     RelabelConfig();
     bool Init(const Json::Value&);
-    bool Process(Labels&) const;
+    bool Process(Labels&, std::vector<std::string>& toDelete) const;
 
     // A list of labels from which values are taken and concatenated
     // with the configured separator in order.
@@ -71,8 +71,8 @@ private:
 class RelabelConfigList {
 public:
     bool Init(const Json::Value& relabelConfigs);
-    bool Process(MetricEvent&) const;
-    bool Process(Labels&) const;
+    bool Process(MetricEvent&, std::vector<std::string>& toDelete) const;
+    bool Process(Labels&, std::vector<std::string>& toDelete) const;
 
     [[nodiscard]] bool Empty() const;
 

--- a/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
+++ b/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
@@ -193,11 +193,8 @@ TargetSubscriberScheduler::BuildScrapeSchedulerSet(std::vector<Labels>& targetGr
     for (const auto& labels : targetGroups) {
         // Relabel Config
         Labels resultLabel = labels;
-        // bool keep = prometheus::Process(labels, mScrapeConfigPtr->mRelabelConfigs, resultLabel);
-        // if (!keep) {
-        //     continue;
-        // }
-        if (!mScrapeConfigPtr->mRelabelConfigs.Process(resultLabel)) {
+        vector<string> toDelete;
+        if (!mScrapeConfigPtr->mRelabelConfigs.Process(resultLabel, toDelete)) {
             continue;
         }
         resultLabel.RemoveMetaLabels();

--- a/core/unittest/processor/ProcessorPromRelabelMetricNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorPromRelabelMetricNativeUnittest.cpp
@@ -261,15 +261,16 @@ test_metric8{k1="v1", k3="v2", } 9.9410452992e+10 1715829785083
     eventGroup.SetTag(string("k3"), string("v3"));
     APSARA_TEST_EQUAL((size_t)8, eventGroup.GetEvents().size());
     auto targetTags = eventGroup.GetTags();
+    auto toDelete = processor.GetToDeleteTargetLabels(targetTags);
     // honor_labels is true
-    processor.ProcessEvent(eventGroup.MutableEvents()[0], targetTags);
+    processor.ProcessEvent(eventGroup.MutableEvents()[0], targetTags, toDelete);
     APSARA_TEST_EQUAL("v3", eventGroup.GetEvents().at(0).Cast<MetricEvent>().GetTag(string("k3")));
-    processor.ProcessEvent(eventGroup.MutableEvents()[6], targetTags);
+    processor.ProcessEvent(eventGroup.MutableEvents()[6], targetTags, toDelete);
     APSARA_TEST_EQUAL("2", eventGroup.GetEvents().at(6).Cast<MetricEvent>().GetTag(string("k3")).to_string());
 
     // honor_labels is false
     processor.mScrapeConfigPtr->mHonorLabels = false;
-    processor.ProcessEvent(eventGroup.MutableEvents()[7], targetTags);
+    processor.ProcessEvent(eventGroup.MutableEvents()[7], targetTags, toDelete);
     APSARA_TEST_EQUAL("v3", eventGroup.GetEvents().at(7).Cast<MetricEvent>().GetTag(string("k3")).to_string());
     APSARA_TEST_EQUAL("v2", eventGroup.GetEvents().at(7).Cast<MetricEvent>().GetTag(string("exported_k3")).to_string());
 }

--- a/core/unittest/prometheus/RelabelUnittest.cpp
+++ b/core/unittest/prometheus/RelabelUnittest.cpp
@@ -136,7 +136,8 @@ void RelabelConfigUnittest::TestReplace() {
     APSARA_TEST_TRUE(configList.Init(configJson));
 
     Labels result = labels;
-    configList.Process(result);
+    vector<string> toDelete;
+    configList.Process(result, toDelete);
 
     APSARA_TEST_EQUAL((size_t)3, result.Size());
     APSARA_TEST_EQUAL("172.17.0.3:9100", result.Get("__address__"));
@@ -166,7 +167,8 @@ void RelabelConfigUnittest::TestKeep() {
     configList = RelabelConfigList();
     APSARA_TEST_TRUE(configList.Init(configJson));
     auto result = labels;
-    configList.Process(result);
+    vector<string> toDelete;
+    configList.Process(result, toDelete);
     APSARA_TEST_EQUAL((size_t)2, result.Size());
     APSARA_TEST_EQUAL("172.17.0.3", result.Get("__meta_kubernetes_pod_ip"));
 }
@@ -194,8 +196,8 @@ void RelabelConfigUnittest::TestDrop() {
     configList = RelabelConfigList();
     APSARA_TEST_TRUE(configList.Init(configJson));
     auto result = labels;
-
-    APSARA_TEST_FALSE(configList.Process(result));
+    vector<string> toDelete;
+    APSARA_TEST_FALSE(configList.Process(result, toDelete));
 }
 
 void RelabelConfigUnittest::TestDropEqual() {
@@ -223,7 +225,8 @@ void RelabelConfigUnittest::TestDropEqual() {
     configList = RelabelConfigList();
     APSARA_TEST_TRUE(configList.Init(configJson));
     auto result = dropEqualLabels;
-    APSARA_TEST_FALSE(configList.Process(result));
+    vector<string> toDelete;
+    APSARA_TEST_FALSE(configList.Process(result, toDelete));
 }
 
 void RelabelConfigUnittest::TestKeepEqual() {
@@ -251,7 +254,8 @@ void RelabelConfigUnittest::TestKeepEqual() {
     configList = RelabelConfigList();
     APSARA_TEST_TRUE(configList.Init(configJson));
     auto result = keepEqualLabels;
-    configList.Process(result);
+    vector<string> toDelete;
+    configList.Process(result, toDelete);
     APSARA_TEST_EQUAL((size_t)3, result.Size());
     APSARA_TEST_EQUAL("172.17.0.3", result.Get("__meta_kubernetes_pod_ip"));
 }
@@ -281,7 +285,8 @@ void RelabelConfigUnittest::TestLowerCase() {
     configList = RelabelConfigList();
     APSARA_TEST_TRUE(configList.Init(configJson));
     auto result = lowercaseLabels;
-    configList.Process(result);
+    vector<string> toDelete;
+    configList.Process(result, toDelete);
     APSARA_TEST_EQUAL((size_t)3, result.Size());
     APSARA_TEST_EQUAL("node-exporter", result.Get("__meta_kubernetes_pod_label_app"));
 }
@@ -311,7 +316,8 @@ void RelabelConfigUnittest::TestUpperCase() {
     configList = RelabelConfigList();
     APSARA_TEST_TRUE(configList.Init(configJson));
     auto result = uppercaseLabels;
-    configList.Process(result);
+    vector<string> toDelete;
+    configList.Process(result, toDelete);
     APSARA_TEST_EQUAL((size_t)3, result.Size());
     APSARA_TEST_EQUAL("NODE-EXPORTER", result.Get("__meta_kubernetes_pod_label_app"));
 }
@@ -343,7 +349,8 @@ void RelabelConfigUnittest::TestHashMod() {
     configList = RelabelConfigList();
     APSARA_TEST_TRUE(configList.Init(configJson));
     auto result = hashmodLabels;
-    configList.Process(result);
+    vector<string> toDelete;
+    configList.Process(result, toDelete);
     APSARA_TEST_EQUAL((size_t)4, result.Size());
     APSARA_TEST_TRUE(!result.Get("hash_val").empty());
 }
@@ -368,7 +375,8 @@ void RelabelConfigUnittest::TestLabelMap() {
     configList = RelabelConfigList();
     APSARA_TEST_TRUE(configList.Init(configJson));
     auto result = labels;
-    configList.Process(result);
+    vector<string> toDelete;
+    configList.Process(result, toDelete);
     APSARA_TEST_EQUAL((size_t)3, result.Size());
     APSARA_TEST_EQUAL("node-exporter", result.Get("k8s_app"));
 }
@@ -395,7 +403,8 @@ void RelabelConfigUnittest::TestLabelDrop() {
     configList = RelabelConfigList();
     APSARA_TEST_TRUE(configList.Init(configJson));
     auto result = labelDropLabels;
-    configList.Process(result);
+    vector<string> toDelete;
+    configList.Process(result, toDelete);
     APSARA_TEST_EQUAL((size_t)1, result.Size());
     APSARA_TEST_EQUAL("172.17.0.3", result.Get("pod_ip"));
 }
@@ -422,7 +431,8 @@ void RelabelConfigUnittest::TestLabelKeep() {
     configList = RelabelConfigList();
     APSARA_TEST_TRUE(configList.Init(configJson));
     auto result = labelKeepLabels;
-    configList.Process(result);
+    vector<string> toDelete;
+    configList.Process(result, toDelete);
     APSARA_TEST_EQUAL((size_t)2, result.Size());
     APSARA_TEST_EQUAL("172.17.0.3", result.Get("__meta_kubernetes_pod_ip"));
     APSARA_TEST_EQUAL("node-exporter", result.Get("__meta_kubernetes_pod_label_app"));
@@ -467,7 +477,8 @@ void RelabelConfigUnittest::TestMultiRelabel() {
     configList = RelabelConfigList();
     APSARA_TEST_TRUE(configList.Init(configJson));
     auto result = labels;
-    APSARA_TEST_TRUE(configList.Process(result));
+    vector<string> toDelete;
+    APSARA_TEST_TRUE(configList.Process(result, toDelete));
     APSARA_TEST_EQUAL((size_t)3, result.Size());
     APSARA_TEST_EQUAL("172.17.0.3:9100", result.Get("__address__"));
 
@@ -475,7 +486,7 @@ void RelabelConfigUnittest::TestMultiRelabel() {
     configList = RelabelConfigList();
     APSARA_TEST_TRUE(configList.Init(configJson));
     // result = labels;
-    configList.Process(result);
+    APSARA_TEST_TRUE(configList.Process(result, toDelete));
 }
 
 UNIT_TEST_CASE(ActionConverterUnittest, TestStringToAction)

--- a/core/unittest/prometheus/RelabelUnittest.cpp
+++ b/core/unittest/prometheus/RelabelUnittest.cpp
@@ -485,7 +485,7 @@ void RelabelConfigUnittest::TestMultiRelabel() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr2, configJson, errorMsg));
     configList = RelabelConfigList();
     APSARA_TEST_TRUE(configList.Init(configJson));
-    // result = labels;
+    result = labels;
     APSARA_TEST_TRUE(configList.Process(result, toDelete));
 }
 


### PR DESCRIPTION
200*5000 场景优化前 181MB、0.733C，优化后150MB、0.686C, 对应18%的内存提升和7%的 CPU 提升