### PR TITLE
feat: Integrate metrics tracking in StaticFileServer

### DIFF
--- a/core/file_server/StaticFileServer.h
+++ b/core/file_server/StaticFileServer.h
@@ -32,6 +32,9 @@
 #include "file_server/MultilineOptions.h"
 #include "file_server/reader/FileReaderOptions.h"
 #include "file_server/reader/LogFileReader.h"
+#include "monitor/MetricManager.h"
+#include "monitor/metric_constants/MetricConstants.h"
+#include "monitor/metric_models/MetricRecord.h"
 #include "runner/InputRunner.h"
 
 namespace logtail {
@@ -66,7 +69,7 @@ public:
 #endif
 
 private:
-    StaticFileServer() = default;
+    StaticFileServer();
     ~StaticFileServer() = default;
 
     void Run();
@@ -81,8 +84,12 @@ private:
 
     std::future<void> mThreadRes;
     mutable std::mutex mThreadRunningMux;
-    bool mIsThreadRunning = true;
+    bool mIsThreadRunning = false;
     mutable std::condition_variable mStopCV;
+
+    mutable MetricsRecordRef mMetricsRecordRef;
+    IntGaugePtr mLastRunTimeGauge;
+    IntGaugePtr mActiveInputsTotalGauge;
 
     time_t mStartTime = 0;
     bool mIsUnusedCheckpointsCleared = false;

--- a/core/file_server/checkpoint/InputStaticFileCheckpoint.cpp
+++ b/core/file_server/checkpoint/InputStaticFileCheckpoint.cpp
@@ -73,7 +73,8 @@ InputStaticFileCheckpoint::InputStaticFileCheckpoint(const string& configName,
       mInputIdx(idx),
       mFileCheckpoints(std::move(fileCpts)),
       mStartTime(startTime),
-      mExpireTime(expireTime) {
+      mExpireTime(expireTime),
+      mWaitingSentFlags(mFileCheckpoints.size(), false) {
 }
 
 bool InputStaticFileCheckpoint::UpdateCurrentFileCheckpoint(uint64_t offset, uint64_t size, bool& needDump) {
@@ -373,6 +374,10 @@ bool InputStaticFileCheckpoint::Deserialize(const string& str, string* errMsg) {
         }
         mFileCheckpoints.emplace_back(std::move(cpt));
     }
+
+    // 初始化等待发送标志数组
+    mWaitingSentFlags.resize(mFileCheckpoints.size(), false);
+
     return true;
 }
 
@@ -444,6 +449,16 @@ bool InputStaticFileCheckpoint::SerializeToLogEvents() const {
     // 从上次发送位置开始发送，避免重复处理已发送的文件
     for (size_t i = startIndex; i < mFileCheckpoints.size(); ++i) {
         const auto& cpt = mFileCheckpoints[i];
+
+        // 对于 WAITING 状态的文件，检查是否已经发送过
+        if (cpt.mStatus == FileStatus::WAITING) {
+            if (mWaitingSentFlags[i]) {
+                // 已经发送过，跳过
+                continue;
+            }
+            // 标记为已发送
+            mWaitingSentFlags[i] = true;
+        }
 
         LogEvent* logEvent = SelfMonitorServer::GetInstance()->AddTaskStatus(region);
         if (!logEvent) {

--- a/core/file_server/checkpoint/InputStaticFileCheckpoint.h
+++ b/core/file_server/checkpoint/InputStaticFileCheckpoint.h
@@ -65,6 +65,7 @@ private:
     uint32_t mExpireTime = 0;
     uint32_t mFinishTime = 0; // 记录状态变为 FINISHED 或 ABORT 的时间
     mutable size_t mLastSentIndex = 0; // 跟踪上次发送到的位置
+    mutable std::vector<bool> mWaitingSentFlags; // 跟踪每个文件是否已发送过 waiting 状态
 
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class InputStaticFileCheckpointManagerUnittest;

--- a/core/monitor/metric_constants/MetricConstants.h
+++ b/core/monitor/metric_constants/MetricConstants.h
@@ -295,6 +295,7 @@ extern const std::string METRIC_LABEL_VALUE_RUNNER_NAME_PROCESSOR;
 extern const std::string METRIC_LABEL_VALUE_RUNNER_NAME_PROMETHEUS;
 extern const std::string METRIC_LABEL_VALUE_RUNNER_NAME_EBPF_SERVER;
 extern const std::string METRIC_LABEL_VALUE_RUNNER_NAME_K8S_METADATA;
+extern const std::string METRIC_LABEL_VALUE_RUNNER_NAME_STATIC_FILE_SERVER;
 
 // metric keys
 extern const std::string& METRIC_RUNNER_IN_EVENTS_TOTAL;
@@ -335,6 +336,11 @@ extern const std::string METRIC_RUNNER_FILE_ENABLE_FILE_INCLUDED_BY_MULTI_CONFIG
 extern const std::string METRIC_RUNNER_FILE_POLLING_MODIFY_CACHE_SIZE;
 extern const std::string METRIC_RUNNER_FILE_POLLING_DIR_CACHE_SIZE;
 extern const std::string METRIC_RUNNER_FILE_POLLING_FILE_CACHE_SIZE;
+
+/**********************************************************
+ *   static file server
+ **********************************************************/
+extern const std::string METRIC_RUNNER_STATIC_FILE_SERVER_ACTIVE_INPUTS_COUNT;
 
 /**********************************************************
  *   ebpf server

--- a/core/monitor/metric_constants/RunnerMetrics.cpp
+++ b/core/monitor/metric_constants/RunnerMetrics.cpp
@@ -31,6 +31,7 @@ const string METRIC_LABEL_VALUE_RUNNER_NAME_PROCESSOR = "processor_runner";
 const string METRIC_LABEL_VALUE_RUNNER_NAME_PROMETHEUS = "prometheus_runner";
 const string METRIC_LABEL_VALUE_RUNNER_NAME_EBPF_SERVER = "ebpf_runner";
 const string METRIC_LABEL_VALUE_RUNNER_NAME_K8S_METADATA = "k8s_metadata_runner";
+const string METRIC_LABEL_VALUE_RUNNER_NAME_STATIC_FILE_SERVER = "static_file_server";
 
 // metric keys
 const string& METRIC_RUNNER_IN_EVENTS_TOTAL = METRIC_IN_EVENTS_TOTAL;
@@ -71,6 +72,11 @@ const string METRIC_RUNNER_FILE_ENABLE_FILE_INCLUDED_BY_MULTI_CONFIGS_FLAG = "en
 const string METRIC_RUNNER_FILE_POLLING_MODIFY_CACHE_SIZE = "polling_modify_cache_size";
 const string METRIC_RUNNER_FILE_POLLING_DIR_CACHE_SIZE = "polling_dir_cache_size";
 const string METRIC_RUNNER_FILE_POLLING_FILE_CACHE_SIZE = "polling_file_cache_size";
+
+/**********************************************************
+ *   static file server
+ **********************************************************/
+const string METRIC_RUNNER_STATIC_FILE_SERVER_ACTIVE_INPUTS_COUNT = "active_inputs_count";
 
 /**********************************************************
  *   ebpf server


### PR DESCRIPTION
- Implemented metrics recording for the StaticFileServer, including last run time and active inputs count.
- Refactored initialization and stopping logic to ensure proper thread management.
- Added waiting sent flags in InputStaticFileCheckpoint to track file statuses.
- Updated metric constants for better categorization and tracking of static file server metrics.

Change-Id: Id8ebe48f363c9749f9cdf752635392240149da8b
Co-developed-by: Cursor <noreply@cursor.com>