### PR TITLE
fix: Enhance logging and error handling in eBPF components

### DIFF
--- a/core/ebpf/EBPFAdapter.cpp
+++ b/core/ebpf/EBPFAdapter.cpp
@@ -280,6 +280,9 @@ bool EBPFAdapter::SetNetworkObserverCidFilter(const std::string& cid, bool updat
 
 int32_t EBPFAdapter::PollPerfBuffers(PluginType pluginType, int32_t maxEvents, int32_t* flag, int timeoutMs) {
     if (!dynamicLibSuccess()) {
+        LOG_WARNING(sLogger,
+            ("poll perf buffer skip, dynamic lib not ready",
+             magic_enum::enum_name(pluginType)));
         return -1;
     }
     void* f = mFuncs[static_cast<int>(ebpf_func::EBPF_POLL_PLUGIN_PBS)];
@@ -473,6 +476,9 @@ std::vector<int> EBPFAdapter::GetPerfBufferEpollFds(PluginType pluginType) {
 
 int32_t EBPFAdapter::ConsumePerfBufferData(PluginType pluginType) {
     if (!dynamicLibSuccess()) {
+        LOG_WARNING(sLogger,
+            ("consume perf buffer data skip, dynamic lib not ready",
+             magic_enum::enum_name(pluginType)));
         return -1;
     }
     void* f = mFuncs[static_cast<int>(ebpf_func::EBPF_CONSUME_PLUGIN_PB_DATA)];

--- a/core/ebpf/driver/eBPFDriver.cpp
+++ b/core/ebpf/driver/eBPFDriver.cpp
@@ -288,6 +288,7 @@ int start_plugin(logtail::ebpf::PluginConfig* arg) {
             if (ret) {
                 ebpf_log(logtail::ebpf::eBPFLogType::NAMI_LOG_TYPE_WARN,
                          "file security: DynamicAttachBPFObject fail\n");
+                DeletePerfBuffers(arg->mPluginType);
                 return kErrDriverInternal;
             }
             ebpf_log(logtail::ebpf::eBPFLogType::NAMI_LOG_TYPE_DEBUG,
@@ -338,6 +339,7 @@ int start_plugin(logtail::ebpf::PluginConfig* arg) {
             if (ret) {
                 EBPF_LOG(logtail::ebpf::eBPFLogType::NAMI_LOG_TYPE_WARN,
                          "network security: DynamicAttachBPFObject fail\n");
+                DeletePerfBuffers(arg->mPluginType);
                 return kErrDriverInternal;
             }
             EBPF_LOG(logtail::ebpf::eBPFLogType::NAMI_LOG_TYPE_DEBUG,
@@ -392,6 +394,7 @@ int start_plugin(logtail::ebpf::PluginConfig* arg) {
                 EBPF_LOG(logtail::ebpf::eBPFLogType::NAMI_LOG_TYPE_WARN,
                          "process security: DynamicAttachBPFObject fail ret:%d\n",
                          ret);
+                DeletePerfBuffers(arg->mPluginType);
                 return kErrDriverInternal;
             }
             EBPF_LOG(logtail::ebpf::eBPFLogType::NAMI_LOG_TYPE_DEBUG,

--- a/core/ebpf/plugin/ProcessCacheManager.cpp
+++ b/core/ebpf/plugin/ProcessCacheManager.cpp
@@ -404,11 +404,9 @@ int ProcessCacheManager::ConsumePerfBufferData() {
     int ret = 0;
     mIsConsuming = true;
     if (mInited) {
-        mEBPFAdapter->ConsumePerfBufferData(PluginType::PROCESS_SECURITY);
-        LOG_DEBUG(sLogger, ("process cache consume buffer", "")("cnt", ret));
+        ret = mEBPFAdapter->ConsumePerfBufferData(PluginType::PROCESS_SECURITY);
     }
     mIsConsuming = false;
-
     return ret;
 }
 


### PR DESCRIPTION
- Added warning logs for skipping operations when the dynamic library is not ready in EBPFAdapter.
- Improved error handling in EBPFServer for consuming performance buffer data, logging warnings on failures.
- Updated BPFWrapper to ensure proper initialization checks before performing operations.
- Refined ProcessCacheManager to return the result of consuming performance buffer data.

These changes improve the robustness and debuggability of the eBPF components.

Change-Id: I9331a84baf69e5e1ecd1508094377a4f33a55755
Co-developed-by: Cursor <noreply@cursor.com>