### PR TITLE
add cgroup collector

### DIFF
--- a/core/host_monitor/Constants.cpp
+++ b/core/host_monitor/Constants.cpp
@@ -43,6 +43,7 @@ const std::filesystem::path PROCESS_STATUS = "status";
 const int EXECUTE_SUCCESS = 0;
 const int EXECUTE_FAIL = -1;
 const std::filesystem::path PROCESS_NET_IF_INET6 = "net/if_inet6";
+const std::filesystem::path PROCESS_CGROUP = "cgroups";
 const int64_t SYSTEM_HERTZ = sysconf(_SC_CLK_TCK);
 const long PAGE_SIZE = sysconf(_SC_PAGESIZE);
 

--- a/core/host_monitor/Constants.h
+++ b/core/host_monitor/Constants.h
@@ -50,6 +50,7 @@ const extern int EXECUTE_FAIL;
 const extern std::filesystem::path PROCESS_NET_IF_INET6;
 const extern int64_t SYSTEM_HERTZ;
 const extern long PAGE_SIZE;
+const extern std::filesystem::path PROCESS_CGROUP;
 #ifdef __ENTERPRISE__
 inline constexpr StringView DEFAULT_INSTANCE_ID_LABEL = "instance_id";
 inline constexpr StringView DEFAULT_USER_ID_LABEL = "user_id";

--- a/core/host_monitor/HostMonitorInputRunner.cpp
+++ b/core/host_monitor/HostMonitorInputRunner.cpp
@@ -36,6 +36,7 @@
 #include "host_monitor/Constants.h"
 #include "host_monitor/HostMonitorTimerEvent.h"
 #include "host_monitor/collector/CPUCollector.h"
+#include "host_monitor/collector/CgroupCollector.h"
 #include "host_monitor/collector/DiskCollector.h"
 #include "host_monitor/collector/MemCollector.h"
 #include "host_monitor/collector/NetCollector.h"
@@ -64,6 +65,7 @@ HostMonitorInputRunner::HostMonitorInputRunner() {
     RegisterCollector<DiskCollector>();
     RegisterCollector<ProcessCollector>();
     RegisterCollector<NetCollector>();
+    RegisterCollector<CgroupCollector>();
 
     size_t threadPoolSize = 1;
     // threadPoolSize should be greater than 0

--- a/core/host_monitor/LinuxSystemInterface.h
+++ b/core/host_monitor/LinuxSystemInterface.h
@@ -57,6 +57,9 @@ private:
     bool GetProcessCredNameOnce(pid_t pid, ProcessCredName& processCredName) override;
     bool GetExecutablePathOnce(pid_t pid, ProcessExecutePath& executePath) override;
     bool GetProcessOpenFilesOnce(pid_t pid, ProcessFd& processFd) override;
+
+    bool GetCgroupStatInformationOnce(CgroupStatInformation& cgroupStatInfo) override;
+
     bool GetHostSystemStat(std::vector<std::string>& lines, std::string& errorMessage);
     bool GetHostLoadavg(std::vector<std::string>& lines, std::string& errorMessage);
     bool ReadSocketStat(const std::filesystem::path& path, uint64_t& tcp);

--- a/core/host_monitor/SystemInterface.cpp
+++ b/core/host_monitor/SystemInterface.cpp
@@ -253,6 +253,17 @@ bool SystemInterface::GetNetInterfaceInformation(NetInterfaceInformation& netInt
         errorType);
 }
 
