### PR TITLE
feat: add context for config server v2 pb

### DIFF
--- a/config_server/protocol/v2/README.md
+++ b/config_server/protocol/v2/README.md
@@ -174,7 +174,7 @@ Server：应当通过capbilitiies上报Server自身的能力，这样如果新�
 
 Client：Agent启动后第一次向Server汇报全量信息，request字段应填尽填。request\_id、sequence\_num、capabilities、instance\_id、agent\_type、startup\_time为必填字段。
 
-Server：Server根据上报的信息返回响应。pipeline\_config\_updates、instance\_config\_updates中包含agent需要同步的配置，updates中必然包含name和version，是否包含detail取决于server端实现。custom\_command_updates包含要求agent执行的命令command中必然包含type、name和expire\_time。
+Server：Server根据上报的信息返回响应。pipeline\_config\_updates、instance\_config\_updates中包含agent需要同步的配置，updates中必然包含name和version，是否包含详情context和detail取决于server端实现。custom\_command_updates包含要求agent执行的命令command中必然包含type、name和expire\_time。
 
 Server是否保存Client信息取决于Server实现，如果服务端找不到或保存的sequence\_num + 1 ≠ 心跳的sequence\_num，那么就立刻返回并且flags中必须设置ReportFullStatus标识位。
 
@@ -257,5 +257,6 @@ Server: 服务端正常返回时HeartbeatResponse中的code应始终设置为0�
 Client: 当HeartbeatResponse中的code为0时，Agent应该正常处理下发的配置。当HeartbeatResponse中的code不为0时，Agent必须忽略除code和message外的其他字段，并择机重试。
 
 ### 辅助信息
-在command\_info, command\_detail, config\_info, config\_detail中，都预留有context字段，可以用于传递一些用户自定义的辅助信息。\
+在command\_info, command\_detail, config\_info, config\_detail中，都预留了context字段，可以用于传递一些额外的用户自定义的辅助信息。\
+
 注意：context仅作传递辅助信息使用，不会对管控行为造成任何影响。

--- a/config_server/protocol/v2/README.md
+++ b/config_server/protocol/v2/README.md
@@ -52,7 +52,7 @@
         int64 version = 2;       // Required, Config's version number or hash code
         ConfigStatus status = 3; // Config's status
         string message = 4;      // Optional error message
-        map<string, bytes> context = 5;   // Optional context
+        map<string, bytes> extra = 5;   // Optional extra info
     }
 
     // Define the Command information carried in the request
@@ -61,7 +61,7 @@
         string name = 2;         // Required, Command's unique identification
         ConfigStatus status = 3; // Command's status
         string message = 4;      // Optional error message
-        map<string, bytes> context = 5;   // Optional context
+        map<string, bytes> extra = 5;   // Optional extra info
     }
 
     // Define Agent's basic attributes
@@ -114,7 +114,7 @@
         string name = 1;        // Required, Config's unique identification
         int64 version = 2;      // Required, Config's version number or hash code
         bytes detail = 3;       // Required, Config's detail
-        map<string, bytes> context = 4;   // Optional context
+        map<string, bytes> extra = 4;   // Optional extra info
     }
 
     message CommandDetail {
@@ -122,7 +122,7 @@
         string name = 2;                // Required, Command name
         bytes detail = 3;               // Required, Command's detail
         int64 expire_time = 4;          // After which the command can be safely removed from history
-        map<string, bytes> context = 5;   // Optional context
+        map<string, bytes> extra = 5;   // Optional extra info
     }
 
     enum ServerCapabilities {
@@ -174,7 +174,7 @@ Server：应当通过capbilitiies上报Server自身的能力，这样如果新�
 
 Client：Agent启动后第一次向Server汇报全量信息，request字段应填尽填。request\_id、sequence\_num、capabilities、instance\_id、agent\_type、startup\_time为必填字段。
 
-Server：Server根据上报的信息返回响应。pipeline\_config\_updates、instance\_config\_updates中包含agent需要同步的配置，updates中必然包含name和version，是否包含详情context和detail取决于server端实现。custom\_command_updates包含要求agent执行的命令command中必然包含type、name和expire\_time。
+Server：Server根据上报的信息返回响应。pipeline\_config\_updates、instance\_config\_updates中包含agent需要同步的配置，updates中必然包含name和version，是否包含detail取决于server端实现。custom\_command_updates包含要求agent执行的命令command中必然包含type、name和expire\_time。
 
 Server是否保存Client信息取决于Server实现，如果服务端找不到或保存的sequence\_num + 1 ≠ 心跳的sequence\_num，那么就立刻返回并且flags中必须设置ReportFullStatus标识位。
 
@@ -257,6 +257,6 @@ Server: 服务端正常返回时HeartbeatResponse中的code应始终设置为0�
 Client: 当HeartbeatResponse中的code为0时，Agent应该正常处理下发的配置。当HeartbeatResponse中的code不为0时，Agent必须忽略除code和message外的其他字段，并择机重试。
 
 ### 辅助信息
-在command\_info, command\_detail, config\_info, config\_detail中，都预留了context字段，可以用于传递一些额外的用户自定义的辅助信息。\
+在command\_info, command\_detail, config\_info, config\_detail中，都预留了extra字段，可以用于传递一些额外的用户自定义的辅助信息。\
 
-注意：context仅作传递辅助信息使用，不会对管控行为造成任何影响。
+注意：extra字段仅作传递辅助信息使用，不会对管控行为造成任何影响。

--- a/config_server/protocol/v2/README.md
+++ b/config_server/protocol/v2/README.md
@@ -51,6 +51,8 @@
         string name = 1;         // Required, Config's unique identification
         int64 version = 2;       // Required, Config's version number or hash code
         ConfigStatus status = 3; // Config's status
+        string message = 4;      // Optional error message
+        map<string, bytes> context = 5;   // Optional context
     }
 
     // Define the Command information carried in the request
