### PR TITLE
Fix alarm send fail

### DIFF
--- a/core/monitor/LogtailAlarm.cpp
+++ b/core/monitor/LogtailAlarm.cpp
@@ -194,7 +194,15 @@ void LogtailAlarm::SendAllRegionAlarm() {
             // check sender queue status, if invalid jump this region
 
             QueueKey alarmPrjLogstoreKey = QueueKeyManager::GetInstance()->GetKey(
-                "-flusher_sls-" + GetProfileSender()->GetProfileProjectName(region) + "#logtail_alarm");
+                GetProfileSender()->GetProfileProjectName(region) + "-" + "logtail_alarm");
+            if (SenderQueueManager::GetInstance()->GetQueue(alarmPrjLogstoreKey) == nullptr) {
+                PipelineContext ctx;
+                SenderQueueManager::GetInstance()->CreateQueue(
+                    alarmPrjLogstoreKey,
+                    "",
+                    ctx,
+                    std::unordered_map<std::string, std::shared_ptr<ConcurrencyLimiter>>());
+            }
             if (!SenderQueueManager::GetInstance()->IsValidToPush(alarmPrjLogstoreKey)) {
                 // jump this region
                 ++sendRegionIndex;


### PR DESCRIPTION
1. 统一自监控模块SenderQueue的Key的格式为project-logstore
2. 修复SenderQueueKey不存在导致的alarm发送失败问题