+bool SystemInterface::GetCgroupStatInformation(CgroupStatInformation& cgroupStatInfo) {
+    const std::string errorType = "Cgroup stat";
+    return MemoizedCall(
+        mCgroupStatInformationCache,
+        [this](BaseInformation& info) {
+            return this->GetCgroupStatInformationOnce(static_cast<CgroupStatInformation&>(info));
+        },
+        cgroupStatInfo,
+        errorType);
+}
+
 template <typename F, typename InfoT, typename... Args>
 bool SystemInterface::MemoizedCall(
     SystemInformationCache<InfoT, Args...>& cache, F&& func, InfoT& info, const std::string& errorType, Args... args) {

--- a/core/host_monitor/collector/CgroupCollector.cpp
+++ b/core/host_monitor/collector/CgroupCollector.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 iLogtail Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "host_monitor/collector/CgroupCollector.h"
+
+#include "MetricValue.h"
+#include "common/StringTools.h"
+#include "host_monitor/Constants.h"
+#include "host_monitor/LinuxSystemInterface.h"
+#include "host_monitor/SystemInterface.h"
+
+
+namespace logtail {
+
+const std::string CgroupCollector::sName = "cgroup";
+
+CgroupCollector::CgroupCollector() {
+    Init();
+}
+
+int CgroupCollector::Init(int totalCount) {
+    return 0;
+}
+
+bool CgroupCollector::Collect(const HostMonitorTimerEvent::CollectConfig& collectConfig, PipelineEventGroup* group) {
+    if (group == nullptr) {
+        std::cout << "group is nullptr" << std::endl;
+        return false;
+    }
+
+    CgroupStatInformation info;
+    if (!SystemInterface::GetInstance()->GetCgroupStatInformation(info)) {
+        std::cout << "GetCgroupStatInformation failed" << std::endl;
+        return false;
+    }
+
+    const time_t now = time(nullptr);
+
+    MetricEvent* metricEvent = group->AddMetricEvent(true);
+    if (!metricEvent) {
+        std::cout << "metricEvent is nullptr" << std::endl;
+        return false;
+    }
+    metricEvent->SetTimestamp(now, 0);
+    metricEvent->SetValue<UntypedMultiDoubleValues>(metricEvent);
+    auto* multiDoubleValues = metricEvent->MutableValue<UntypedMultiDoubleValues>();
+    multiDoubleValues->SetValue(
+        std::string("cgroup_cpuset"),
+        UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeGauge, static_cast<double>(info.stat.cpuset)});
+    multiDoubleValues->SetValue(
+        std::string("cgroup_cpu"),
+        UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeGauge, static_cast<double>(info.stat.cpu)});
+    multiDoubleValues->SetValue(
+        std::string("cgroup_cpuacct"),
+        UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeGauge, static_cast<double>(info.stat.cpuacct)});
+    multiDoubleValues->SetValue(
+        std::string("cgroup_blkio"),
+        UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeGauge, static_cast<double>(info.stat.blkio)});
+    multiDoubleValues->SetValue(
+        std::string("cgroup_memory"),
+        UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeGauge, static_cast<double>(info.stat.memory)});
+    multiDoubleValues->SetValue(
+        std::string("cgroup_devices"),
+        UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeGauge, static_cast<double>(info.stat.devices)});
+    multiDoubleValues->SetValue(
+        std::string("cgroup_freezer"),
+        UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeGauge, static_cast<double>(info.stat.freezer)});
+    multiDoubleValues->SetValue(
+        std::string("cgroup_net_cls"),
+        UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeGauge, static_cast<double>(info.stat.net_cls)});
+    multiDoubleValues->SetValue(
+        std::string("cgroup_perf_event"),
+        UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeGauge, static_cast<double>(info.stat.perf_event)});
+    multiDoubleValues->SetValue(
+        std::string("cgroup_net_prio"),
+        UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeGauge, static_cast<double>(info.stat.net_prio)});
+    multiDoubleValues->SetValue(
+        std::string("cgroup_hugetlb"),
+        UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeGauge, static_cast<double>(info.stat.hugetlb)});
+    multiDoubleValues->SetValue(
+        std::string("cgroup_pids"),
+        UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeGauge, static_cast<double>(info.stat.pids)});
+    multiDoubleValues->SetValue(
+        std::string("cgroup_ioasids"),
+        UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeGauge, static_cast<double>(info.stat.ioasids)});
+    multiDoubleValues->SetValue(
+        std::string("cgroup_rdma"),
+        UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeGauge, static_cast<double>(info.stat.rdma)});
+
+    metricEvent->SetTag(std::string("m"), std::string("system.cgroup"));
+    return true;
+}
+
+} // namespace logtail

--- a/core/host_monitor/collector/CgroupCollector.h
+++ b/core/host_monitor/collector/CgroupCollector.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 iLogtail Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <filesystem>
+#include <vector>
+
+#include "host_monitor/LinuxSystemInterface.h"
+#include "host_monitor/collector/BaseCollector.h"
+#include "host_monitor/collector/MetricCalculate.h"
+#include "plugin/input/InputHostMonitor.h"
+
+namespace logtail {
+
+class CgroupCollector : public BaseCollector {
+public:
+    CgroupCollector();
+
+    int Init(int totalCount = 3);
+    ~CgroupCollector() override = default;
+
+    bool Collect(const HostMonitorTimerEvent::CollectConfig& collectConfig, PipelineEventGroup* group) override;
+
+    static const std::string sName;
+    const std::string& Name() const override { return sName; }
+};
+
+} // namespace logtail

