### PR TITLE
fix: convert chinese log path on windows

### DIFF
--- a/core/file_server/reader/LogFileReader.h
+++ b/core/file_server/reader/LogFileReader.h
@@ -233,8 +233,8 @@ public:
     bool GetSymbolicLinkFlag() const { return mSymbolicLinkFlag; }
 
     /// @return e.g. `/home/admin/access.log`
-    const std::string& GetConvertedPath() const { return mDockerPath.empty() ? mHostLogPath : mDockerPath; }
-
+    const std::string& GetConvertedPath() const;
+    
     const std::string& GetHostLogPathFile() const { return mHostLogPathFile; }
 
     int64_t GetFileSize() const { return mLastFileSize; }

--- a/core/runner/ProcessorRunner.cpp
+++ b/core/runner/ProcessorRunner.cpp
@@ -31,12 +31,6 @@ DECLARE_FLAG_INT32(max_send_log_group_size);
 
 using namespace std;
 
-#if defined(_MSC_VER)
-// On Windows, if Chinese config base path is used, the log path will be converted to GBK,
-// so the __tag__.__path__ have to be converted back to UTF8 to avoid bad display.
-// Note: enable this will spend CPU to do transformation.
-DEFINE_FLAG_BOOL(enable_chinese_tag_path, "Enable Chinese __tag__.__path__", true);
-#endif
 DEFINE_FLAG_INT32(default_flush_merged_buffer_interval, "default flush merged buffer, seconds", 1);
 DEFINE_FLAG_INT32(processor_runner_exit_timeout_secs, "", 60);
 


### PR DESCRIPTION
- 问题：windows下的logPath需要转码才能显示正常
- 影响：1.8改造的时候就把这个给漏了。因为此问题只有windows才有，而windows从1.6之后没有发过版，因此没有线上影响。