### PR TITLE
Enable OTLP Trace flushing to SLS

### DIFF
--- a/docs/cn/plugins/input/service-otlp.md
+++ b/docs/cn/plugins/input/service-otlp.md
@@ -2,7 +2,7 @@
 
 ## 简介
 
-`service_otlp` `input`插件实现了`ServiceInputV1`和`ServiceInputV2`接口，可以接受`Opentelemetry log/metric/trace protocol`的http/gRPC请求，并且转换输出SLSProto或PipelineGroupEvents。目前尚不支持otlp trace转换到SLSProto。
+`service_otlp` `input`插件实现了`ServiceInputV1`和`ServiceInputV2`接口，可以接受`Opentelemetry log/metric/trace protocol`的http/gRPC请求，并且转换输出SLSProto或PipelineGroupEvents。
 
 ## 版本
 

--- a/pkg/protocol/decoder/opentelemetry/otlpDataToSLSProto.go
+++ b/pkg/protocol/decoder/opentelemetry/otlpDataToSLSProto.go
@@ -427,5 +427,6 @@ func ConvertOtlpTraceRequestV1(otlpTraceReq ptraceotlp.ExportRequest) (logs []*p
 }
 
 func ConvertOtlpTraceV1(otlpTrace ptrace.Traces) (logs []*protocol.Log, err error) {
-	return logs, fmt.Errorf("does_not_support_otlptraces")
+	log, _ := ConvertTrace(otlpTrace)
+	return log, nil
 }


### PR DESCRIPTION
This pull request includes changes to the `service_otlp` plugin documentation and the `ConvertOtlpTraceV1` function to improve functionality and accuracy. The most important changes are detailed below:

Documentation updates:

* [`docs/cn/plugins/input/service-otlp.md`](diffhunk://#diff-f848e2e156c29dd9454c0be16604ae284a69c302916bda7538ade53789190865L5-R5): Removed the note about not supporting OTLP trace conversion to SLSProto, indicating that this functionality is now supported.

Functionality improvements:

* [`pkg/protocol/decoder/opentelemetry/otlpDataToSLSProto.go`](diffhunk://#diff-bca3635bdf846ceebfdf96393ff2c3a38d4e2b03442841f2b3a2ec33ed4568e4L430-R431): Updated the `ConvertOtlpTraceV1` function to convert OTLP traces to logs using the `ConvertTrace` function, removing the previous error return indicating lack of support.