### PR TITLE
Enhance the functionality of container state change scenarios and improve compatibility with legacy Checkpoint configurations.

### DIFF
--- a/core/container_manager/ContainerDiff.h
+++ b/core/container_manager/ContainerDiff.h
@@ -31,6 +31,8 @@ namespace logtail {
 struct ContainerDiff {
     std::vector<std::shared_ptr<RawContainerInfo>> mAdded;
     std::vector<std::shared_ptr<RawContainerInfo>> mModified;
+
+    // 旧版本checkpoint中，只包含完整的rootfs+采集配置路径信息，因此这里需要额外字段记录
     std::vector<std::pair<std::string, std::shared_ptr<RawContainerInfo>>> mLegacyCheckpointAdded;
     std::vector<std::string> mRemoved;
 

--- a/core/container_manager/ContainerManager.cpp
+++ b/core/container_manager/ContainerManager.cpp
@@ -115,9 +115,9 @@ void ContainerManager::ApplyContainerDiffs() {
         LOG_INFO(sLogger, ("ApplyContainerDiffs diff", diff->ToString())("configName", ctx->GetConfigName()));
 
         for (const auto& pair : diff->mLegacyCheckpointAdded) {
-            const std::string& checkpointPath = pair.first;
+            const std::string& basePathInCheckpoint = pair.first;
             const std::shared_ptr<RawContainerInfo>& container = pair.second;
-            options->UpdateRawContainerInfo(container, ctx, checkpointPath);
+            options->UpdateRawContainerInfo(container, ctx, basePathInCheckpoint);
         }
 
         for (const auto& container : diff->mAdded) {
@@ -891,9 +891,9 @@ void ContainerManager::loadContainerInfoFromDetailFormat(const Json::Value& root
                     info->mLogPath = paramsJson["LogPath"].asString();
                 }
 
-                std::string checkpointPath;
+                std::string basePathInCheckpoint;
                 if (info->mUpperDir.empty() && paramsJson.isMember("Path") && paramsJson["Path"].isString()) {
-                    checkpointPath = paramsJson["Path"].asString();
+                    basePathInCheckpoint = paramsJson["Path"].asString();
                 }
 
                 // Parse mounts
@@ -966,7 +966,7 @@ void ContainerManager::loadContainerInfoFromDetailFormat(const Json::Value& root
                     tmpContainerMap[info->mID] = info;
                     // Also associate with config if config name is available
                     if (!configName.empty()) {
-                        configContainerMap[configName].push_back(std::make_pair(checkpointPath, info));
+                        configContainerMap[configName].push_back(std::make_pair(basePathInCheckpoint, info));
                     }
                 }
             } else {

--- a/core/file_server/FileDiscoveryOptions.cpp
+++ b/core/file_server/FileDiscoveryOptions.cpp
@@ -798,7 +798,7 @@ size_t FileDiscoveryOptions::GetRealBaseDirIndex(const ContainerInfo* containerI
 
 bool FileDiscoveryOptions::UpdateRawContainerInfo(const std::shared_ptr<RawContainerInfo>& rawContainerInfo,
                                                   const CollectionPipelineContext* ctx,
-                                                  const std::string& checkpointPath) {
+                                                  const std::string& basePathInCheckpoint) {
     if (!mContainerInfos) {
         return false;
     }
@@ -809,11 +809,11 @@ bool FileDiscoveryOptions::UpdateRawContainerInfo(const std::shared_ptr<RawConta
     mContainerDiscovery.GetCustomExternalTags(
         rawContainerInfo->mEnv, rawContainerInfo->mK8sInfo.mLabels, containerInfo.mExtraTags);
 
-    if (!checkpointPath.empty()) {
+    if (!basePathInCheckpoint.empty()) {
         LOG_INFO(sLogger,
-                 ("set container base dir for checkpoint path", checkpointPath)("container id",
-                                                                                containerInfo.mRawContainerInfo->mID));
-        containerInfo.mRealBaseDirs.push_back(checkpointPath);
+                 ("set container base dir for checkpoint path",
+                  basePathInCheckpoint)("container id", containerInfo.mRawContainerInfo->mID));
+        containerInfo.mRealBaseDirs.push_back(basePathInCheckpoint);
     } else {
         if (!mDeduceAndSetContainerBaseDirFunc(containerInfo, ctx, this)) {
             return false;

--- a/core/file_server/FileDiscoveryOptions.h
+++ b/core/file_server/FileDiscoveryOptions.h
@@ -96,7 +96,7 @@ public:
 
     bool UpdateRawContainerInfo(const std::shared_ptr<RawContainerInfo>& rawContainerInfo,
                                 const CollectionPipelineContext*,
-                                const std::string& checkpointPath = "");
+                                const std::string& basePathInCheckpoint = "");
     bool DeleteRawContainerInfo(const std::string& containerID);
 
     ContainerInfo* GetContainerPathByLogPath(const std::string& logPath) const;

--- a/core/unittest/container_manager/ContainerManagerUnittest.cpp
+++ b/core/unittest/container_manager/ContainerManagerUnittest.cpp
@@ -657,7 +657,6 @@ void ContainerManagerUnittest::TestLoadContainerInfoFromDetailFormatWithTags() c
 
     // Verify container info
     EXPECT_EQ(it->second->mID, "2e832614c7e4ca22a79d5735fc7bf2b77d76d1dabc18cd5d6fc47764394a97c0");
-    // Verify that Path was processed: /logtail_host prefix removed and assigned to UpperDir
     EXPECT_EQ(it->second->mUpperDir, "");
     EXPECT_EQ(it->second->mK8sInfo.mNamespace, "kube-system");
     EXPECT_EQ(it->second->mK8sInfo.mPod, "csi-provisioner-5f5d9d84fc-hc6mt");

--- a/pkg/helper/containercenter/container_center.go
+++ b/pkg/helper/containercenter/container_center.go
@@ -1216,6 +1216,7 @@ func (dc *ContainerCenter) markRemove(containerID string) {
 		logger.Debugf(context.Background(), "mark remove container: id:%v\tname:%v\tcreated:%v\tstatus:%v detail=%+v",
 			container.IDPrefix(), container.ContainerInfo.Name, container.ContainerInfo.Created, container.Status(), container.ContainerInfo)
 		container.ContainerInfo.State.Status = ContainerStatusExited
+		computeContainerMetadataHash(container)
 		container.deleteFlag = true
 		container.lastUpdateTime = time.Now()
 		dc.refreshLastUpdateMapTime()

--- a/pkg/helper/containercenter/container_export.go
+++ b/pkg/helper/containercenter/container_export.go
@@ -269,7 +269,7 @@ func GetContainerDiffForPluginManager(cachedList map[string]string) (update []*D
 	}
 
 	// Build new cache with hashes and check for new or updated containers
-	newCachedList = make(map[string]string)
+	newCachedList = make(map[string]string, len(instance.containerMap))
 	for currentID, currentInfo := range instance.containerMap {
 		currentHash := currentInfo.MetadataHash()
 		newCachedList[currentID] = currentHash
@@ -286,7 +286,7 @@ func GetContainerDiffForPluginManager(cachedList map[string]string) (update []*D
 	}
 
 	if !changed {
-		return update, delete, stop, false, nil
+		return update, delete, stop, false, make(map[string]string)
 	}
 
 	return update, delete, stop, true, newCachedList

--- a/pluginmanager/containers_api.go
+++ b/pluginmanager/containers_api.go
@@ -151,7 +151,6 @@ func GetDiffContainers() string {
 	}
 	lastUpdateTime = newUpdateTime
 
-	// Use GetContainerDiffForPluginManagerV2 which supports metadata hash comparison
 	update, delete, stop, changed, newFullList := containercenter.GetContainerDiffForPluginManager(caCachedFullList)
 	if !changed {
 		return ""


### PR DESCRIPTION
修复两个场景的问题：
1. 容器的state变化的时候，容器元信息无法更新到C++侧。典型的是ECI场景，container.json文件是分段写入的，creaate的时候会写入完整的容器信息，但是state不会更新，start的时候会更新state字段。文件采集场景会对state字段进行判断，如果state字段不存在或者state字段的值不是running，则认为容器没有启动成功，则不会采集。
2. 2.1之前版本的容器元信息的checkpoint文件格式兼容问题，对Path字段做了一个兼容操作，会直接放到mRealBaseDirs里
2.1版本之前是这样的，
{
    "ID": "2e832614c7e4ca22a79d5735fc7bf2b77d76d1dabc18cd5d6fc47764394a97c0",
    "Path": "/logtail_host/run/containerd/io.containerd.runtime.v2.task/k8s.io/2e832614c7e4ca22a79d5735fc7bf2b77d76d1dabc18cd5d6fc47764394a97c0/rootfs/app/logs",
    "Tags": [
        "_container_name_",
        "external-snapshot-controller",
        "_pod_name_",
        "csi-provisioner-5f5d9d84fc-hc6mt",
        "_namespace_",
        "kube-system",
        "_pod_uid_",
        "21d7468a-dc19-44fa-81ad-c799f21df5ff",
        "_container_ip_",
        "192.168.0.48",
        "_image_name_",
        "registry-cn-hongkong-vpc.ack.aliyuncs.com/acs/snapshot-controller:v4.0.0-a230d5b3-aliyun"
    ]
}
2.1版本之后是这样的：
{
    "ID": "8859e31bc57dae7cf750cc2353204c6b4d1fa9a40e4eb26fb4c5257be81dcf44",
    "LogPath": "/var/log/pods/dynatrace_dynatrace-webhook-5676d99f4-5dl6n_bddb70c4-e44d-4685-b429-4150aaa51eea/webhook/1.log",
    "MetaDatas": [
        "_pod_name_",
        "dynatrace-webhook-5676d99f4-5dl6n",
        "_namespace_",
        "dynatrace",
        "_pod_uid_",
        "bddb70c4-e44d-4685-b429-4150aaa51eea",
        "_container_ip_",
        "192.168.0.50",
        "_image_name_",
        "public.ecr.aws/dynatrace/dynatrace-operator:v1.2.1",
        "_container_name_",
        "webhook"
    ],
    "Mounts": [
        {
            "Destination": "/dev/shm",
            "Source": "/run/containerd/io.containerd.grpc.v1.cri/sandboxes/81028d27e413191ac921800bc5393dedfce19e7f56313c9aad9a442d9d80e9e0/shm"
        },
        {
            "Destination": "/etc/hostname",
            "Source": "/var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/81028d27e413191ac921800bc5393dedfce19e7f56313c9aad9a442d9d80e9e0/hostname"
        },
        {
            "Destination": "/etc/resolv.conf",
            "Source": "/var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/81028d27e413191ac921800bc5393dedfce19e7f56313c9aad9a442d9d80e9e0/resolv.conf"
        },
        {
            "Destination": "/dev/termination-log",
            "Source": "/var/lib/kubelet/pods/bddb70c4-e44d-4685-b429-4150aaa51eea/containers/webhook/c6e318a7"
        },
        {
            "Destination": "/etc/hosts",
            "Source": "/var/lib/kubelet/pods/bddb70c4-e44d-4685-b429-4150aaa51eea/etc-hosts"
        },
        {
            "Destination": "/tmp/k8s-webhook-server/serving-certs",
            "Source": "/var/lib/kubelet/pods/bddb70c4-e44d-4685-b429-4150aaa51eea/volumes/kubernetes.io~empty-dir/certs-dir"
        },
        {
            "Destination": "/var/run/secrets/kubernetes.io/serviceaccount",
            "Source": "/var/lib/kubelet/pods/bddb70c4-e44d-4685-b429-4150aaa51eea/volumes/kubernetes.io~projected/kube-api-access-hp4zj"
        },
        {
            "Destination": "/sys/fs/cgroup",
            "Source": "cgroup"
        },
        {
            "Destination": "/dev/pts",
            "Source": "devpts"
        },
        {
            "Destination": "/dev/mqueue",
            "Source": "mqueue"
        },
        {
            "Destination": "/proc",
            "Source": "proc"
        },
        {
            "Destination": "/sys",
            "Source": "sysfs"
        },
        {
            "Destination": "/dev",
            "Source": "tmpfs"
        }
    ],
    "Path": "/logtail_host/run/containerd/io.containerd.runtime.v2.task/k8s.io/8859e31bc57dae7cf750cc2353204c6b4d1fa9a40e4eb26fb4c5257be81dcf44/rootfs/app/logs",
    "Tags": [

    ],
    "UpperDir": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/8859e31bc57dae7cf750cc2353204c6b4d1fa9a40e4eb26fb4c5257be81dcf44/rootfs"
}