### PR TITLE
Fix the issue of missing container information caused by the event sequence when docker compose is repeatedly up.

### DIFF
--- a/pkg/helper/docker_center.go
+++ b/pkg/helper/docker_center.go
@@ -16,6 +16,7 @@ package helper
 
 import (
 	"context"
+	"errors"
 	"hash/fnv"
 	"path"
 	"regexp"
@@ -1022,6 +1023,35 @@ func (dc *DockerCenter) updateContainer(id string, container *DockerInfoDetail) 
 	dc.refreshLastUpdateMapTime()
 }
 
+func (dc *DockerCenter) inspectOneContainer(containerID string) (types.ContainerJSON, error) {
+	var err error
+	var containerDetail types.ContainerJSON
+	for idx := 0; idx < 3; idx++ {
+		if containerDetail, err = dc.client.ContainerInspect(context.Background(), containerID); err == nil {
+			break
+		}
+		time.Sleep(time.Second * 5)
+	}
+	if err != nil {
+		dc.setLastError(err, "inspect container error "+containerID)
+		return types.ContainerJSON{}, err
+	}
+	if !ContainerProcessAlive(containerDetail.State.Pid) {
+		containerDetail.State.Status = ContainerStatusExited
+		finishedAt := containerDetail.State.FinishedAt
+		finishedAtTime, _ := time.Parse(time.RFC3339, finishedAt)
+		now := time.Now()
+		duration := now.Sub(finishedAtTime)
+		if duration >= ContainerInfoDeletedTimeout {
+			errMsg := "inspect time out container " + containerID
+			err = errors.New(errMsg)
+			dc.setLastError(err, errMsg)
+			return types.ContainerJSON{}, err
+		}
+	}
+	return containerDetail, nil
+}
+
 func (dc *DockerCenter) fetchAll() error {
 	dc.containerStateLock.Lock()
 	defer dc.containerStateLock.Unlock()
@@ -1034,27 +1064,9 @@ func (dc *DockerCenter) fetchAll() error {
 	var containerMap = make(map[string]*DockerInfoDetail)
 
 	for _, container := range containers {
-		var containerDetail types.ContainerJSON
-		for idx := 0; idx < 3; idx++ {
-			if containerDetail, err = dc.client.ContainerInspect(context.Background(), container.ID); err == nil {
-				break
-			}
-			time.Sleep(time.Second * 5)
-		}
+		containerDetail, err := dc.inspectOneContainer(container.ID)
 		if err == nil {
-			if !ContainerProcessAlive(containerDetail.State.Pid) {
-				containerDetail.State.Status = ContainerStatusExited
-				finishedAt := containerDetail.State.FinishedAt
-				finishedAtTime, _ := time.Parse(time.RFC3339, finishedAt)
-				now := time.Now()
-				duration := now.Sub(finishedAtTime)
-				if duration >= ContainerInfoDeletedTimeout {
-					continue
-				}
-			}
 			containerMap[container.ID] = dc.CreateInfoDetail(containerDetail, envConfigPrefix, false)
-		} else {
-			dc.setLastError(err, "inspect container error "+container.ID)
 		}
 	}
 	dc.updateContainers(containerMap)
@@ -1065,13 +1077,9 @@ func (dc *DockerCenter) fetchAll() error {
 func (dc *DockerCenter) fetchOne(containerID string, tryFindSandbox bool) error {
 	dc.containerStateLock.Lock()
 	defer dc.containerStateLock.Unlock()
-	containerDetail, err := dc.client.ContainerInspect(context.Background(), containerID)
+	containerDetail, err := dc.inspectOneContainer(containerID)
 	if err != nil {
-		dc.setLastError(err, "inspect container error "+containerID)
 		return err
-	}
-	if containerDetail.State.Status == ContainerStatusRunning && !ContainerProcessAlive(containerDetail.State.Pid) {
-		containerDetail.State.Status = ContainerStatusExited
 	}
 	// docker 场景下
 	// tryFindSandbox如果是false, 那么fetchOne的地方应该会调用两次，一次是sandbox的id，一次是业务容器的id

--- a/pkg/helper/docker_center.go
+++ b/pkg/helper/docker_center.go
@@ -1064,7 +1064,8 @@ func (dc *DockerCenter) fetchAll() error {
 	var containerMap = make(map[string]*DockerInfoDetail)
 
 	for _, container := range containers {
-		containerDetail, err := dc.inspectOneContainer(container.ID)
+		var containerDetail types.ContainerJSON
+		containerDetail, err = dc.inspectOneContainer(container.ID)
 		if err == nil {
 			containerMap[container.ID] = dc.CreateInfoDetail(containerDetail, envConfigPrefix, false)
 		}


### PR DESCRIPTION
问题描述： docker compose环境下，会发现容器信息发现模块会获取的created状态的容器，参见https://alidocs.dingtalk.com/i/nodes/N7dx2rn0JbxOaqnACxvaegn5WMGjLRb3

复现条件：
docker compose up -d命令，启动一个容器之后，修改docker-compose.yaml文件，然后再执行docker compose up -d

问题原因分析：
![image](https://github.com/user-attachments/assets/f5218b60-de54-4edb-bd6b-49ff570dd27f)

从事件顺序可以看到，新旧容器的交替顺序是这样的：
新容器create(其他名字)，旧容器杀、停、删，新容器rename，新容器start
![image](https://github.com/user-attachments/assets/96f225a5-551c-4927-8b97-b597be07b982)
事件监听rename的时候，会fetchone，rename的时候，容器还没有start，此时fetchone获取的就是created状态的容器信息。标准输出的插件里面，会根据containerID缓存容器信息，所以及时后面fetchone又更新了容器信息，标准输出也感知不到

修复方案：
fetchone里强校验容器状态