### PR TITLE
SymLinkName, PidFileName, and AgentPrefix support logtail_mode.

### DIFF
--- a/core/app_config/AppConfig.cpp
+++ b/core/app_config/AppConfig.cpp
@@ -25,6 +25,7 @@
 #include "common/FileSystemUtil.h"
 #include "common/JsonUtil.h"
 #include "common/LogtailCommonFlags.h"
+#include "common/version.h"
 #include "config/InstanceConfigManager.h"
 #include "config/watcher/InstanceConfigWatcher.h"
 #include "file_server/ConfigManager.h"
@@ -520,7 +521,7 @@ std::string GetAgentName() {
         return "ilogtail";
     } else {
         return "loongcollector";
-    } 
+    }
 }
 
 std::string GetMonitorInfoFileName() {
@@ -528,6 +529,22 @@ std::string GetMonitorInfoFileName() {
         return "logtail_monitor_info";
     } else {
         return "loongcollector_monitor_info";
+    }
+}
+
+std::string GetSymLinkName() {
+    if (BOOL_FLAG(logtail_mode)) {
+        return GetProcessExecutionDir() + "ilogtail";
+    } else {
+        return GetProcessExecutionDir() + "loongcollector";
+    }
+}
+
+std::string GetPidFileName() {
+    if (BOOL_FLAG(logtail_mode)) {
+        return GetProcessExecutionDir() + ILOGTAIL_PREFIX + ILOGTAIL_VERSION + ILOGTAIL_PIDFILE_SUFFIX;
+    } else {
+        return GetAgentRunDir() + "loongcollector.pid";
     }
 }
 

--- a/core/app_config/AppConfig.cpp
+++ b/core/app_config/AppConfig.cpp
@@ -1538,8 +1538,8 @@ void AppConfig::ReadFlagsFromMap(const std::unordered_map<std::string, std::stri
  *    - 记录无法转换的值
  */
 void AppConfig::RecurseParseJsonToFlags(const Json::Value& confJson, std::string prefix) {
-    const static unordered_set<string> sIgnoreKeySet = {"data_server_list", "legacy_data_server_list"};
-    const static unordered_set<string> sForceKeySet = {"config_server_address_list", "config_server_list"};
+    const static unordered_set<string> sIgnoreKeySet = {"data_server_list", "data_servers"};
+    const static unordered_set<string> sForceKeySet = {"config_server_address_list", "config_servers"};
     for (auto name : confJson.getMemberNames()) {
         auto jsonvalue = confJson[name];
         string fullName;

--- a/core/app_config/AppConfig.cpp
+++ b/core/app_config/AppConfig.cpp
@@ -40,6 +40,10 @@
 
 using namespace std;
 
+#define ILOGTAIL_PREFIX "ilogtail_"
+#define ILOGTAIL_PIDFILE_SUFFIX ".pid"
+#define LOONGCOLLECTOR_PREFIX "loongcollector_"
+
 DEFINE_FLAG_BOOL(logtail_mode, "logtail mode", false);
 DEFINE_FLAG_INT32(max_buffer_num, "max size", 40);
 DEFINE_FLAG_INT32(pub_max_buffer_num, "max size", 8);

--- a/core/app_config/AppConfig.cpp
+++ b/core/app_config/AppConfig.cpp
@@ -548,6 +548,14 @@ std::string GetPidFileName() {
     }
 }
 
+std::string GetAgentPrefix() {
+    if (BOOL_FLAG(logtail_mode)) {
+        return ILOGTAIL_PREFIX;
+    } else {
+        return LOONGCOLLECTOR_PREFIX;
+    }
+}
+
 AppConfig::AppConfig() {
     LOG_INFO(sLogger, ("AppConfig AppConfig", "success"));
     SetIlogtailConfigJson("");

--- a/core/app_config/AppConfig.h
+++ b/core/app_config/AppConfig.h
@@ -62,6 +62,7 @@ std::string GetAgentName();
 std::string GetMonitorInfoFileName();
 std::string GetSymLinkName();
 std::string GetPidFileName();
+std::string GetAgentPrefix();
 
 template <class T>
 class DoubleBuffer {

--- a/core/app_config/AppConfig.h
+++ b/core/app_config/AppConfig.h
@@ -60,6 +60,8 @@ std::string GetVersionTag();
 std::string GetGoPluginCheckpoint();
 std::string GetAgentName();
 std::string GetMonitorInfoFileName();
+std::string GetSymLinkName();
+std::string GetPidFileName();
 
 template <class T>
 class DoubleBuffer {
@@ -304,7 +306,7 @@ private:
 
 public:
     AppConfig();
-    ~AppConfig() {};
+    ~AppConfig(){};
 
     void LoadInstanceConfig(const std::map<std::string, std::shared_ptr<InstanceConfig>>&);
 

--- a/core/common/version.h
+++ b/core/common/version.h
@@ -22,8 +22,4 @@ extern const char* const ILOGTAIL_UPDATE_SUFFIX;
 extern const char* const ILOGTAIL_GIT_HASH;
 extern const char* const ILOGTAIL_BUILD_DATE;
 
-#define ILOGTAIL_PREFIX "ilogtail_"
-#define ILOGTAIL_PIDFILE_SUFFIX ".pid"
-#define LOONGCOLLECTOR_PREFIX "loongcollector_"
-
 #endif

--- a/core/common/version.h
+++ b/core/common/version.h
@@ -24,5 +24,6 @@ extern const char* const ILOGTAIL_BUILD_DATE;
 
 #define ILOGTAIL_PREFIX "ilogtail_"
 #define ILOGTAIL_PIDFILE_SUFFIX ".pid"
+#define LOONGCOLLECTOR_PREFIX "loongcollector_"
 
 #endif


### PR DESCRIPTION
This pull request introduces several new utility methods and constants to the `AppConfig` class in the `core/app_config` module. These changes aim to enhance the configuration management and file naming conventions based on the `logtail_mode` flag.

Key changes include:

### New utility methods in `AppConfig`:

* Added `GetSymLinkName` method to determine the symbolic link name based on the `logtail_mode` flag.
* Added `GetPidFileName` method to generate the PID file name depending on the `logtail_mode` flag.
* Added `GetAgentPrefix` method to return the appropriate prefix for the agent based on the `logtail_mode` flag.

### Header file updates:

* Declared the new utility methods (`GetSymLinkName`, `GetPidFileName`, and `GetAgentPrefix`) in `core/app_config/AppConfig.h`.

### Constants definition:

* Introduced `LOONGCOLLECTOR_PREFIX` constant in `core/common/version.h` to support the new methods.

### Additional includes:

* Included `common/version.h` in `core/app_config/AppConfig.cpp` to access the newly defined constants.