### PR TITLE
fix: multithreaded package size calculation race condition

### DIFF
--- a/core/processor/daemon/LogProcess.cpp
+++ b/core/processor/daemon/LogProcess.cpp
@@ -391,17 +391,16 @@ void* LogProcess::ProcessLoop(int32_t threadNo) {
                                             false,
                                             false,
                                             logBuffer->exactlyOnceCheckpoint);
-                    if (!Sender::Instance()->Send(
-                            projectName,
-                            logFileReader->GetSourceId(),
-                            *(pLogGroup.get()),
-                            logFileReader->GetLogGroupKey(),
-                            flusherSLS,
-                            flusherSLS->mBatch.mMergeType,
-                            (uint32_t)(profile.logGroupSize * DOUBLE_FLAG(loggroup_bytes_inflation)),
-                            "",
-                            convertedPath,
-                            context)) {
+                    if (!Sender::Instance()->Send(projectName,
+                                                  logFileReader->GetSourceId(),
+                                                  *(pLogGroup.get()),
+                                                  logFileReader->GetLogGroupKey(),
+                                                  flusherSLS,
+                                                  flusherSLS->mBatch.mMergeType,
+                                                  0,
+                                                  "",
+                                                  convertedPath,
+                                                  context)) {
                         LogtailAlarm::GetInstance()->SendAlarm(DISCARD_DATA_ALARM,
                                                                "push file data into batch map fail",
                                                                projectName,


### PR DESCRIPTION
In multithreaded concurrent processing scenarios, due to race conditions in package size calculation, the computed package size may be inaccurate, leading to incorrect rejection of packages as too large. By setting package size to 0, we allow the send method to recalculate the actual package size internally, bypassing the race condition issue and ensuring data can be sent normally.

Change-Id: Ia4fafbf8a8925f8d11adf4071a8ae0c5098ea24d
Co-developed-by: Cursor <noreply@cursor.com>