--- a/core/plugin/input/InputHostMonitor.cpp
+++ b/core/plugin/input/InputHostMonitor.cpp
@@ -20,6 +20,7 @@
 #include "common/ParamExtractor.h"
 #include "host_monitor/HostMonitorInputRunner.h"
 #include "host_monitor/collector/CPUCollector.h"
+#include "host_monitor/collector/CgroupCollector.h"
 #include "host_monitor/collector/DiskCollector.h"
 #include "host_monitor/collector/MemCollector.h"
 #include "host_monitor/collector/NetCollector.h"
@@ -160,6 +161,21 @@ bool InputHostMonitor::Init(const Json::Value& config, Json::Value& optionalGoPi
         mCollectors.push_back(NetCollector::sName);
     }
 
+    // cgroup
+    bool enableCgroup = true;
+    if (!GetOptionalBoolParam(config, "EnableCgroup", enableCgroup, errorMsg)) {
+        PARAM_ERROR_RETURN(mContext->GetLogger(),
+                           mContext->GetAlarm(),
+                           errorMsg,
+                           sName,
+                           mContext->GetConfigName(),
+                           mContext->GetProjectName(),
+                           mContext->GetLogstoreName(),
+                           mContext->GetRegion());
+    }
+    if (enableCgroup) {
+        mCollectors.push_back(CgroupCollector::sName);
+    }
 
     return true;
 }

--- a/core/unittest/host_monitor/CMakeLists.txt
+++ b/core/unittest/host_monitor/CMakeLists.txt
@@ -1,64 +1,73 @@
-# Copyright 2023 iLogtail Authors
+#Copyright 2023 iLogtail Authors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+#Licensed under the Apache License, Version 2.0(the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#http: // www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
 
-cmake_minimum_required(VERSION 3.22)
-project(host_monitor_unittest)
+cmake_minimum_required(VERSION 3.22) project(host_monitor_unittest)
 
-add_executable(process_entity_collector_unittest ProcessEntityCollectorUnittest.cpp)
-target_link_libraries(process_entity_collector_unittest ${UT_BASE_TARGET})
+    add_executable(process_entity_collector_unittest ProcessEntityCollectorUnittest.cpp) target_link_libraries(
+        process_entity_collector_unittest ${UT_BASE_TARGET})
 
-add_executable(host_monitor_input_runner_unittest HostMonitorInputRunnerUnittest.cpp)
-target_link_libraries(host_monitor_input_runner_unittest ${UT_BASE_TARGET})
+        add_executable(host_monitor_input_runner_unittest HostMonitorInputRunnerUnittest.cpp) target_link_libraries(
+            host_monitor_input_runner_unittest ${UT_BASE_TARGET})
 
-add_executable(cpu_collector_unittest CPUCollectorUnittest.cpp)
-target_link_libraries(cpu_collector_unittest ${UT_BASE_TARGET})
+            add_executable(cpu_collector_unittest CPUCollectorUnittest.cpp) target_link_libraries(
+                cpu_collector_unittest ${UT_BASE_TARGET})
 
-add_executable(system_collector_unittest SystemCollectorUnittest.cpp)
-target_link_libraries(system_collector_unittest ${UT_BASE_TARGET})
+                add_executable(system_collector_unittest SystemCollectorUnittest.cpp) target_link_libraries(
+                    system_collector_unittest ${UT_BASE_TARGET})
 
-add_executable(net_collector_unittest NetCollectorUnittest.cpp)
-target_link_libraries(net_collector_unittest ${UT_BASE_TARGET})
+                    add_executable(net_collector_unittest NetCollectorUnittest.cpp) target_link_libraries(
+                        net_collector_unittest ${UT_BASE_TARGET})
 
-add_executable(metric_calculate_unittest MetricCalculateUnittest.cpp)
-target_link_libraries(metric_calculate_unittest ${UT_BASE_TARGET})
+                        add_executable(metric_calculate_unittest MetricCalculateUnittest.cpp) target_link_libraries(
+                            metric_calculate_unittest ${UT_BASE_TARGET})
 
-add_executable(system_interface_unittest SystemInterfaceUnittest.cpp)
-target_link_libraries(system_interface_unittest ${UT_BASE_TARGET})
+                            add_executable(system_interface_unittest SystemInterfaceUnittest.cpp) target_link_libraries(
+                                system_interface_unittest ${UT_BASE_TARGET})
 
