### PR TITLE
Fix: fix flushing delay when multiple flushers exist

### DIFF
--- a/core/pipeline/Pipeline.cpp
+++ b/core/pipeline/Pipeline.cpp
@@ -167,7 +167,7 @@ bool Pipeline::Init(PipelineConfig&& config) {
             = PluginRegistry::GetInstance()->CreateFlusher(pluginType, GenNextPluginMeta(false));
         if (flusher) {
             Json::Value optionalGoPipeline;
-            if (!flusher->Init(detail, mContext, optionalGoPipeline)) {
+            if (!flusher->Init(detail, mContext, i, optionalGoPipeline)) {
                 return false;
             }
             mFlushers.emplace_back(std::move(flusher));

--- a/core/pipeline/batch/Batcher.h
+++ b/core/pipeline/batch/Batcher.h
@@ -176,7 +176,7 @@ public:
                         }
                         if (mGroupQueue->IsEmpty()) {
                             TimeoutFlushManager::GetInstance()->UpdateRecord(mFlusher->GetContext().GetConfigName(),
-                                                                             0,
+                                                                             mFlusher->GetFlusherIndex(),
                                                                              0,
                                                                              mGroupFlushStrategy->GetTimeoutSecs(),
                                                                              mFlusher);
@@ -193,8 +193,11 @@ public:
                                g.GetSourceBuffer(),
                                g.GetExactlyOnceCheckpoint(),
                                g.GetMetadata(EventGroupMetaKey::SOURCE_ID));
-                    TimeoutFlushManager::GetInstance()->UpdateRecord(
-                        mFlusher->GetContext().GetConfigName(), 0, key, mEventFlushStrategy.GetTimeoutSecs(), mFlusher);
+                    TimeoutFlushManager::GetInstance()->UpdateRecord(mFlusher->GetContext().GetConfigName(),
+                                                                     mFlusher->GetFlusherIndex(),
+                                                                     key,
+                                                                     mEventFlushStrategy.GetTimeoutSecs(),
+                                                                     mFlusher);
                     mBufferedGroupsTotal->Add(1);
                     mBufferedDataSizeByte->Add(item.DataSize());
                 } else if (i == 0) {
@@ -243,8 +246,11 @@ public:
             mGroupQueue->Flush(res);
         }
         if (mGroupQueue->IsEmpty()) {
-            TimeoutFlushManager::GetInstance()->UpdateRecord(
-                mFlusher->GetContext().GetConfigName(), 0, 0, mGroupFlushStrategy->GetTimeoutSecs(), mFlusher);
+            TimeoutFlushManager::GetInstance()->UpdateRecord(mFlusher->GetContext().GetConfigName(),
+                                                             mFlusher->GetFlusherIndex(),
+                                                             0,
+                                                             mGroupFlushStrategy->GetTimeoutSecs(),
+                                                             mFlusher);
         }
         iter->second.Flush(mGroupQueue.value());
         mEventQueueMap.erase(iter);

--- a/core/pipeline/plugin/instance/FlusherInstance.cpp
+++ b/core/pipeline/plugin/instance/FlusherInstance.cpp
@@ -20,9 +20,10 @@ using namespace std;
 
 namespace logtail {
 
-bool FlusherInstance::Init(const Json::Value& config, PipelineContext& context, Json::Value& optionalGoPipeline) {
+bool FlusherInstance::Init(const Json::Value& config, PipelineContext& context, size_t flusherIdx, Json::Value& optionalGoPipeline) {
     mPlugin->SetContext(context);
     mPlugin->SetPluginID(PluginID());
+    mPlugin->SetFlusherIndex(flusherIdx);
     mPlugin->SetMetricsRecordRef(Name(), PluginID());
     if (!mPlugin->Init(config, optionalGoPipeline)) {
         return false;

--- a/core/pipeline/plugin/instance/FlusherInstance.h
+++ b/core/pipeline/plugin/instance/FlusherInstance.h
@@ -31,12 +31,13 @@ namespace logtail {
 
 class FlusherInstance : public PluginInstance {
 public:
-    FlusherInstance(Flusher* plugin, const PluginInstance::PluginMeta& pluginMeta) : PluginInstance(pluginMeta), mPlugin(plugin) {}
+    FlusherInstance(Flusher* plugin, const PluginInstance::PluginMeta& pluginMeta)
+        : PluginInstance(pluginMeta), mPlugin(plugin) {}
 
     const std::string& Name() const override { return mPlugin->Name(); };
     const Flusher* GetPlugin() const { return mPlugin.get(); }
 
-    bool Init(const Json::Value& config, PipelineContext& context, Json::Value& optionalGoPipeline);
+    bool Init(const Json::Value& config, PipelineContext& context, size_t flusherIdx, Json::Value& optionalGoPipeline);
     bool Start() { return mPlugin->Start(); }
     bool Stop(bool isPipelineRemoving) { return mPlugin->Stop(isPipelineRemoving); }
     bool Send(PipelineEventGroup&& g);

--- a/core/pipeline/plugin/interface/Flusher.h
+++ b/core/pipeline/plugin/interface/Flusher.h
@@ -44,6 +44,8 @@ public:
 
     QueueKey GetQueueKey() const { return mQueueKey; }
     void SetPluginID(const std::string& pluginID) { mPluginID = pluginID; }
+    size_t GetFlusherIndex() { return mIndex; }
+    void SetFlusherIndex(size_t idx) { mIndex = idx; }
     const std::string& GetPluginID() const { return mPluginID; }
 
 protected:
@@ -54,6 +56,7 @@ protected:
 
     QueueKey mQueueKey;
     std::string mPluginID;
+    size_t mIndex = 0;
 
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class FlusherInstanceUnittest;

--- a/core/unittest/pipeline/PipelineUnittest.cpp
+++ b/core/unittest/pipeline/PipelineUnittest.cpp
@@ -2736,13 +2736,13 @@ void PipelineUnittest::TestSend() const {
         {
             auto flusher
                 = PluginRegistry::GetInstance()->CreateFlusher(FlusherMock::sName, pipeline.GenNextPluginMeta(false));
-            flusher->Init(Json::Value(), ctx, tmp);
+            flusher->Init(Json::Value(), ctx, 0, tmp);
             pipeline.mFlushers.emplace_back(std::move(flusher));
         }
         {
             auto flusher
                 = PluginRegistry::GetInstance()->CreateFlusher(FlusherMock::sName, pipeline.GenNextPluginMeta(false));
-            flusher->Init(Json::Value(), ctx, tmp);
+            flusher->Init(Json::Value(), ctx, 0, tmp);
             pipeline.mFlushers.emplace_back(std::move(flusher));
         }
         vector<pair<size_t, const Json::Value*>> configs;
@@ -2788,13 +2788,13 @@ void PipelineUnittest::TestSend() const {
         {
             auto flusher
                 = PluginRegistry::GetInstance()->CreateFlusher(FlusherMock::sName, pipeline.GenNextPluginMeta(false));
-            flusher->Init(Json::Value(), ctx, tmp);
+            flusher->Init(Json::Value(), ctx, 0, tmp);
             pipeline.mFlushers.emplace_back(std::move(flusher));
         }
         {
             auto flusher
                 = PluginRegistry::GetInstance()->CreateFlusher(FlusherMock::sName, pipeline.GenNextPluginMeta(false));
-            flusher->Init(Json::Value(), ctx, tmp);
+            flusher->Init(Json::Value(), ctx, 0, tmp);
             pipeline.mFlushers.emplace_back(std::move(flusher));
         }
 
@@ -2855,13 +2855,13 @@ void PipelineUnittest::TestFlushBatch() const {
     {
         auto flusher
             = PluginRegistry::GetInstance()->CreateFlusher(FlusherMock::sName, pipeline.GenNextPluginMeta(false));
-        flusher->Init(Json::Value(), ctx, tmp);
+        flusher->Init(Json::Value(), ctx, 0, tmp);
         pipeline.mFlushers.emplace_back(std::move(flusher));
     }
     {
         auto flusher
             = PluginRegistry::GetInstance()->CreateFlusher(FlusherMock::sName, pipeline.GenNextPluginMeta(false));
-        flusher->Init(Json::Value(), ctx, tmp);
+        flusher->Init(Json::Value(), ctx, 0, tmp);
         pipeline.mFlushers.emplace_back(std::move(flusher));
     }
     {

--- a/core/unittest/plugin/FlusherInstanceUnittest.cpp
+++ b/core/unittest/plugin/FlusherInstanceUnittest.cpp
@@ -46,7 +46,7 @@ void FlusherInstanceUnittest::TestInit() const {
         = make_unique<FlusherInstance>(new FlusherMock(), PluginInstance::PluginMeta("0"));
     Json::Value config, opt;
     PipelineContext context;
-    APSARA_TEST_TRUE(flusher->Init(config, context, opt));
+    APSARA_TEST_TRUE(flusher->Init(config, context, 0, opt));
     APSARA_TEST_EQUAL(&context, &flusher->GetPlugin()->GetContext());
 }
 


### PR DESCRIPTION
问题在于Batcher预留了Index用于区分不同的flusher但是之前没有实现，全都是默认的0，导致部分数据拿不出来并延迟发送。

当初开发Batcher的时候并没有多flusher的说法