### PR TITLE
fix single event not returned to event pool

### DIFF
--- a/core/collection_pipeline/batch/BatchedEvents.h
+++ b/core/collection_pipeline/batch/BatchedEvents.h
@@ -34,7 +34,8 @@ struct BatchedEvents {
     StringView mPackIdPrefix;
 
     BatchedEvents() = default;
-    ~BatchedEvents();
+    BatchedEvents(const BatchedEvents& other) = delete;
+    BatchedEvents& operator=(const BatchedEvents& other) = delete;
     BatchedEvents(BatchedEvents&& other) noexcept
         : mEvents(std::move(other.mEvents)),
           mTags(std::move(other.mTags)),
@@ -42,7 +43,8 @@ struct BatchedEvents {
           mSizeBytes(other.mSizeBytes),
           mExactlyOnceCheckpoint(std::move(other.mExactlyOnceCheckpoint)),
           mPackIdPrefix(other.mPackIdPrefix) {}
-    BatchedEvents& operator=(BatchedEvents&&) noexcept = default;
+    BatchedEvents& operator=(BatchedEvents&&) noexcept = delete;
+    ~BatchedEvents();
 
     // for flusher_sls only
     BatchedEvents(EventsContainer&& events,

--- a/core/models/EventPool.cpp
+++ b/core/models/EventPool.cpp
@@ -112,6 +112,42 @@ void EventPool::Release(vector<RawEvent*>&& obj) {
     }
 }
 
+void EventPool::Release(LogEvent* e) {
+    if (mEnableLock) {
+        lock_guard<mutex> lock(mPoolBakMux);
+        mLogEventPoolBak.push_back(e);
+    } else {
+        mLogEventPool.push_back(e);
+    }
+}
+
+void EventPool::Release(MetricEvent* e) {
+    if (mEnableLock) {
+        lock_guard<mutex> lock(mPoolBakMux);
+        mMetricEventPoolBak.push_back(e);
+    } else {
+        mMetricEventPool.push_back(e);
+    }
+}
+
+void EventPool::Release(SpanEvent* e) {
+    if (mEnableLock) {
+        lock_guard<mutex> lock(mPoolBakMux);
+        mSpanEventPoolBak.push_back(e);
+    } else {
+        mSpanEventPool.push_back(e);
+    }
+}
+
+void EventPool::Release(RawEvent* e) {
+    if (mEnableLock) {
+        lock_guard<mutex> lock(mPoolBakMux);
+        mRawEventPoolBak.push_back(e);
+    } else {
+        mRawEventPool.push_back(e);
+    }
+}
+
 template <class T>
 void DoGC(vector<T*>& pool, vector<T*>& poolBak, size_t& minUnusedCnt, mutex* mux, const string& type) {
     if (minUnusedCnt <= pool.size() || minUnusedCnt == numeric_limits<size_t>::max()) {

--- a/core/models/EventPool.h
+++ b/core/models/EventPool.h
@@ -46,6 +46,10 @@ public:
     void Release(std::vector<MetricEvent*>&& obj);
     void Release(std::vector<SpanEvent*>&& obj);
     void Release(std::vector<RawEvent*>&& obj);
+    void Release(LogEvent* e);
+    void Release(MetricEvent* e);
+    void Release(SpanEvent* e);
+    void Release(RawEvent* e);
     void CheckGC();
 
 #ifdef APSARA_UNIT_TEST_MAIN
@@ -104,6 +108,7 @@ private:
     friend class EventPoolUnittest;
     friend class PipelineEventGroupUnittest;
     friend class BatchedEventsUnittest;
+    friend class PipelineEventPtrUnittest;
 #endif
 };
 

--- a/core/models/PipelineEventGroup.cpp
+++ b/core/models/PipelineEventGroup.cpp
@@ -75,29 +75,12 @@ PipelineEventGroup::PipelineEventGroup(PipelineEventGroup&& rhs) noexcept
 }
 
 PipelineEventGroup::~PipelineEventGroup() {
-    if (mEvents.empty() || !mEvents[0]) {
-        return;
-    }
-    switch (mEvents[0]->GetType()) {
-        case PipelineEvent::Type::LOG:
-            DestroyEvents<LogEvent>(std::move(mEvents));
-            break;
-        case PipelineEvent::Type::METRIC:
-            DestroyEvents<MetricEvent>(std::move(mEvents));
-            break;
-        case PipelineEvent::Type::SPAN:
-            DestroyEvents<SpanEvent>(std::move(mEvents));
-            break;
-        case PipelineEvent::Type::RAW:
-            DestroyEvents<RawEvent>(std::move(mEvents));
-            break;
-        default:
-            break;
-    }
+    destroy();
 }
 
 PipelineEventGroup& PipelineEventGroup::operator=(PipelineEventGroup&& rhs) noexcept {
     if (this != &rhs) {
+        destroy();
         mMetadata = std::move(rhs.mMetadata);
         mTags = std::move(rhs.mTags);
         mEvents = std::move(rhs.mEvents);
@@ -121,6 +104,28 @@ PipelineEventGroup PipelineEventGroup::Copy() const {
         res.mEvents.back()->ResetPipelineEventGroup(&res);
     }
     return res;
+}
+
+void PipelineEventGroup::destroy() {
+    if (mEvents.empty() || !mEvents[0]) {
+        return;
+    }
+    switch (mEvents[0]->GetType()) {
+        case PipelineEvent::Type::LOG:
+            DestroyEvents<LogEvent>(std::move(mEvents));
+            break;
+        case PipelineEvent::Type::METRIC:
+            DestroyEvents<MetricEvent>(std::move(mEvents));
+            break;
+        case PipelineEvent::Type::SPAN:
+            DestroyEvents<SpanEvent>(std::move(mEvents));
+            break;
+        case PipelineEvent::Type::RAW:
+            DestroyEvents<RawEvent>(std::move(mEvents));
+            break;
+        default:
+            break;
+    }
 }
 
 unique_ptr<LogEvent> PipelineEventGroup::CreateLogEvent(bool fromPool, EventPool* pool) {

--- a/core/models/PipelineEventGroup.h
+++ b/core/models/PipelineEventGroup.h
@@ -83,6 +83,8 @@ public:
     PipelineEventGroup(const std::shared_ptr<SourceBuffer>& sourceBuffer, SourceBufferSet& extraSourceBuffers)
         : mSourceBuffer(sourceBuffer), mExtraSourceBuffers(extraSourceBuffers) {}
     ~PipelineEventGroup();
+    PipelineEventGroup(const PipelineEventGroup&) = delete;
+    PipelineEventGroup& operator=(const PipelineEventGroup&) = delete;
     PipelineEventGroup(PipelineEventGroup&&) noexcept;
     PipelineEventGroup& operator=(PipelineEventGroup&&) noexcept;
 
@@ -144,6 +146,8 @@ public:
 #endif
 
 private:
+    void destroy();
+
     GroupMetadata mMetadata; // Used to generate tag/log. Will not output.
     SizedMap mTags; // custom tags to output
     EventsContainer mEvents;

--- a/core/models/PipelineEventPtr.cpp
+++ b/core/models/PipelineEventPtr.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 iLogtail Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "models/PipelineEventPtr.h"
+
+#include "models/EventPool.h"
+
+namespace logtail {
+
+template <typename T>
+void PipelineEventPtr::releaseToPool() {
+    if (mEventPool) {
+        mEventPool->Release(static_cast<T*>(Release()));
+    } else {
+        gThreadedEventPool.Release(static_cast<T*>(Release()));
+    }
+}
+
+void PipelineEventPtr::destroy() {
+    if (mData && mFromEventPool) {
+        mData->Reset();
+        switch (mData->GetType()) {
+            case PipelineEvent::Type::LOG:
+                releaseToPool<LogEvent>();
+                break;
+            case PipelineEvent::Type::METRIC:
+                releaseToPool<MetricEvent>();
+                break;
+            case PipelineEvent::Type::SPAN:
+                releaseToPool<SpanEvent>();
+                break;
+            case PipelineEvent::Type::RAW:
+                releaseToPool<RawEvent>();
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+PipelineEventPtr& PipelineEventPtr::operator=(PipelineEventPtr&& other) noexcept {
+    if (this != &other) {
+        destroy();
+        mData = std::move(other.mData);
+        mFromEventPool = other.mFromEventPool;
+        mEventPool = other.mEventPool;
+    }
+    return *this;
+}
+
+PipelineEventPtr::~PipelineEventPtr() {
+    destroy();
+}
+} // namespace logtail

--- a/core/models/PipelineEventPtr.h
+++ b/core/models/PipelineEventPtr.h
@@ -36,6 +36,11 @@ public:
         : mData(std::unique_ptr<PipelineEvent>(ptr)), mFromEventPool(fromPool), mEventPool(pool) {}
     PipelineEventPtr(std::unique_ptr<PipelineEvent>&& ptr, bool fromPool, EventPool* pool)
         : mData(std::move(ptr)), mFromEventPool(fromPool), mEventPool(pool) {}
+    PipelineEventPtr(const PipelineEventPtr&) = delete;
+    PipelineEventPtr& operator=(const PipelineEventPtr&) = delete;
+    PipelineEventPtr(PipelineEventPtr&&) noexcept = default;
+    PipelineEventPtr& operator=(PipelineEventPtr&&) noexcept;
+    ~PipelineEventPtr();
 
     template <typename T>
     bool Is() const {
@@ -80,6 +85,11 @@ public:
     EventPool* GetEventPool() const { return mEventPool; }
 
 private:
+    void destroy();
+
+    template <typename T>
+    void releaseToPool();
+
     std::unique_ptr<PipelineEvent> mData;
     bool mFromEventPool = false;
     EventPool* mEventPool = nullptr; // null means using processor runner threaded pool


### PR DESCRIPTION
- 问题：之前假定所有的event都是通过event group集体释放的，遗漏了单个event单独释放的场景（比如filter，解析失败等）。这导致这一部分的event直接归还os了。
- 影响：在filter和解析失败比较多的场景，有略微的cpu性能下降。
- 解决：增加event析构和赋值时的归还操作。