-if (LINUX)
-    add_executable(linux_system_interface_unittest LinuxSystemInterfaceUnittest.cpp)
-    target_link_libraries(linux_system_interface_unittest ${UT_BASE_TARGET})
-endif()
-add_executable(mem_collector_unittest MemCollectorUnittest.cpp)
-target_link_libraries(mem_collector_unittest ${UT_BASE_TARGET})
-add_executable(process_collector_unittest ProcessCollectorUnittest.cpp)
-target_link_libraries(process_collector_unittest ${UT_BASE_TARGET})
+                                add_executable(cgroup_collector_unittest CgroupCollectorUnittest
+                                                   .cpp) target_link_libraries(cgroup_collector_unittest ${
+                                    UT_BASE_TARGET})
 
-add_executable(disk_collector_unittest DiskCollectorUnittest.cpp)
-target_link_libraries(disk_collector_unittest ${UT_BASE_TARGET})
+                                    if (LINUX) add_executable(
+                                        linux_system_interface_unittest LinuxSystemInterfaceUnittest
+                                            .cpp) target_link_libraries(linux_system_interface_unittest ${
+                                        UT_BASE_TARGET}) endif() add_executable(mem_collector_unittest
+                                                                                    MemCollectorUnittest.cpp)
+                                        target_link_libraries(mem_collector_unittest ${UT_BASE_TARGET}) add_executable(
+                                            process_collector_unittest ProcessCollectorUnittest
+                                                .cpp) target_link_libraries(process_collector_unittest ${
+                                            UT_BASE_TARGET})
 
-include(GoogleTest)
-gtest_discover_tests(process_entity_collector_unittest)
-gtest_discover_tests(host_monitor_input_runner_unittest)
-gtest_discover_tests(cpu_collector_unittest)
-gtest_discover_tests(metric_calculate_unittest)
-gtest_discover_tests(system_interface_unittest)
-if (LINUX)
-    gtest_discover_tests(linux_system_interface_unittest)
-endif()
-gtest_discover_tests(system_collector_unittest)
-gtest_discover_tests(mem_collector_unittest)
-gtest_discover_tests(disk_collector_unittest)
-gtest_discover_tests(process_collector_unittest)
-gtest_discover_tests(net_collector_unittest)
+                                            add_executable(disk_collector_unittest DiskCollectorUnittest
+                                                               .cpp) target_link_libraries(disk_collector_unittest ${
+                                                UT_BASE_TARGET})
+
+                                                include(GoogleTest) gtest_discover_tests(
+                                                    process_entity_collector_unittest)
+                                                    gtest_discover_tests(host_monitor_input_runner_unittest)
+                                                        gtest_discover_tests(cpu_collector_unittest) gtest_discover_tests(
+                                                            metric_calculate_unittest)
+                                                            gtest_discover_tests(system_interface_unittest) if (LINUX)
+                                                                gtest_discover_tests(linux_system_interface_unittest)
+                                                                    endif() gtest_discover_tests(
+                                                                        system_collector_unittest)
+                                                                        gtest_discover_tests(mem_collector_unittest)
+                                                                            gtest_discover_tests(
+                                                                                disk_collector_unittest)
+                                                                                gtest_discover_tests(
+                                                                                    process_collector_unittest)
+                                                                                    gtest_discover_tests(
+                                                                                        net_collector_unittest)
+                                                                                        gtest_discover_tests(
+                                                                                            cgroup_collector_unittest)

