### PR TITLE
fix hostmonitor collctor bug

### DIFF
--- a/core/host_monitor/collector/BaseCollector.h
+++ b/core/host_monitor/collector/BaseCollector.h
@@ -41,6 +41,7 @@ public:
 
 protected:
     bool mValidState = true;
+    static const uint32_t kWarningPrintInterval = 10; // 警告打印频率（每发生 kWarningPrintInterval 次错误打印一次警告）
 };
 
 class CollectorInstance {

--- a/core/host_monitor/collector/CPUCollector.h
+++ b/core/host_monitor/collector/CPUCollector.h
@@ -56,6 +56,7 @@ public:
     CPUCollector() = default;
     ~CPUCollector() override = default;
 
+    bool Init(HostMonitorContext& collectContext) override;
     bool Collect(HostMonitorContext& collectContext, PipelineEventGroup* groupPtr) override;
     [[nodiscard]] const std::chrono::seconds GetCollectInterval() const override;
 
@@ -69,6 +70,7 @@ private:
     int cpuCount = 0;
     MetricCalculate<CPUPercent> mCalculate;
     CPUStat lastCpu{};
+    uint32_t mJiffiesDeltaWarningCount = 0; // jiffies delta is negative warning 计数
 };
 
 } // namespace logtail

--- a/core/host_monitor/collector/DiskCollector.h
+++ b/core/host_monitor/collector/DiskCollector.h
@@ -203,6 +203,10 @@ private:
     std::chrono::steady_clock::time_point mLastTime; // 上次获取磁盘信息的时间
     std::unordered_map<uint64_t, std::shared_ptr<IODev>> fileSystemCache;
     std::map<std::string, MetricCalculate<DeviceMetric>> mDeviceCalMap;
+    uint32_t mErrorWarningCount = 0; // collect disk error warning 计数
+    uint32_t mFirstTimeWarningCount = 0; // collect disk first time warning 计数
+    uint32_t mFrequencyWarningCount = 0; // collect disk too frequency warning 计数
+    uint32_t mQueueNotFiniteWarningCount = 0; // diskUsage.queue is not finite warning 计数
 };
 
 } // namespace logtail

--- a/core/host_monitor/collector/ProcessCollector.cpp
+++ b/core/host_monitor/collector/ProcessCollector.cpp
@@ -94,6 +94,7 @@ bool ProcessCollector::Init(HostMonitorContext& collectContext) {
         return false;
     }
     mTotalMemory = meminfo.memStat.total;
+    mClearProcessCpuTimeCacheErrorCount = 0;
     return true;
 }
 
@@ -130,7 +131,7 @@ bool ProcessCollector::Collect(HostMonitorContext& collectContext, PipelineEvent
         allPidStats.push_back(stat);
     }
 
-    int processNum = allPidStats.size();
+    int processNum = pids.size();
 
     VMProcessNumStat processNumStat;
     processNumStat.vmProcessNum = processNum;
@@ -530,7 +531,12 @@ void ProcessCollector::ClearProcessCpuTimeCache() {
             }
         }
     } catch (const std::exception& e) {
-        LOG_ERROR(sLogger, ("ClearProcessCpuTimeCache error", e.what()));
+        if (++mClearProcessCpuTimeCacheErrorCount >= kWarningPrintInterval) {
+            LOG_ERROR(
+                sLogger,
+                ("ClearProcessCpuTimeCache error", e.what())("occurred_times", mClearProcessCpuTimeCacheErrorCount));
+            mClearProcessCpuTimeCacheErrorCount = 0;
+        }
     }
 
     return;

--- a/core/host_monitor/collector/ProcessCollector.h
+++ b/core/host_monitor/collector/ProcessCollector.h
@@ -91,6 +91,7 @@ private:
     std::unordered_map<pid_t, double> mMinProcessNumThreads;
     std::unordered_map<pid_t, double> mMaxProcessNumThreads;
     std::unordered_map<pid_t, std::string> pidNameMap;
+    uint32_t mClearProcessCpuTimeCacheErrorCount = 0; // ClearProcessCpuTimeCache error warning 计数
 };
 
 } // namespace logtail


### PR DESCRIPTION
1. 采集网络指标时，默认数据格式类似“ TCP: inuse 10 orphan 0 tw abc alloc 15”，部分系统存在简化写法如“TCP6: inuse 15”，补充这种情况
2. 在容器内运行lc时，无法读取到磁盘挂载映射信息，导致频繁报错，控制报错频率。
3. 删除导致ut执行时间长的ut
4. 进程数量之前一直是5，现在修改为机器上实际的进程数量