### PR TITLE
fix: Remove null terminator from gbkBuffer(pick to 2.1)

### DIFF
--- a/core/reader/LogFileReader.cpp
+++ b/core/reader/LogFileReader.cpp
@@ -1834,7 +1834,6 @@ void LogFileReader::ReadGBK(LogBuffer& logBuffer, int64_t end, bool& moreData, b
         }
         readCharCount = alignedBytes;
     }
-    gbkBuffer[readCharCount] = '\0';
 
     vector<long> lineFeedPos = {-1}; // elements point to the last char of each line
     for (long idx = 0; idx < long(readCharCount - 1); ++idx) {


### PR DESCRIPTION
Removed null terminator assignment for gbkBuffer.