### PR TITLE
fix: add exception handling for GPU check

### DIFF
--- a/core/host_monitor/SystemInformationTools.cpp
+++ b/core/host_monitor/SystemInformationTools.cpp
@@ -48,40 +48,53 @@ bool CheckGPUDevice() {
         return false;
     }
 
-    auto binary_path = boost::process::search_path(NVSMI);
-    if (binary_path.empty()) {
-        LOG_WARNING(sLogger, ("GPU check failed", "nvidia-smi not found in PATH"));
-        return false;
-    }
-
-    boost::process::ipstream pipe_stream;
-    std::string cmd = "nvidia-smi -L";
-    std::error_code ec;
-
-    int exit_code = boost::process::system(cmd, boost::process::std_out > pipe_stream, ec);
-    if (ec || exit_code != 0) {
-        LOG_WARNING(sLogger,
-                    ("GPU check failed",
-                     "nvidia-smi execution error")("command", cmd)("error", ec.message())("exit_code", exit_code));
-        return false;
-    }
-
-    std::string line;
-    bool has_output = false;
-    while (std::getline(pipe_stream, line)) {
-        if (!line.empty()) {
-            has_output = true;
-            LOG_DEBUG(sLogger, ("GPU detected", line));
+    try {
+        auto binary_path = boost::process::search_path(NVSMI);
+        if (binary_path.empty()) {
+            LOG_WARNING(sLogger, ("GPU check failed", "nvidia-smi not found in PATH"));
+            return false;
         }
-    }
 
-    if (!has_output) {
-        LOG_WARNING(sLogger, ("GPU check failed", "no GPU devices found"));
+        boost::process::ipstream pipe_stream;
+        std::string cmd = "nvidia-smi -L";
+
+        int exit_code = boost::process::system(cmd, boost::process::std_out > pipe_stream);
+        if (exit_code != 0) {
+            LOG_WARNING(sLogger,
+                        ("GPU check failed", "nvidia-smi execution error")("command", cmd)("exit_code", exit_code));
+            return false;
+        }
+
+        std::string line;
+        bool has_output = false;
+        while (std::getline(pipe_stream, line)) {
+            if (!line.empty()) {
+                has_output = true;
+                LOG_DEBUG(sLogger, ("GPU detected", line));
+            }
+        }
+
+        if (!has_output) {
+            LOG_WARNING(sLogger, ("GPU check failed", "no GPU devices found"));
+            return false;
+        }
+
+        LOG_INFO(sLogger, ("GPU check successful", "GPU monitoring available"));
+        return true;
+    } catch (const std::system_error& e) {
+        LOG_ERROR(sLogger,
+                  ("GPU check failed", "system error")("command", "nvidia-smi -L")("error",
+                                                                                   e.what())("code", e.code().value()));
+        return false;
+    } catch (const std::exception& e) {
+        LOG_ERROR(
+            sLogger,
+            ("GPU check failed", "std::exception during GPU check")("command", "nvidia-smi -L")("error", e.what()));
+        return false;
+    } catch (...) {
+        LOG_ERROR(sLogger, ("GPU check failed", "unknown exception during GPU check")("command", "nvidia-smi -L"));
         return false;
     }
-
-    LOG_INFO(sLogger, ("GPU check successful", "GPU monitoring available"));
-    return true;
 #elif defined(_MSC_VER)
     // GPU detection implementation for Windows platform
     // On Windows, GPU detection can be implemented via WMI or DirectX API


### PR DESCRIPTION
fix: add exception handling for GPU check to prevent process crash

Problem:
CheckGPUDevice() could cause process crash (signal 6) when boost::process::system()
throws exceptions, even with error_code parameter provided. The uncaught
boost::process::process_error exception led to std::terminate().

Root Cause:
boost::process::system() can still throw exceptions (e.g., pipe creation failure)
even when error_code is provided, especially with stream redirection. The code
lacked exception handling.

Solution:
- Wrapped GPU check logic in try-catch blocks
- Added handlers for std::system_error, std::exception, and unknown exceptions
- All handlers log errors and return false gracefully instead of crashing

This prevents process crash when GPU check fails and improves robustness.