### PR TITLE
Fix: fix StaticFileServer dead lock

### DIFF
--- a/core/file_server/StaticFileServer.cpp
+++ b/core/file_server/StaticFileServer.cpp
@@ -274,10 +274,7 @@ LogFileReaderPtr StaticFileServer::GetNextAvailableReader(const string& configNa
         return reader;
     }
     // all files have been read
-    {
-        lock_guard<mutex> lock(mUpdateMux);
-        mDeletedInputs.emplace(configName, idx);
-    }
+    mDeletedInputs.emplace(configName, idx);
     return LogFileReaderPtr();
 }
 


### PR DESCRIPTION
引入：https://github.com/alibaba/loongcollector/pull/2460

影响：一次性文件采集不可用，且主线程卡死，触发条件：一次性采集配置过期

一个一次性采集配置如果全部采集完了，就会卡死在GetNextAvailableReader。到这还是只影响一次性文件采集。

```cpp
void StaticFileServer::ReadFiles() {
    for (auto& item : mPipelineNameReadersMap) {
        {
            lock_guard<mutex> lock(mUpdateMux); // 这里加锁了
            // ......
                reader = GetNextAvailableReader(configName, inputIdx);
            // ......
        }
    }
}

LogFileReaderPtr StaticFileServer::GetNextAvailableReader(const string& configName, size_t idx) {
    // ......
    // all files have been read
    {
        lock_guard<mutex> lock(mUpdateMux); // 问题就在这里，这里不应该、也不需要再加锁了，因为所有GetNextAvailableReader的入口都是有锁的。
        mDeletedInputs.emplace(configName, idx);
    }
}
```

一次性采集配置过期时，主线程会调用RemoveInput，因为锁被GetNextAvailableReader占用，导致主线程卡死，PipelineConfigWatcher等关键组件不再运行，配置更新无法生效。

```cpp
void StaticFileServer::RemoveInput(const string& configName, size_t idx) {
    {
        lock_guard<mutex> lock(mUpdateMux); // 这里有锁，但是锁卡在GetNextAvailableReader了
        mInputFileDiscoveryConfigsMap.erase(make_pair(configName, idx));
        mInputFileReaderConfigsMap.erase(make_pair(configName, idx));
        mInputMultilineConfigsMap.erase(make_pair(configName, idx));
        mInputFileTagConfigsMap.erase(make_pair(configName, idx));
        mDeletedInputs.emplace(configName, idx);
    }
    InputStaticFileCheckpointManager::GetInstance()->DeleteCheckpoint(configName, idx);
}
```
