### PR TITLE
fix: correct timeStrCache calculation to exclude unmatched trailing chars

### DIFF
--- a/core/plugin/processor/ProcessorParseTimestampNative.cpp
+++ b/core/plugin/processor/ProcessorParseTimestampNative.cpp
@@ -203,7 +203,13 @@ bool ProcessorParseTimestampNative::ParseLogTime(const StringView& curTimeStr, /
     } else {
         strptimeResult = Strptime(curTimeStr.data(), mSourceFormat.c_str(), &logTime, nanosecondLength, mSourceYear);
         if (NULL != strptimeResult) {
-            timeStrCache = curTimeStr.substr(0, curTimeStr.length() - nanosecondLength);
+            // Use strptimeResult position (actual matched end) instead of curTimeStr.length()
+            // to correctly exclude any unmatched trailing chars (e.g. timezone +08:00) from cache.
+            int cacheLen = strptimeResult - curTimeStr.data();
+            if (nanosecondLength > 0) {
+                cacheLen -= nanosecondLength;
+            }
+            timeStrCache = curTimeStr.substr(0, cacheLen);
             logTime.tv_sec = logTime.tv_sec - mLogTimeZoneOffsetSecond;
         }
     }

--- a/core/unittest/processor/ProcessorParseTimestampNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseTimestampNativeUnittest.cpp
@@ -891,6 +891,26 @@ void ProcessorParseLogTimeUnittest::TestParseLogTimeSecondCache() {
             APSARA_TEST_EQUAL(outTime.tv_nsec, c.exceptedLogTimeNanosecond);
         }
     }
+    { // case: %f format with trailing chars not in format
+        config["SourceFormat"] = "%Y-%m-%dT%H:%M:%S.%f";
+        config["SourceTimezone"] = "GMT+00:00";
+        ProcessorParseTimestampNative& processor = *(new ProcessorParseTimestampNative);
+        ProcessorInstance processorInstance(&processor, getPluginMeta());
+        APSARA_TEST_TRUE_FATAL(processorInstance.Init(config, mContext));
+
+        LogtailTime outTime = {0, 0};
+        uint64_t preciseTimestamp = 0;
+        StringView timeStrCache;
+        const std::string timeStr = "2026-03-09T14:39:49.985+08:00";
+
+        // cache is empty
+        bool ret1 = processor.ParseLogTime(timeStr, "/var/log/message", outTime, preciseTimestamp, timeStrCache);
+        APSARA_TEST_EQUAL(ret1, true);
+
+        // same string -> IsPrefixString hits the polluted cache -> enters fast path
+        bool ret2 = processor.ParseLogTime(timeStr, "/var/log/message", outTime, preciseTimestamp, timeStrCache);
+        APSARA_TEST_EQUAL(ret2, true);
+    }
 }
 
 void ProcessorParseLogTimeUnittest::TestAdjustTimeZone() {


### PR DESCRIPTION
Use strptimeResult position (actual matched end) instead of curTimeStr.length() 
when building the second-level cache. This fixes cache pollution when the time 
string contains trailing characters not matched by the format string (e.g. timezone suffix +08:00)