### PR TITLE
read blocked event as soon as process queue triggers feedback to improve file reading performance

### DIFF
--- a/core/file_server/event/BlockEventManager.cpp
+++ b/core/file_server/event/BlockEventManager.cpp
@@ -17,6 +17,7 @@
 #include "common/Flags.h"
 #include "common/HashUtil.h"
 #include "common/StringTools.h"
+#include "file_server/event_handler/LogInput.h"
 #include "logger/Logger.h"
 #include "pipeline/queue/ProcessQueueManager.h"
 
@@ -69,8 +70,11 @@ BlockedEventManager::~BlockedEventManager() {
 }
 
 void BlockedEventManager::Feedback(int64_t key) {
-    lock_guard<mutex> lock(mFeedbackQueueMux);
-    mFeedbackQueue.emplace_back(key);
+    {
+        lock_guard<mutex> lock(mFeedbackQueueMux);
+        mFeedbackQueue.emplace_back(key);
+    }
+    LogInput::GetInstance()->Trigger();
 }
 
 void BlockedEventManager::UpdateBlockEvent(

--- a/core/file_server/event_handler/LogInput.cpp
+++ b/core/file_server/event_handler/LogInput.cpp
@@ -393,8 +393,7 @@ void* LogInput::ProcessLoop() {
             else
                 ProcessEvent(dispatcher, ev);
         } else {
-            mutex mux;
-            unique_lock<mutex> lock(mux);
+            unique_lock<mutex> lock(mFeedbackMux);
             mFeedbackCV.wait_for(lock, chrono::microseconds(INT32_FLAG(log_input_thread_wait_interval)));
         }
 

--- a/core/file_server/event_handler/LogInput.h
+++ b/core/file_server/event_handler/LogInput.h
@@ -60,6 +60,8 @@ public:
 
     int32_t GetLastReadEventTime() { return mLastReadEventTime; }
 
+    void Trigger() { mFeedbackCV.notify_one(); }
+
 private:
     LogInput();
     ~LogInput();
@@ -88,6 +90,8 @@ private:
     std::atomic_int mLastReadEventTime{0};
     mutable std::mutex mThreadRunningMux;
     mutable std::condition_variable mStopCV;
+
+    mutable std::condition_variable mFeedbackCV;
 
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class LogInputUnittest;

--- a/core/file_server/event_handler/LogInput.h
+++ b/core/file_server/event_handler/LogInput.h
@@ -91,6 +91,7 @@ private:
     mutable std::mutex mThreadRunningMux;
     mutable std::condition_variable mStopCV;
 
+    mutable std::mutex mFeedbackMux;
     mutable std::condition_variable mFeedbackCV;
 
 #ifdef APSARA_UNIT_TEST_MAIN


### PR DESCRIPTION
- 现状：当LogInput线程没有事件的时候，会等待20ms再尝试读取事件。如果在这等待时间里，处理队列空了，理论上应该立刻读取相应的block event，但是实际只能等到睡眠结束才能读。对于大流量的日志场景，会严重影响读取性能（约有30%的性能损耗）
- 方案：增加一个通信机制，处理队列空了以后立刻读取block event。