@@ -58,6 +60,8 @@
         string type = 1;         // Command's type
         string name = 2;         // Required, Command's unique identification
         ConfigStatus status = 3; // Command's status
+        string message = 4;      // Optional error message
+        map<string, bytes> context = 5;   // Optional context
     }
 
     // Define Agent's basic attributes
@@ -110,6 +114,7 @@
         string name = 1;        // Required, Config's unique identification
         int64 version = 2;      // Required, Config's version number or hash code
         bytes detail = 3;       // Required, Config's detail
+        map<string, bytes> context = 4;   // Optional context
     }
 
     message CommandDetail {
@@ -117,6 +122,7 @@
         string name = 2;                // Required, Command name
         bytes detail = 3;               // Required, Command's detail
         int64 expire_time = 4;          // After which the command can be safely removed from history
+        map<string, bytes> context = 5;   // Optional context
     }
 
     enum ServerCapabilities {
@@ -168,7 +174,7 @@ Server：应当通过capbilitiies上报Server自身的能力，这样如果新�
 
 Client：Agent启动后第一次向Server汇报全量信息，request字段应填尽填。request\_id、sequence\_num、capabilities、instance\_id、agent\_type、startup\_time为必填字段。
 
-Server：Server根据上报的信息返回响应。pipeline\_config\_updates、instance\_config\_updates中包含agent需要同步的配置，updates中必然包含name和version，是否包含详情context和detail取决于server端实现。custom\_command_updates包含要求agent执行的命令command中必然包含type、name和expire\_time。
+Server：Server根据上报的信息返回响应。pipeline\_config\_updates、instance\_config\_updates中包含agent需要同步的配置，updates中必然包含name和version，是否包含detail取决于server端实现。custom\_command_updates包含要求agent执行的命令command中必然包含type、name和expire\_time。
 
 Server是否保存Client信息取决于Server实现，如果服务端找不到或保存的sequence\_num + 1 ≠ 心跳的sequence\_num，那么就立刻返回并且flags中必须设置ReportFullStatus标识位。
 
@@ -249,3 +255,7 @@ Server: 如果上报+已知的Agent状态中，缺少应下发的custom\_comman
 Server: 服务端正常返回时HeartbeatResponse中的code应始终设置为0，而当服务端异常时，必须将HeartbeatResponse中的code设置为非0，HeartbeatResponse中的message应包含错误信息，此时Response中的其他字段必须为空。
 
 Client: 当HeartbeatResponse中的code为0时，Agent应该正常处理下发的配置。当HeartbeatResponse中的code不为0时，Agent必须忽略除code和message外的其他字段，并择机重试。
+
+### 辅助信息
+在command\_info, command\_detail, config\_info, config\_detail中，都预留有context字段，可以用于传递一些用户自定义的辅助信息。\
+注意：context仅作传递辅助信息使用，不会对管控行为造成任何影响。

--- a/config_server/protocol/v2/agentV2.proto
+++ b/config_server/protocol/v2/agentV2.proto
@@ -25,7 +25,7 @@ message ConfigInfo {
     int64 version = 2;       // Required, Config's version number or hash code
     ConfigStatus status = 3; // Config's status
     string message = 4;      // Optional error message
-    map<string, bytes> context = 100;   // Optional context
+    map<string, bytes> context = 5;   // Optional context
 }
 
 // Define the Command information carried in the request
@@ -34,7 +34,7 @@ message CommandInfo {
     string name = 2;         // Required, Command's unique identification
     ConfigStatus status = 3; // Command's status
     string message = 4;      // Optional error message
-    map<string, bytes> context = 100;   // Optional context
+    map<string, bytes> context = 5;   // Optional context
 }
 
 // Define Agent's basic attributes
@@ -96,7 +96,7 @@ message ConfigDetail {
     string name = 1;        // Required, Config's unique identification
     int64 version = 2;      // Required, Config's version number or hash code
     bytes detail = 3;       // Required, Config's detail
-    map<string, bytes> context = 100;   // Optional context
+    map<string, bytes> context = 4;   // Optional context
 }
 
 message CommandDetail {
@@ -104,7 +104,7 @@ message CommandDetail {
     string name = 2;                // Required, Command name
     bytes detail = 3;               // Required, Command's detail
     int64 expire_time = 4;          // After which the command can be safely removed from history
-    map<string, bytes> context = 100;   // Optional context
+    map<string, bytes> context = 5;   // Optional context
 }
 
 enum ServerCapabilities {

--- a/config_server/protocol/v2/agentV2.proto
+++ b/config_server/protocol/v2/agentV2.proto
@@ -25,7 +25,7 @@ message ConfigInfo {
     int64 version = 2;       // Required, Config's version number or hash code
     ConfigStatus status = 3; // Config's status
     string message = 4;      // Optional error message
-    map<string, bytes> context = 5;   // Optional context
+    map<string, bytes> extra = 5;   // Optional extra info
 }
 
 // Define the Command information carried in the request
@@ -34,7 +34,7 @@ message CommandInfo {
     string name = 2;         // Required, Command's unique identification
     ConfigStatus status = 3; // Command's status
     string message = 4;      // Optional error message
-    map<string, bytes> context = 5;   // Optional context
+    map<string, bytes> extra = 5;   // Optional extra info
 }
 
 // Define Agent's basic attributes
@@ -96,7 +96,7 @@ message ConfigDetail {
     string name = 1;        // Required, Config's unique identification
     int64 version = 2;      // Required, Config's version number or hash code
     bytes detail = 3;       // Required, Config's detail
-    map<string, bytes> context = 4;   // Optional context
+    map<string, bytes> extra = 4;   // Optional extra info
 }
 
 message CommandDetail {
@@ -104,7 +104,7 @@ message CommandDetail {
     string name = 2;                // Required, Command name
     bytes detail = 3;               // Required, Command's detail
     int64 expire_time = 4;          // After which the command can be safely removed from history
-    map<string, bytes> context = 5;   // Optional context
+    map<string, bytes> extra = 5;   // Optional extra info
 }
 
 enum ServerCapabilities {

--- a/config_server/protocol/v2/agentV2.proto
+++ b/config_server/protocol/v2/agentV2.proto
@@ -25,7 +25,7 @@ message ConfigInfo {
     int64 version = 2;       // Required, Config's version number or hash code
     ConfigStatus status = 3; // Config's status
     string message = 4;      // Optional error message
-    map<string, bytes> context = 100;   // context
+    map<string, bytes> context = 100;   // Optional context
 }
 
 // Define the Command information carried in the request
@@ -34,7 +34,7 @@ message CommandInfo {
     string name = 2;         // Required, Command's unique identification
     ConfigStatus status = 3; // Command's status
     string message = 4;      // Optional error message
-    map<string, bytes> context = 100;   // context
+    map<string, bytes> context = 100;   // Optional context
 }
 
 // Define Agent's basic attributes
@@ -96,7 +96,7 @@ message ConfigDetail {
     string name = 1;        // Required, Config's unique identification
     int64 version = 2;      // Required, Config's version number or hash code
     bytes detail = 3;       // Required, Config's detail
-    map<string, bytes> context = 100;   // context
+    map<string, bytes> context = 100;   // Optional context
 }
 
 message CommandDetail {
@@ -104,7 +104,7 @@ message CommandDetail {
     string name = 2;                // Required, Command name
     bytes detail = 3;               // Required, Command's detail
     int64 expire_time = 4;          // After which the command can be safely removed from history
-    map<string, bytes> context = 100;   // context
+    map<string, bytes> context = 100;   // Optional context
 }
 
 enum ServerCapabilities {

--- a/config_server/protocol/v2/agentV2.proto
+++ b/config_server/protocol/v2/agentV2.proto
@@ -25,6 +25,7 @@ message ConfigInfo {
     int64 version = 2;       // Required, Config's version number or hash code
     ConfigStatus status = 3; // Config's status
     string message = 4;      // Optional error message
+    map<string, bytes> context = 100;   // context
 }
 
 // Define the Command information carried in the request
@@ -33,6 +34,7 @@ message CommandInfo {
     string name = 2;         // Required, Command's unique identification
     ConfigStatus status = 3; // Command's status
     string message = 4;      // Optional error message
+    map<string, bytes> context = 100;   // context
 }
 
 // Define Agent's basic attributes
@@ -94,6 +96,7 @@ message ConfigDetail {
     string name = 1;        // Required, Config's unique identification
     int64 version = 2;      // Required, Config's version number or hash code
     bytes detail = 3;       // Required, Config's detail
+    map<string, bytes> context = 100;   // context
 }
 
 message CommandDetail {
@@ -101,6 +104,7 @@ message CommandDetail {
     string name = 2;                // Required, Command name
     bytes detail = 3;               // Required, Command's detail
     int64 expire_time = 4;          // After which the command can be safely removed from history
+    map<string, bytes> context = 100;   // context
 }
 
 enum ServerCapabilities {


### PR DESCRIPTION
Change-Id: I58a7d73be66857967f6c0f54cd67877ee6945dae


给管控协议的流水线下发及操作指令增加一个额外可选的上下文，用来传递一些额外信息。