### PR TITLE
fix core caused by failed queue push

### DIFF
--- a/core/runner/ProcessorRunner.cpp
+++ b/core/runner/ProcessorRunner.cpp
@@ -82,6 +82,7 @@ bool ProcessorRunner::PushQueue(QueueKey key, size_t inputIndex, PipelineEventGr
         }
         this_thread::sleep_for(chrono::milliseconds(10));
     }
+    group = std::move(item->mEventGroup);
     return false;
 }
 


### PR DESCRIPTION
当group push失败时，group就已经被move走了，再次调用push会导致空的group。

ps：理论上这段逻辑不应该走到，具体原因还要再看下