### PR TITLE
feat: support dynamic label values and global metrics record.

### DIFF
--- a/pkg/helper/k8smeta/k8s_meta_manager.go
+++ b/pkg/helper/k8smeta/k8s_meta_manager.go
@@ -224,9 +224,8 @@ func GetMetaManagerMetrics() []map[string]string {
 		},
 	}
 
-	return []map[string]string{
-		manager.metricRecord.ExportMetricRecords(),
-	}
+	return manager.metricRecord.ExportMetricRecords()
+
 }
 
 func (m *MetaManager) runServer() {

--- a/pkg/helper/local_context.go
+++ b/pkg/helper/local_context.go
@@ -115,7 +115,7 @@ func (p *LocalContext) ExportMetricRecords() []map[string]string {
 
 	records := make([]map[string]string, 0)
 	for _, metricsRecord := range p.MetricsRecords {
-		records = append(records, metricsRecord.ExportMetricRecords())
+		records = append(records, metricsRecord.ExportMetricRecords()...)
 	}
 	return records
 }

--- a/pluginmanager/context_imp.go
+++ b/pluginmanager/context_imp.go
@@ -140,7 +140,7 @@ func (p *ContextImp) ExportMetricRecords() []map[string]string {
 
 	records := make([]map[string]string, 0)
 	for _, metricsRecord := range p.MetricsRecords {
-		records = append(records, metricsRecord.ExportMetricRecords())
+		records = append(records, metricsRecord.ExportMetricRecords()...)
 	}
 	return records
 }

--- a/pluginmanager/metric_export.go
+++ b/pluginmanager/metric_export.go
@@ -38,7 +38,9 @@ type globalMetricRecords struct {
 }
 
 func RegisterGlobalMetricRecord(labels ...selfmonitor.LabelPair) *selfmonitor.MetricsRecord {
-	record := &selfmonitor.MetricsRecord{Labels: labels}
+	globalLabels := []selfmonitor.LabelPair{{Key: selfmonitor.MetricLabelKeyMetricCategory, Value: "runner"}}
+	globalLabels = append(globalLabels, labels...)
+	record := &selfmonitor.MetricsRecord{Labels: globalLabels}
 	globalMetricRecord.Lock()
 	defer globalMetricRecord.Unlock()
 	globalMetricRecord.records[record] = struct{}{}

--- a/plugins/test/mock/context.go
+++ b/plugins/test/mock/context.go
@@ -119,7 +119,7 @@ func (p *EmptyContext) ExportMetricRecords() []map[string]string {
 
 	records := make([]map[string]string, 0)
 	for _, metricsRecord := range p.MetricsRecords {
-		records = append(records, metricsRecord.ExportMetricRecords())
+		records = append(records, metricsRecord.ExportMetricRecords()...)
 	}
 	return records
 }


### PR DESCRIPTION
1. 增加一个GlobalMetricsRecord，用来记录一些和插件流水线及插件无关的指标
2. 支持将Go单个MetricVector级别的静态Label和动态可变Label Value序列化后转出给c++，原先这部分信息丢失。