### PR TITLE
Update default value of ForceRerunWhenUpdate to false in PipelineConfig

### DIFF
--- a/core/config/PipelineConfig.cpp
+++ b/core/config/PipelineConfig.cpp
@@ -53,8 +53,7 @@ IsOneTime(const string& configName, const Json::Value& global, uint32_t* timeout
     }
     // Read ForceRerunWhenUpdate for onetime pipeline
     if (forceRerunWhenUpdate != nullptr) {
-        // Set default value first (true)
-        *forceRerunWhenUpdate = true;
+        *forceRerunWhenUpdate = false;
         const char* key = "ForceRerunWhenUpdate";
         const auto* it = global.find(key, key + strlen(key));
         if (it != nullptr && it->isBool()) {
@@ -62,7 +61,7 @@ IsOneTime(const string& configName, const Json::Value& global, uint32_t* timeout
         } else if (it != nullptr && !it->isBool()) {
             LOG_WARNING(sLogger,
                         ("param global.ForceRerunWhenUpdate is not of type bool",
-                         "use default instead")("default", true)("config", configName));
+                         "use default instead")("default", false)("config", configName));
         }
     }
     return true;

--- a/core/config/PipelineConfig.h
+++ b/core/config/PipelineConfig.h
@@ -39,7 +39,7 @@ struct PipelineConfig {
     std::optional<uint32_t> mOnetimeStartTime;
     std::optional<uint32_t> mOnetimeExpireTime;
     bool mIsRunningBeforeStart = false;
-    bool mForceRerunWhenUpdate = true;
+    bool mForceRerunWhenUpdate = false;
 
     PipelineConfig(const std::string& name,
                    std::unique_ptr<Json::Value>&& detail,

--- a/docs/cn/plugins/input/native/input-static-file-onetime.md
+++ b/docs/cn/plugins/input/native/input-static-file-onetime.md
@@ -33,7 +33,7 @@
 |  **参数**  |  **类型**  |  **是否必填**  |  **默认值**  |  **说明**  |
 | ---------- | ---------- | -------------- | ------------ | ---------- |
 |  ExcutionTimeout  |  uint  |  是  |  /  |  OneTime配置执行超时时间（秒）。取值范围：600～604800（10分钟～1周）。超过此时间配置将自动过期并被删除。  |
-|  ForceRerunWhenUpdate  |  bool  |  否  |  true  |  配置更新时是否强制重新执行。当配置文件的hash发生变化时：<ul><li>**true（默认）**：无论inputs配置是否变化，都会重新执行采集任务</li><li>**false**：如果inputs配置和ExcutionTimeout都未变化，则继续使用之前的过期时间，不重新执行；如果inputs配置或ExcutionTimeout发生变化，则重新执行</li></ul>该参数适用于需要在不改变inputs配置的情况下更新其他配置项（如processor、flusher等）的场景。  |
+|  ForceRerunWhenUpdate  |  bool  |  否  |  false  |  配置更新时是否强制重新执行。当配置文件的hash发生变化时：<ul><li>**true**：无论inputs配置是否变化，都会重新执行采集任务</li><li>**false（默认）**：如果inputs配置和ExcutionTimeout都未变化，则继续使用之前的过期时间，不重新执行；如果inputs配置或ExcutionTimeout发生变化，则重新执行</li></ul>该参数适用于需要在不改变inputs配置的情况下更新其他配置项（如processor、flusher等）的场景。  |
 
 ### 插件配置参数
 


### PR DESCRIPTION
Modified the default setting for the ForceRerunWhenUpdate parameter in both PipelineConfig.cpp and PipelineConfig.h to false, reflecting a change in behavior for configuration updates. Updated documentation to align with this new default value.