--- a/core/unittest/host_monitor/CgroupCollectorUnittest.cpp
+++ b/core/unittest/host_monitor/CgroupCollectorUnittest.cpp
@@ -1,0 +1,117 @@
+// Copyright 2025 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "host_monitor/Constants.h"
+#include "host_monitor/HostMonitorTimerEvent.h"
+#include "host_monitor/SystemInterface.h"
+#include "host_monitor/collector/CgroupCollector.h"
+#include "models/MetricEvent.h"
+#include "unittest/Unittest.h"
+
+using namespace std;
+
+namespace logtail {
+
+class CgroupCollectorUnittest : public testing::Test {
+public:
+    void TestCollectNormal() const;
+
+protected:
+    void SetUp() override {
+        ofstream ofs("./cgroups", std::ios::trunc);
+        ofs << "#subsys_name    hierarchy       num_cgroups     enabled\n";
+        ofs << "cpuset  10      5       1\n";
+        ofs << "cpu     3       89      1\n";
+        ofs << "cpuacct 3       89      1\n";
+        ofs << "blkio   7       84      1\n";
+        ofs << "memory  12      126     1\n";
+        ofs << "devices 9       84      1\n";
+        ofs << "freezer 11      5       1\n";
+        ofs << "net_cls 13      5       1\n";
+        ofs << "perf_event      4       5       1\n";
+        ofs << "net_prio        13      5       1\n";
+        ofs << "hugetlb 8       5       1\n";
+        ofs << "pids    5       92      1\n";
+        ofs << "ioasids 2       1       1\n";
+        ofs << "rdma    6       5       1\n";
+        ofs.close();
+        PROCESS_DIR = ".";
+    }
+};
+
+void CgroupCollectorUnittest::TestCollectNormal() const {
+    auto collector = CgroupCollector();
+    PipelineEventGroup group(make_shared<SourceBuffer>());
+    HostMonitorTimerEvent::CollectConfig collectConfig(CgroupCollector::sName, 0, 0, std::chrono::seconds(1));
+
+    APSARA_TEST_TRUE(collector.Collect(collectConfig, &group));
+
+    vector<string> expected_names = {"cgroup_cpuset",
+                                     "cgroup_cpu",
+                                     "cgroup_cpuacct",
+                                     "cgroup_blkio",
+                                     "cgroup_memory",
+                                     "cgroup_devices",
+                                     "cgroup_freezer",
+                                     "cgroup_net_cls",
+                                     "cgroup_perf_event",
+                                     "cgroup_net_prio",
+                                     "cgroup_hugetlb",
+                                     "cgroup_pids",
+                                     "cgroup_ioasids",
+                                     "cgroup_rdma"};
+    vector<double> expected_values = {
+        5, // cgroup_cpuset
+        89, // cgroup_cpu
+        89, // cgroup_cpuacct
+        84, // cgroup_blkio
+        126, // cgroup_memory
+        84, // cgroup_devices
+        5, // cgroup_freezer
+        5, // cgroup_net_cls
+        5, // cgroup_perf_event - 修正：应该是5，不是4
+        5, // cgroup_net_prio - 修正：应该是5，不是13
+        5, // cgroup_hugetlb
+        92, // cgroup_pids
+        1, // cgroup_ioasids
+        5, // cgroup_rdma
+    };
+
+    // 创建name到value的映射关系，确保一一对应
+    std::unordered_map<string, double> expected_name_value_map;
+    for (size_t i = 0; i < expected_names.size(); ++i) {
+        expected_name_value_map[expected_names[i]] = expected_values[i];
+    }
+
+    auto event = group.GetEvents()[0].Cast<MetricEvent>();
+    auto maps = event.GetValue<UntypedMultiDoubleValues>()->mValues;
+
+    // 验证所有期望的指标都存在
+    for (const auto& expected_name : expected_names) {
+        APSARA_TEST_TRUE(maps.find(expected_name) != maps.end());
+    }
+
+    // 验证每个指标的值都正确
+    for (const auto& [name, expected_value] : expected_name_value_map) {
+        APSARA_TEST_TRUE(maps.find(name) != maps.end());
+        double actual_value = maps[name].Value;
+        APSARA_TEST_EQUAL_FATAL(expected_value, actual_value);
+    }
+}
+
+UNIT_TEST_CASE(CgroupCollectorUnittest, TestCollectNormal);
+
+} // namespace logtail
+
+UNIT_TEST_MAIN

--- a/core/unittest/host_monitor/MockSystemInterface.h
+++ b/core/unittest/host_monitor/MockSystemInterface.h
@@ -193,6 +193,15 @@ private:
         return true;
     }
 
+    bool GetCgroupStatInformationOnce(CgroupStatInformation& cgroupStatInfo) override {
+        if (mBlockTime > 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(mBlockTime));
+        }
+        cgroupStatInfo.collectTime = std::chrono::steady_clock::now();
+        ++mMockCalledCount;
+        return true;
+    }
+
     int64_t mBlockTime = 0;
     int64_t mMockCalledCount = 0;
 


### PR DESCRIPTION
Collects cgroup information and exports it to SLS.

cgroup metrics include：
"cgroup_cpuset",
"cgroup_cpu",
"cgroup_cpuacct",
"cgroup_blkio",
"cgroup_memory",
"cgroup_devices",
"cgroup_freezer",
"cgroup_net_cls",
"cgroup_perf_event",
"cgroup_net_prio",
"cgroup_hugetlb",
"cgroup_pids",
"cgroup_ioasids",
"cgroup_rdma"