### PR TITLE
fix: recover collection progress from old checkpoint to avoid duplication

### DIFF
--- a/core/checkpoint/CheckPointManager.cpp
+++ b/core/checkpoint/CheckPointManager.cpp
@@ -213,7 +213,7 @@ void CheckPointManager::LoadFileCheckPoint(const Json::Value& root) {
             int32_t containerStopped = 0;
             string containerID;
             int32_t lastForceRead = 0;
-            int32_t idxInReaderArray = LogFileReader::CHECKPOINT_IDX_OF_NOT_FOUND;
+            int32_t idxInReaderArray = LogFileReader::CHECKPOINT_IDX_UNDEFINED;
             if (meta.isMember("real_file_name")) {
                 realFilePath = meta["real_file_name"].asString();
             }

--- a/core/checkpoint/CheckPointManager.h
+++ b/core/checkpoint/CheckPointManager.h
@@ -52,7 +52,7 @@ public:
     std::string mConfigName;
     std::string mFileName;
     std::string mRealFileName;
-    int32_t mIdxInReaderArray = LogFileReader::CHECKPOINT_IDX_OF_NOT_FOUND;
+    int32_t mIdxInReaderArray = LogFileReader::CHECKPOINT_IDX_UNDEFINED;
 
     CheckPoint() {}
 

--- a/core/file_server/event_handler/EventHandler.cpp
+++ b/core/file_server/event_handler/EventHandler.cpp
@@ -467,7 +467,7 @@ LogFileReaderPtr ModifyHandler::CreateLogFileReaderPtr(const string& path,
     }
     // should only happen when upgrade from old version, may cause wrong reader array order
     else { // rotate log
-        if (idx != LogFileReader::CHECKPOINT_IDX_OF_NOT_FOUND) {
+        if (idx != LogFileReader::CHECKPOINT_IDX_UNDEFINED) {
             LOG_ERROR(
                 sLogger,
                 ("unexpected checkpoint reader array index, may cause wrong reader array order",

--- a/core/file_server/reader/LogFileReader.h
+++ b/core/file_server/reader/LogFileReader.h
@@ -163,7 +163,7 @@ public:
     static size_t BUFFER_SIZE;
     static const int32_t CHECKPOINT_IDX_OF_NEW_READER_IN_ARRAY = -1;
     static const int32_t CHECKPOINT_IDX_OF_ROTATOR_MAP = -2;
-    static const int32_t CHECKPOINT_IDX_OF_NOT_FOUND = -3;
+    static const int32_t CHECKPOINT_IDX_UNDEFINED = -3;
     std::vector<BaseLineParse*> mLineParsers = {};
     template <typename T>
     T* GetParser(size_t size) {

--- a/core/unittest/event_handler/ModifyHandlerUnittest.cpp
+++ b/core/unittest/event_handler/ModifyHandlerUnittest.cpp
@@ -386,7 +386,7 @@ void ModifyHandlerUnittest::TestRecoverReaderFromCheckpoint() {
     reader5->mLastFileSignatureSize = sigSize;
     reader5->mLastFileSignatureHash = sigHash;
     reader5->mLastFilePos = signature.size();
-    reader5->DumpMetaToMem(false, LogFileReader::CHECKPOINT_IDX_OF_NOT_FOUND);
+    reader5->DumpMetaToMem(false, LogFileReader::CHECKPOINT_IDX_UNDEFINED);
 
     // clear reader map
     handlerPtr.reset(new ModifyHandler(mConfigName, mConfig));
@@ -552,7 +552,7 @@ void ModifyHandlerUnittest::TestRecoverReaderFromCheckpointRotateLog() {
     reader3->mLastFileSignatureSize = sigSize;
     reader3->mLastFileSignatureHash = sigHash;
     reader3->mLastFilePos = signature.size();
-    reader3->DumpMetaToMem(false, LogFileReader::CHECKPOINT_IDX_OF_NOT_FOUND);
+    reader3->DumpMetaToMem(false, LogFileReader::CHECKPOINT_IDX_UNDEFINED);
 
     // clear reader map
     handlerPtr.reset(new ModifyHandler(mConfigName, mConfig));


### PR DESCRIPTION
## 问题
当文件为软链接并且从低版本升级到高版本时，会导致checkpoint失效。

## 修复方案
1. 当backFlag为false的时候（仅当从老版本升级到新版本时候会遇到），遵循老版本的处理逻辑，把reader推到reader array开头。虽然这样可能会导致reader顺序错误，但能保证Checkpoint有效。
2. 从老版本Checkpoint中恢复的reader，应当位于队列的开头。但由于现在引入了对reader的排序机制，会把这类reader的位置再次打乱。仅凭原有CHECKPOINT_IDX_OF_NEW_READER_IN_ARRAY这一个状态无法区分是新reader还是从老版本checkpoint恢复的reader，所以新引入CHECKPOINT_IDX_OF_NOT_FOUND作为Checkpoint的默认状态。