### PR TITLE
Refine cpp container manager code

### DIFF
--- a/core/container_manager/ContainerManager.cpp
+++ b/core/container_manager/ContainerManager.cpp
@@ -528,7 +528,7 @@ bool IsMapLabelsMatch(const MatchCriteriaFilter& filter, const std::unordered_ma
         if (!matchedFlag) {
             for (const auto& pair : filter.mIncludeFields.mFieldsRegMap) {
                 auto it = labels.find(pair.first);
-                if (it != labels.end() && boost::regex_match(it->second, *pair.second)) {
+                if (it != labels.end() && boost::regex_search(it->second, *pair.second)) {
                     matchedFlag = true;
                     break;
                 }
@@ -551,7 +551,7 @@ bool IsMapLabelsMatch(const MatchCriteriaFilter& filter, const std::unordered_ma
     // 检查 exclude 正则
     for (const auto& pair : filter.mExcludeFields.mFieldsRegMap) {
         auto it = labels.find(pair.first);
-        if (it != labels.end() && boost::regex_match(it->second, *pair.second)) {
+        if (it != labels.end() && boost::regex_search(it->second, *pair.second)) {
             return false;
         }
     }
@@ -564,15 +564,15 @@ bool IsK8sFilterMatch(const K8sFilter& filter, const K8sInfo& k8sInfo) {
         return false;
     }
     // 匹配命名空间
-    if (filter.mNamespaceReg && !boost::regex_match(k8sInfo.mNamespace, *filter.mNamespaceReg)) {
+    if (filter.mNamespaceReg && !boost::regex_search(k8sInfo.mNamespace, *filter.mNamespaceReg)) {
         return false;
     }
     // 匹配 Pod 名称
-    if (filter.mPodReg && !boost::regex_match(k8sInfo.mPod, *filter.mPodReg)) {
+    if (filter.mPodReg && !boost::regex_search(k8sInfo.mPod, *filter.mPodReg)) {
         return false;
     }
     // 匹配容器名称
-    if (filter.mContainerReg && !boost::regex_match(k8sInfo.mContainerName, *filter.mContainerReg)) {
+    if (filter.mContainerReg && !boost::regex_search(k8sInfo.mContainerName, *filter.mContainerReg)) {
         return false;
     }
     // 确保 Labels 不为 nullptr，使用默认的空映射初始化

--- a/core/file_server/FileServer.cpp
+++ b/core/file_server/FileServer.cpp
@@ -116,7 +116,7 @@ void FileServer::Resume(bool isConfigUpdate, bool isContainerUpdate) {
         ("file server resume", "starts")("isConfigUpdate", isConfigUpdate)("isContainerUpdate", isContainerUpdate));
     ConfigManager::GetInstance()->RegisterHandlers();
     LOG_INFO(sLogger, ("watch dirs", "succeeded"));
-    if (isConfigUpdate) {
+    if (isConfigUpdate || isContainerUpdate) {
         EventDispatcher::GetInstance()->AddExistedCheckPointFileEvents();
     }
     LogInput::GetInstance()->Resume();

--- a/core/unittest/container_manager/testDataSet/ContainerManagerUnittest/k8s_pod_regex_test.json
+++ b/core/unittest/container_manager/testDataSet/ContainerManagerUnittest/k8s_pod_regex_test.json
@@ -113,6 +113,16 @@
                 "K8sPodRegex": "^frontend-.*"
             },
             "expected_matched_ids": []
+        },
+        {
+            "name": "k8s_pod_substring_regex",
+            "description": "测试 Pod 名称正则为子串时的匹配（如 nginx-app-deployment 匹配 nginx-app-deployment-12345-abcde）",
+            "filters": {
+                "K8sPodRegex": "nginx-app-deployment"
+            },
+            "expected_matched_ids": [
+                "nginx-app-deployment"
+            ]
         }
     ]
 }


### PR DESCRIPTION
修复两个问题：
1. FileServer resume的时候，容器变更的条件漏了，这个在数据量比较小的场景下，会有重复采集的问题。
2. C++部分做容器过滤的时候，使用的是regex_match，改成使用regex_search。k8s的容器过滤条件，我们代码里没有做强校验，比如他pod的过滤条件配置成了my-app，实际他pod name叫my-app-XXXX，这个在使用regex_match是不满足的，但是使用regex_search就可以满足。regex_search跟go原来的逻辑保持一致