### PR TITLE
feat(ebpf): input_agentsight 支持 Cmdline/Domain 扁平化筛选与内置默认规则

### DIFF
--- a/core/ebpf/Config.cpp
+++ b/core/ebpf/Config.cpp
@@ -14,6 +14,7 @@
 
 #include "ebpf/Config.h"
 
+#include <functional>
 #include <string>
 #include <unordered_set>
 
@@ -513,6 +514,78 @@ void WarnSecurityProbeConfigIgnore(const CollectionPipelineContext* mContext,
                          mContext->GetRegion());
 }
 
+/// Fills `dest` with non-empty argv-glob rows from `cmdlineRules[key]` (array of string arrays).
+void ParseAgentsightCmdlineRuleList(const Json::Value& cmdlineRules,
+                                    const char* key,
+                                    std::vector<std::vector<std::string>>& dest,
+                                    std::string& errorMsg,
+                                    const std::function<void()>& warn) {
+    if (!cmdlineRules.isMember(key)) {
+        return;
+    }
+    const Json::Value& rows = cmdlineRules[key];
+    if (!rows.isArray()) {
+        errorMsg = std::string("ProbeConfig.CmdlineRules.") + key + " must be an array";
+        warn();
+        return;
+    }
+    for (Json::ArrayIndex i = 0; i < rows.size(); ++i) {
+        const Json::Value& row = rows[i];
+        if (!row.isArray()) {
+            errorMsg = std::string("ProbeConfig.CmdlineRules.") + key + " row " + std::to_string(i) + " must be a "
+                + "string array";
+            warn();
+            continue;
+        }
+        std::vector<std::string> patterns;
+        patterns.reserve(row.size());
+        bool rowOk = true;
+        for (const auto& cell : row) {
+            if (!cell.isString()) {
+                errorMsg = std::string("ProbeConfig.CmdlineRules.") + key + " row " + std::to_string(i)
+                    + " contains non-string element";
+                warn();
+                rowOk = false;
+                break;
+            }
+            patterns.emplace_back(cell.asString());
+        }
+        if (!rowOk) {
+            continue;
+        }
+        if (patterns.empty()) {
+            errorMsg = std::string("ProbeConfig.CmdlineRules.") + key + " row " + std::to_string(i) + " is empty";
+            warn();
+            continue;
+        }
+        dest.emplace_back(std::move(patterns));
+    }
+}
+
+void ParseAgentsightDomainRules(const Json::Value& innerConfig,
+                                std::vector<std::string>& dest,
+                                std::string& errorMsg,
+                                const std::function<void()>& warn) {
+    if (!innerConfig.isMember("DomainRules")) {
+        return;
+    }
+    const Json::Value& dr = innerConfig["DomainRules"];
+    if (!dr.isArray()) {
+        errorMsg = "ProbeConfig.DomainRules must be an array of strings";
+        warn();
+        return;
+    }
+    for (Json::ArrayIndex i = 0; i < dr.size(); ++i) {
+        const Json::Value& cell = dr[i];
+        if (!cell.isString()) {
+            errorMsg = "ProbeConfig.DomainRules element " + std::to_string(i) + " is not a string";
+            warn();
+            continue;
+        }
+        dest.emplace_back(cell.asString());
+    }
+}
+
 } // namespace
 
 bool SecurityOptions::Init(SecurityProbeType probeType,
@@ -526,6 +599,9 @@ bool SecurityOptions::Init(SecurityProbeType probeType,
         mOptionList.clear();
         mVerbose = 0;
         mLogPath.clear();
+        mAgentsightCmdlineWhitelist.clear();
+        mAgentsightCmdlineBlacklist.clear();
+        mAgentsightDomainRules.clear();
     }
 
     SecurityOption thisSecurityOption;
@@ -554,6 +630,19 @@ bool SecurityOptions::Init(SecurityProbeType probeType,
                 if (!GetOptionalStringParam(innerConfig, "LogPath", mLogPath, errorMsg)) {
                     warnOptionalParse();
                 }
+                if (innerConfig.isMember("CmdlineRules")) {
+                    if (!innerConfig["CmdlineRules"].isObject()) {
+                        errorMsg = "ProbeConfig.CmdlineRules must be an object with optional whitelist/blacklist";
+                        warnOptionalParse();
+                    } else {
+                        const Json::Value& cr = innerConfig["CmdlineRules"];
+                        ParseAgentsightCmdlineRuleList(
+                            cr, "whitelist", mAgentsightCmdlineWhitelist, errorMsg, warnOptionalParse);
+                        ParseAgentsightCmdlineRuleList(
+                            cr, "blacklist", mAgentsightCmdlineBlacklist, errorMsg, warnOptionalParse);
+                    }
+                }
+                ParseAgentsightDomainRules(innerConfig, mAgentsightDomainRules, errorMsg, warnOptionalParse);
                 return true;
             }
             case SecurityProbeType::FILE: {

--- a/core/ebpf/Config.cpp
+++ b/core/ebpf/Config.cpp
@@ -514,26 +514,21 @@ void WarnSecurityProbeConfigIgnore(const CollectionPipelineContext* mContext,
                          mContext->GetRegion());
 }
 
-/// Fills `dest` with non-empty argv-glob rows from `cmdlineRules[key]` (array of string arrays).
-void ParseAgentsightCmdlineRuleList(const Json::Value& cmdlineRules,
-                                    const char* key,
+/// Fills `dest` with argv-glob rows from `rows` (must be JSON array of string arrays).
+void ParseAgentsightCmdlineRowArray(const Json::Value& rows,
+                                    const std::string& contextLabel,
                                     std::vector<std::vector<std::string>>& dest,
                                     std::string& errorMsg,
                                     const std::function<void()>& warn) {
-    if (!cmdlineRules.isMember(key)) {
-        return;
-    }
-    const Json::Value& rows = cmdlineRules[key];
     if (!rows.isArray()) {
-        errorMsg = std::string("ProbeConfig.CmdlineRules.") + key + " must be an array";
+        errorMsg = contextLabel + " must be an array of string arrays";
         warn();
         return;
     }
     for (Json::ArrayIndex i = 0; i < rows.size(); ++i) {
         const Json::Value& row = rows[i];
         if (!row.isArray()) {
-            errorMsg = std::string("ProbeConfig.CmdlineRules.") + key + " row " + std::to_string(i) + " must be a "
-                + "string array";
+            errorMsg = contextLabel + " row " + std::to_string(i) + " must be a string array";
             warn();
             continue;
         }
@@ -542,8 +537,7 @@ void ParseAgentsightCmdlineRuleList(const Json::Value& cmdlineRules,
         bool rowOk = true;
         for (const auto& cell : row) {
             if (!cell.isString()) {
-                errorMsg = std::string("ProbeConfig.CmdlineRules.") + key + " row " + std::to_string(i)
-                    + " contains non-string element";
+                errorMsg = contextLabel + " row " + std::to_string(i) + " contains non-string element";
                 warn();
                 rowOk = false;
                 break;
@@ -554,7 +548,7 @@ void ParseAgentsightCmdlineRuleList(const Json::Value& cmdlineRules,
             continue;
         }
         if (patterns.empty()) {
-            errorMsg = std::string("ProbeConfig.CmdlineRules.") + key + " row " + std::to_string(i) + " is empty";
+            errorMsg = contextLabel + " row " + std::to_string(i) + " is empty";
             warn();
             continue;
         }
@@ -562,23 +556,37 @@ void ParseAgentsightCmdlineRuleList(const Json::Value& cmdlineRules,
     }
 }
 
-void ParseAgentsightDomainRules(const Json::Value& innerConfig,
-                                std::vector<std::string>& dest,
-                                std::string& errorMsg,
-                                const std::function<void()>& warn) {
-    if (!innerConfig.isMember("DomainRules")) {
+void ParseAgentsightCmdlineFromOptionalKey(const Json::Value& innerConfig,
+                                           const char* key,
+                                           const std::string& contextLabel,
+                                           std::vector<std::vector<std::string>>& dest,
+                                           std::string& errorMsg,
+                                           const std::function<void()>& warn) {
+    if (!innerConfig.isMember(key)) {
         return;
     }
-    const Json::Value& dr = innerConfig["DomainRules"];
+    ParseAgentsightCmdlineRowArray(innerConfig[key], contextLabel, dest, errorMsg, warn);
+}
+
+void ParseAgentsightDomainStringList(const Json::Value& innerConfig,
+                                     const char* key,
+                                     const std::string& contextLabel,
+                                     std::vector<std::string>& dest,
+                                     std::string& errorMsg,
+                                     const std::function<void()>& warn) {
+    if (!innerConfig.isMember(key)) {
+        return;
+    }
+    const Json::Value& dr = innerConfig[key];
     if (!dr.isArray()) {
-        errorMsg = "ProbeConfig.DomainRules must be an array of strings";
+        errorMsg = contextLabel + " must be an array of strings";
         warn();
         return;
     }
     for (Json::ArrayIndex i = 0; i < dr.size(); ++i) {
         const Json::Value& cell = dr[i];
         if (!cell.isString()) {
-            errorMsg = "ProbeConfig.DomainRules element " + std::to_string(i) + " is not a string";
+            errorMsg = contextLabel + " element " + std::to_string(i) + " is not a string";
             warn();
             continue;
         }
@@ -601,7 +609,7 @@ bool SecurityOptions::Init(SecurityProbeType probeType,
         mLogPath.clear();
         mAgentsightCmdlineWhitelist.clear();
         mAgentsightCmdlineBlacklist.clear();
-        mAgentsightDomainRules.clear();
+        mAgentsightDomainWhitelist.clear();
     }
 
     SecurityOption thisSecurityOption;
@@ -630,19 +638,57 @@ bool SecurityOptions::Init(SecurityProbeType probeType,
                 if (!GetOptionalStringParam(innerConfig, "LogPath", mLogPath, errorMsg)) {
                     warnOptionalParse();
                 }
-                if (innerConfig.isMember("CmdlineRules")) {
-                    if (!innerConfig["CmdlineRules"].isObject()) {
-                        errorMsg = "ProbeConfig.CmdlineRules must be an object with optional whitelist/blacklist";
-                        warnOptionalParse();
-                    } else {
-                        const Json::Value& cr = innerConfig["CmdlineRules"];
-                        ParseAgentsightCmdlineRuleList(
-                            cr, "whitelist", mAgentsightCmdlineWhitelist, errorMsg, warnOptionalParse);
-                        ParseAgentsightCmdlineRuleList(
-                            cr, "blacklist", mAgentsightCmdlineBlacklist, errorMsg, warnOptionalParse);
+                ParseAgentsightCmdlineFromOptionalKey(innerConfig,
+                                                      "CmdlineWhitelist",
+                                                      "ProbeConfig.CmdlineWhitelist",
+                                                      mAgentsightCmdlineWhitelist,
+                                                      errorMsg,
+                                                      warnOptionalParse);
+                ParseAgentsightCmdlineFromOptionalKey(innerConfig,
+                                                      "CmdlineBlacklist",
+                                                      "ProbeConfig.CmdlineBlacklist",
+                                                      mAgentsightCmdlineBlacklist,
+                                                      errorMsg,
+                                                      warnOptionalParse);
+                if (!innerConfig.isMember("CmdlineWhitelist") && !innerConfig.isMember("CmdlineBlacklist")) {
+                    if (innerConfig.isMember("CmdlineRules")) {
+                        if (!innerConfig["CmdlineRules"].isObject()) {
+                            errorMsg = "ProbeConfig.CmdlineRules must be an object with optional whitelist/blacklist";
+                            warnOptionalParse();
+                        } else {
+                            const Json::Value& cr = innerConfig["CmdlineRules"];
+                            if (cr.isMember("whitelist")) {
+                                ParseAgentsightCmdlineRowArray(cr["whitelist"],
+                                                               "ProbeConfig.CmdlineRules.whitelist",
+                                                               mAgentsightCmdlineWhitelist,
+                                                               errorMsg,
+                                                               warnOptionalParse);
+                            }
+                            if (cr.isMember("blacklist")) {
+                                ParseAgentsightCmdlineRowArray(cr["blacklist"],
+                                                               "ProbeConfig.CmdlineRules.blacklist",
+                                                               mAgentsightCmdlineBlacklist,
+                                                               errorMsg,
+                                                               warnOptionalParse);
+                            }
+                        }
                     }
                 }
-                ParseAgentsightDomainRules(innerConfig, mAgentsightDomainRules, errorMsg, warnOptionalParse);
+                if (innerConfig.isMember("DomainWhitelist")) {
+                    ParseAgentsightDomainStringList(innerConfig,
+                                                    "DomainWhitelist",
+                                                    "ProbeConfig.DomainWhitelist",
+                                                    mAgentsightDomainWhitelist,
+                                                    errorMsg,
+                                                    warnOptionalParse);
+                } else {
+                    ParseAgentsightDomainStringList(innerConfig,
+                                                    "DomainRules",
+                                                    "ProbeConfig.DomainRules",
+                                                    mAgentsightDomainWhitelist,
+                                                    errorMsg,
+                                                    warnOptionalParse);
+                }
                 return true;
             }
             case SecurityProbeType::FILE: {

--- a/core/ebpf/Config.cpp
+++ b/core/ebpf/Config.cpp
@@ -650,45 +650,12 @@ bool SecurityOptions::Init(SecurityProbeType probeType,
                                                       mAgentsightCmdlineBlacklist,
                                                       errorMsg,
                                                       warnOptionalParse);
-                if (!innerConfig.isMember("CmdlineWhitelist") && !innerConfig.isMember("CmdlineBlacklist")) {
-                    if (innerConfig.isMember("CmdlineRules")) {
-                        if (!innerConfig["CmdlineRules"].isObject()) {
-                            errorMsg = "ProbeConfig.CmdlineRules must be an object with optional whitelist/blacklist";
-                            warnOptionalParse();
-                        } else {
-                            const Json::Value& cr = innerConfig["CmdlineRules"];
-                            if (cr.isMember("whitelist")) {
-                                ParseAgentsightCmdlineRowArray(cr["whitelist"],
-                                                               "ProbeConfig.CmdlineRules.whitelist",
-                                                               mAgentsightCmdlineWhitelist,
-                                                               errorMsg,
-                                                               warnOptionalParse);
-                            }
-                            if (cr.isMember("blacklist")) {
-                                ParseAgentsightCmdlineRowArray(cr["blacklist"],
-                                                               "ProbeConfig.CmdlineRules.blacklist",
-                                                               mAgentsightCmdlineBlacklist,
-                                                               errorMsg,
-                                                               warnOptionalParse);
-                            }
-                        }
-                    }
-                }
-                if (innerConfig.isMember("DomainWhitelist")) {
-                    ParseAgentsightDomainStringList(innerConfig,
-                                                    "DomainWhitelist",
-                                                    "ProbeConfig.DomainWhitelist",
-                                                    mAgentsightDomainWhitelist,
-                                                    errorMsg,
-                                                    warnOptionalParse);
-                } else {
-                    ParseAgentsightDomainStringList(innerConfig,
-                                                    "DomainRules",
-                                                    "ProbeConfig.DomainRules",
-                                                    mAgentsightDomainWhitelist,
-                                                    errorMsg,
-                                                    warnOptionalParse);
-                }
+                ParseAgentsightDomainStringList(innerConfig,
+                                                "DomainWhitelist",
+                                                "ProbeConfig.DomainWhitelist",
+                                                mAgentsightDomainWhitelist,
+                                                errorMsg,
+                                                warnOptionalParse);
                 return true;
             }
             case SecurityProbeType::FILE: {

--- a/core/ebpf/Config.h
+++ b/core/ebpf/Config.h
@@ -52,12 +52,12 @@ public:
     // Valid when mProbeType == SecurityProbeType::AGENTSIGHT_OBSERVE (AgentSight input).
     int32_t mVerbose = 0;
     std::string mLogPath;
-    /// Cmdline argv glob rows for `agentsight_config_add_cmdline_rule` (allow=1).
+    /// Cmdline argv glob rows (allow=1) for AgentSight process matching.
     std::vector<std::vector<std::string>> mAgentsightCmdlineWhitelist;
-    /// Cmdline argv glob rows for `agentsight_config_add_cmdline_rule` (allow=0).
+    /// Cmdline argv glob rows (allow=0) for AgentSight process matching.
     std::vector<std::vector<std::string>> mAgentsightCmdlineBlacklist;
-    /// Domain glob strings for `agentsight_config_add_domain_rule`.
-    std::vector<std::string> mAgentsightDomainRules;
+    /// Domain glob strings (whitelist) for AgentSight SNI / domain filtering.
+    std::vector<std::string> mAgentsightDomainWhitelist;
 };
 
 ///////////////////// Process Level Config /////////////////////

--- a/core/ebpf/Config.h
+++ b/core/ebpf/Config.h
@@ -52,6 +52,12 @@ public:
     // Valid when mProbeType == SecurityProbeType::AGENTSIGHT_OBSERVE (AgentSight input).
     int32_t mVerbose = 0;
     std::string mLogPath;
+    /// Cmdline argv glob rows for `agentsight_config_add_cmdline_rule` (allow=1).
+    std::vector<std::vector<std::string>> mAgentsightCmdlineWhitelist;
+    /// Cmdline argv glob rows for `agentsight_config_add_cmdline_rule` (allow=0).
+    std::vector<std::vector<std::string>> mAgentsightCmdlineBlacklist;
+    /// Domain glob strings for `agentsight_config_add_domain_rule`.
+    std::vector<std::string> mAgentsightDomainRules;
 };
 
 ///////////////////// Process Level Config /////////////////////

--- a/core/ebpf/EBPFAdapter.cpp
+++ b/core/ebpf/EBPFAdapter.cpp
@@ -257,6 +257,10 @@ bool EBPFAdapter::tryLoadAgentSightDylib() {
         tmpLib->LoadMethod("agentsight_config_set_verbose", symErr));
     sym.config_set_log_path = reinterpret_cast<decltype(sym.config_set_log_path)>(
         tmpLib->LoadMethod("agentsight_config_set_log_path", symErr));
+    sym.config_add_cmdline_rule = reinterpret_cast<decltype(sym.config_add_cmdline_rule)>(
+        tmpLib->LoadMethod("agentsight_config_add_cmdline_rule", symErr));
+    sym.config_add_domain_rule = reinterpret_cast<decltype(sym.config_add_domain_rule)>(
+        tmpLib->LoadMethod("agentsight_config_add_domain_rule", symErr));
     sym.handle_new = reinterpret_cast<decltype(sym.handle_new)>(tmpLib->LoadMethod("agentsight_new", symErr));
     sym.handle_free = reinterpret_cast<decltype(sym.handle_free)>(tmpLib->LoadMethod("agentsight_free", symErr));
     sym.handle_start = reinterpret_cast<decltype(sym.handle_start)>(tmpLib->LoadMethod("agentsight_start", symErr));

--- a/core/ebpf/EBPFAdapter.h
+++ b/core/ebpf/EBPFAdapter.h
@@ -36,6 +36,8 @@ struct AgentSightSymbolTable {
     void (*config_free)(AgentsightConfigHandle*) = nullptr;
     void (*config_set_verbose)(AgentsightConfigHandle*, int) = nullptr;
     void (*config_set_log_path)(AgentsightConfigHandle*, const char*) = nullptr;
+    void (*config_add_cmdline_rule)(AgentsightConfigHandle*, const char* const*, const char*, int) = nullptr;
+    void (*config_add_domain_rule)(AgentsightConfigHandle*, const char*) = nullptr;
     AgentsightHandle* (*handle_new)(AgentsightConfigHandle*) = nullptr;
     void (*handle_free)(AgentsightHandle*) = nullptr;
     int (*handle_start)(AgentsightHandle*) = nullptr;

--- a/core/ebpf/plugin/agentsight/AgentsightManager.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.cpp
@@ -155,16 +155,18 @@ void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
 
     if (!sym || !sym->config_add_cmdline_rule) {
         LOG_WARNING(sLogger,
-                    ("AgentSight", "cmdline rules required but agentsight_config_add_cmdline_rule is missing; skipped")(
+                    ("AgentSight",
+                     "cmdline rules configured but agentsight_config_add_cmdline_rule symbol not found; skipping")(
                         "user_whitelist_rows", opts.mAgentsightCmdlineWhitelist.size())(
                         "user_blacklist_rows", opts.mAgentsightCmdlineBlacklist.size())("builtin_allow_injected",
                                                                                         injectBuiltinCmdlineAllow));
     }
     if (!sym || !sym->config_add_domain_rule) {
-        LOG_WARNING(sLogger,
-                    ("AgentSight", "domain rules required but agentsight_config_add_domain_rule is missing; skipped")(
-                        "user_domain_rows", opts.mAgentsightDomainWhitelist.size())("builtin_domain_injected",
-                                                                                    injectBuiltinDomainAllow));
+        LOG_WARNING(
+            sLogger,
+            ("AgentSight", "domain rules configured but agentsight_config_add_domain_rule symbol not found; skipping")(
+                "user_domain_rows", opts.mAgentsightDomainWhitelist.size())("builtin_domain_injected",
+                                                                            injectBuiltinDomainAllow));
     }
 
     std::vector<std::pair<std::string, std::vector<std::string>>> allowRowsToApply;

--- a/core/ebpf/plugin/agentsight/AgentsightManager.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.cpp
@@ -126,12 +126,10 @@ static const std::vector<BuiltinCmdlineAllowRule>& GetBuiltinCmdlineAllowRules()
 
 static const std::vector<const char*>& GetBuiltinDomainAllowRules() {
     static const std::vector<const char*> kRules = {
-        "*.openai.com",
-        "*.anthropic.com",
+        "api.openai.com",
+        "api.anthropic.com",
         "dashscope.aliyuncs.com",
-        "*.dashscope.aliyuncs.com",
         "dashscope-intl.aliyuncs.com",
-        "*.dashscope-intl.aliyuncs.com",
     };
     return kRules;
 }
@@ -162,12 +160,11 @@ void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
                         "user_blacklist_rows", opts.mAgentsightCmdlineBlacklist.size())("builtin_allow_injected",
                                                                                         injectBuiltinCmdlineAllow));
     }
-    if ((injectBuiltinDomainAllow || !opts.mAgentsightDomainWhitelist.empty())
-        && (!sym || !sym->config_add_domain_rule)) {
+    if (!sym || !sym->config_add_domain_rule) {
         LOG_WARNING(sLogger,
                     ("AgentSight", "domain rules required but agentsight_config_add_domain_rule is missing; skipped")(
-                        "user_domain_rows", opts.mAgentsightDomainWhitelist.size())(
-                        "builtin_domain_injected", injectBuiltinDomainAllow));
+                        "user_domain_rows", opts.mAgentsightDomainWhitelist.size())("builtin_domain_injected",
+                                                                                    injectBuiltinDomainAllow));
     }
 
     std::vector<std::pair<std::string, std::vector<std::string>>> allowRowsToApply;
@@ -237,16 +234,15 @@ void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
         }
     }
 
-    LOG_INFO(
-        sLogger,
-        ("AgentSight", "applied config rules")("user_cmdline_whitelist", opts.mAgentsightCmdlineWhitelist.size())(
-            "user_cmdline_blacklist", opts.mAgentsightCmdlineBlacklist.size())(
-            "builtin_cmdline_allow_injected", injectBuiltinCmdlineAllow)("cmdline_allow_rows_applied",
-                                                                         allowRowsToApply.size())(
-            "user_domain_whitelist", opts.mAgentsightDomainWhitelist.size())(
-            "builtin_domain_allow_injected", injectBuiltinDomainAllow)("domain_rows_applied", domainRowsApplied)(
-            "whitelist_alias_collisions", aliasCollisions)("cmdline_api", sym && sym->config_add_cmdline_rule)(
-            "domain_api", sym && sym->config_add_domain_rule));
+    LOG_INFO(sLogger,
+             ("AgentSight", "applied config rules")("user_cmdline_whitelist", opts.mAgentsightCmdlineWhitelist.size())(
+                 "user_cmdline_blacklist", opts.mAgentsightCmdlineBlacklist.size())("builtin_cmdline_allow_injected",
+                                                                                    injectBuiltinCmdlineAllow)(
+                 "cmdline_allow_rows_applied", allowRowsToApply.size())("user_domain_whitelist",
+                                                                        opts.mAgentsightDomainWhitelist.size())(
+                 "builtin_domain_allow_injected", injectBuiltinDomainAllow)("domain_rows_applied", domainRowsApplied)(
+                 "whitelist_alias_collisions", aliasCollisions)("cmdline_api", sym && sym->config_add_cmdline_rule)(
+                 "domain_api", sym && sym->config_add_domain_rule));
 }
 
 } // namespace

--- a/core/ebpf/plugin/agentsight/AgentsightManager.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.cpp
@@ -15,11 +15,13 @@
 #include "ebpf/plugin/agentsight/AgentsightManager.h"
 
 #include <algorithm>
+#include <unordered_map>
 
 #include "collection_pipeline/queue/ProcessQueueItem.h"
 #include "collection_pipeline/queue/ProcessQueueManager.h"
 #include "common/StringView.h"
 #include "common/magic_enum.hpp"
+#include "ebpf/Config.h"
 #include "ebpf/EBPFServer.h"
 #include "ebpf/plugin/agentsight/AgentsightEvents.h"
 #include "ebpf/type/table/BaseElements.h"
@@ -98,6 +100,88 @@ bool ParseHostAndPortFromRequestUrl(const std::string& url, std::string& host, s
     return !host.empty();
 }
 
+/// Join argv glob patterns for a stable FFI `agent_name` label (not used for matching).
+std::string DeriveAgentsightAliasBase(const std::vector<std::string>& patterns) {
+    std::string s;
+    for (size_t i = 0; i < patterns.size(); ++i) {
+        if (i > 0) {
+            s += '|';
+        }
+        s += patterns[i];
+    }
+    return s;
+}
+
+void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
+                                  const AgentSightSymbolTable* sym,
+                                  const SecurityOptions& opts) {
+    const bool wantCmdline = !opts.mAgentsightCmdlineWhitelist.empty() || !opts.mAgentsightCmdlineBlacklist.empty();
+    const bool wantDomain = !opts.mAgentsightDomainRules.empty();
+
+    if (wantCmdline && (!sym || !sym->config_add_cmdline_rule)) {
+        LOG_WARNING(
+            sLogger,
+            ("AgentSight", "cmdline rules configured but agentsight_config_add_cmdline_rule is missing; skipped")(
+                "whitelist_rows", opts.mAgentsightCmdlineWhitelist.size())("blacklist_rows",
+                                                                           opts.mAgentsightCmdlineBlacklist.size()));
+    }
+    if (wantDomain && (!sym || !sym->config_add_domain_rule)) {
+        LOG_WARNING(sLogger,
+                    ("AgentSight", "domain rules configured but agentsight_config_add_domain_rule is missing; skipped")(
+                        "domain_rules", opts.mAgentsightDomainRules.size()));
+    }
+
+    size_t aliasCollisions = 0;
+    std::unordered_map<std::string, int> aliasOrdinal;
+    std::vector<std::string> whitelistAliases;
+    whitelistAliases.reserve(opts.mAgentsightCmdlineWhitelist.size());
+    for (const auto& row : opts.mAgentsightCmdlineWhitelist) {
+        const std::string base = DeriveAgentsightAliasBase(row);
+        int& n = aliasOrdinal[base];
+        ++n;
+        if (n == 1) {
+            whitelistAliases.push_back(base);
+        } else {
+            ++aliasCollisions;
+            whitelistAliases.push_back(base + "_" + std::to_string(n));
+        }
+    }
+
+    if (sym && sym->config_add_cmdline_rule) {
+        for (size_t i = 0; i < opts.mAgentsightCmdlineWhitelist.size(); ++i) {
+            const auto& row = opts.mAgentsightCmdlineWhitelist[i];
+            std::vector<const char*> ptrs;
+            ptrs.reserve(row.size() + 1);
+            for (const auto& p : row) {
+                ptrs.push_back(p.c_str());
+            }
+            ptrs.push_back(nullptr);
+            sym->config_add_cmdline_rule(cfg, ptrs.data(), whitelistAliases[i].c_str(), 1);
+        }
+        for (const auto& row : opts.mAgentsightCmdlineBlacklist) {
+            std::vector<const char*> ptrs;
+            ptrs.reserve(row.size() + 1);
+            for (const auto& p : row) {
+                ptrs.push_back(p.c_str());
+            }
+            ptrs.push_back(nullptr);
+            sym->config_add_cmdline_rule(cfg, ptrs.data(), nullptr, 0);
+        }
+    }
+
+    if (sym && sym->config_add_domain_rule) {
+        for (const auto& d : opts.mAgentsightDomainRules) {
+            sym->config_add_domain_rule(cfg, d.c_str());
+        }
+    }
+
+    LOG_INFO(sLogger,
+             ("AgentSight", "applied config rules")("cmdline_whitelist", opts.mAgentsightCmdlineWhitelist.size())(
+                 "cmdline_blacklist", opts.mAgentsightCmdlineBlacklist.size())(
+                 "domain_rules", opts.mAgentsightDomainRules.size())("whitelist_alias_collisions", aliasCollisions)(
+                 "cmdline_api", sym && sym->config_add_cmdline_rule)("domain_api", sym && sym->config_add_domain_rule));
+}
+
 } // namespace
 
 AgentsightManager::AgentsightManager(const std::shared_ptr<ProcessCacheManager>& processCacheManager,
@@ -170,6 +254,8 @@ bool AgentsightManager::RestartAgentSightLocked(const SecurityOptions& opts) {
     if (!opts.mLogPath.empty()) {
         sym->config_set_log_path(cfg, opts.mLogPath.c_str());
     }
+
+    ApplyAgentsightRulesToConfig(cfg, sym, opts);
 
     mHandle = sym->handle_new(cfg);
     if (sym->config_free) {
@@ -424,7 +510,7 @@ int AgentsightManager::HandleEvent(const std::shared_ptr<CommonEvent>& event) {
     if (rec->mPid != 0) {
         log->SetContent("pid", std::to_string(rec->mPid));
     }
-    setStr(StringView("process_name"), rec->mProcessName);
+    setStr(StringView("comm"), rec->mProcessName);
     setStr(StringView("gen_ai.agent.name"), rec->mAgentName);
 
     log->SetContent("gen_ai.request.timestamp", std::to_string(rec->mTimestampNs / 1000000ULL));

--- a/core/ebpf/plugin/agentsight/AgentsightManager.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.cpp
@@ -126,14 +126,12 @@ static const std::vector<BuiltinCmdlineAllowRule>& GetBuiltinCmdlineAllowRules()
 
 static const std::vector<const char*>& GetBuiltinDomainAllowRules() {
     static const std::vector<const char*> kRules = {
-        "api.openai.com",
         "*.openai.com",
+        "*.anthropic.com",
         "dashscope.aliyuncs.com",
         "*.dashscope.aliyuncs.com",
         "dashscope-intl.aliyuncs.com",
         "*.dashscope-intl.aliyuncs.com",
-        "api.anthropic.com",
-        "*.anthropic.com",
     };
     return kRules;
 }

--- a/core/ebpf/plugin/agentsight/AgentsightManager.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.cpp
@@ -16,6 +16,8 @@
 
 #include <algorithm>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "collection_pipeline/queue/ProcessQueueItem.h"
 #include "collection_pipeline/queue/ProcessQueueManager.h"
@@ -100,6 +102,28 @@ bool ParseHostAndPortFromRequestUrl(const std::string& url, std::string& host, s
     return !host.empty();
 }
 
+/// Builtin cmdline allow rules — keep in sync with
+/// `core/_thirdparty/coolbpf/src/agentsight/agentsight.json` (`cmdline.allow`).
+struct BuiltinCmdlineAllowRule {
+    const char* agent_name;
+    std::vector<std::string> argv_globs;
+};
+
+static const std::vector<BuiltinCmdlineAllowRule>& GetBuiltinCmdlineAllowRules() {
+    static const std::vector<BuiltinCmdlineAllowRule> kRules = {
+        {"Hermes", {"hermes*"}},
+        {"Hermes", {"*python*", "*hermes*"}},
+        {"Hermes", {"*python*", "-m", "*hermes*"}},
+        {"Cosh", {"node*", "*/usr/bin/co*"}},
+        {"Cosh", {"node*", "*/usr/bin/cosh*"}},
+        {"Cosh", {"node*", "*/usr/bin/copliot*"}},
+        {"Cosh", {"node*", "*copilot-shell*"}},
+        {"OpenClaw", {"*openclaw-gatewa*"}},
+        {"OpenClaw", {"node*", "*openclaw*"}},
+    };
+    return kRules;
+}
+
 /// Join argv glob patterns for a stable FFI `agent_name` label (not used for matching).
 std::string DeriveAgentsightAliasBase(const std::vector<std::string>& patterns) {
     std::string s;
@@ -115,52 +139,67 @@ std::string DeriveAgentsightAliasBase(const std::vector<std::string>& patterns) 
 void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
                                   const AgentSightSymbolTable* sym,
                                   const SecurityOptions& opts) {
-    const bool wantCmdline = !opts.mAgentsightCmdlineWhitelist.empty() || !opts.mAgentsightCmdlineBlacklist.empty();
-    const bool wantDomain = !opts.mAgentsightDomainRules.empty();
+    const bool injectBuiltinCmdlineAllow
+        = opts.mAgentsightCmdlineWhitelist.empty() && opts.mAgentsightCmdlineBlacklist.empty();
+    const bool wantDomain = !opts.mAgentsightDomainWhitelist.empty();
 
-    if (wantCmdline && (!sym || !sym->config_add_cmdline_rule)) {
-        LOG_WARNING(
-            sLogger,
-            ("AgentSight", "cmdline rules configured but agentsight_config_add_cmdline_rule is missing; skipped")(
-                "whitelist_rows", opts.mAgentsightCmdlineWhitelist.size())("blacklist_rows",
-                                                                           opts.mAgentsightCmdlineBlacklist.size()));
+    if (!sym || !sym->config_add_cmdline_rule) {
+        LOG_WARNING(sLogger,
+                    ("AgentSight", "cmdline rules required but agentsight_config_add_cmdline_rule is missing; skipped")(
+                        "user_whitelist_rows", opts.mAgentsightCmdlineWhitelist.size())(
+                        "user_blacklist_rows", opts.mAgentsightCmdlineBlacklist.size())("builtin_allow_injected",
+                                                                                        injectBuiltinCmdlineAllow));
     }
     if (wantDomain && (!sym || !sym->config_add_domain_rule)) {
         LOG_WARNING(sLogger,
                     ("AgentSight", "domain rules configured but agentsight_config_add_domain_rule is missing; skipped")(
-                        "domain_rules", opts.mAgentsightDomainRules.size()));
+                        "domain_whitelist", opts.mAgentsightDomainWhitelist.size()));
     }
 
+    std::vector<std::pair<std::string, std::vector<std::string>>> allowRowsToApply;
     size_t aliasCollisions = 0;
-    std::unordered_map<std::string, int> aliasOrdinal;
-    std::vector<std::string> whitelistAliases;
-    whitelistAliases.reserve(opts.mAgentsightCmdlineWhitelist.size());
-    for (const auto& row : opts.mAgentsightCmdlineWhitelist) {
-        const std::string base = DeriveAgentsightAliasBase(row);
-        int& n = aliasOrdinal[base];
-        ++n;
-        if (n == 1) {
-            whitelistAliases.push_back(base);
-        } else {
-            ++aliasCollisions;
-            whitelistAliases.push_back(base + "_" + std::to_string(n));
+
+    if (injectBuiltinCmdlineAllow) {
+        const auto& builtins = GetBuiltinCmdlineAllowRules();
+        allowRowsToApply.reserve(builtins.size());
+        for (const auto& br : builtins) {
+            allowRowsToApply.emplace_back(std::string(br.agent_name), br.argv_globs);
+        }
+    } else {
+        std::unordered_map<std::string, int> aliasOrdinal;
+        std::vector<std::string> whitelistAliases;
+        whitelistAliases.reserve(opts.mAgentsightCmdlineWhitelist.size());
+        for (const auto& row : opts.mAgentsightCmdlineWhitelist) {
+            const std::string base = DeriveAgentsightAliasBase(row);
+            int& n = aliasOrdinal[base];
+            ++n;
+            if (n == 1) {
+                whitelistAliases.push_back(base);
+            } else {
+                ++aliasCollisions;
+                whitelistAliases.push_back(base + "_" + std::to_string(n));
+            }
+        }
+        allowRowsToApply.reserve(opts.mAgentsightCmdlineWhitelist.size());
+        for (size_t i = 0; i < opts.mAgentsightCmdlineWhitelist.size(); ++i) {
+            allowRowsToApply.emplace_back(std::move(whitelistAliases[i]), opts.mAgentsightCmdlineWhitelist[i]);
         }
     }
 
     if (sym && sym->config_add_cmdline_rule) {
-        for (size_t i = 0; i < opts.mAgentsightCmdlineWhitelist.size(); ++i) {
-            const auto& row = opts.mAgentsightCmdlineWhitelist[i];
+        for (const auto& entry : allowRowsToApply) {
+            const auto& row = entry.second;
             std::vector<const char*> ptrs;
-            ptrs.reserve(row.size() + 1);
+            ptrs.reserve(row.size() + 1U);
             for (const auto& p : row) {
                 ptrs.push_back(p.c_str());
             }
             ptrs.push_back(nullptr);
-            sym->config_add_cmdline_rule(cfg, ptrs.data(), whitelistAliases[i].c_str(), 1);
+            sym->config_add_cmdline_rule(cfg, ptrs.data(), entry.first.c_str(), 1);
         }
         for (const auto& row : opts.mAgentsightCmdlineBlacklist) {
             std::vector<const char*> ptrs;
-            ptrs.reserve(row.size() + 1);
+            ptrs.reserve(row.size() + 1U);
             for (const auto& p : row) {
                 ptrs.push_back(p.c_str());
             }
@@ -170,16 +209,19 @@ void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
     }
 
     if (sym && sym->config_add_domain_rule) {
-        for (const auto& d : opts.mAgentsightDomainRules) {
+        for (const auto& d : opts.mAgentsightDomainWhitelist) {
             sym->config_add_domain_rule(cfg, d.c_str());
         }
     }
 
-    LOG_INFO(sLogger,
-             ("AgentSight", "applied config rules")("cmdline_whitelist", opts.mAgentsightCmdlineWhitelist.size())(
-                 "cmdline_blacklist", opts.mAgentsightCmdlineBlacklist.size())(
-                 "domain_rules", opts.mAgentsightDomainRules.size())("whitelist_alias_collisions", aliasCollisions)(
-                 "cmdline_api", sym && sym->config_add_cmdline_rule)("domain_api", sym && sym->config_add_domain_rule));
+    LOG_INFO(
+        sLogger,
+        ("AgentSight", "applied config rules")("user_cmdline_whitelist", opts.mAgentsightCmdlineWhitelist.size())(
+            "user_cmdline_blacklist", opts.mAgentsightCmdlineBlacklist.size())(
+            "builtin_cmdline_allow_injected", injectBuiltinCmdlineAllow)("cmdline_allow_rows_applied",
+                                                                         allowRowsToApply.size())(
+            "domain_whitelist", opts.mAgentsightDomainWhitelist.size())("whitelist_alias_collisions", aliasCollisions)(
+            "cmdline_api", sym && sym->config_add_cmdline_rule)("domain_api", sym && sym->config_add_domain_rule));
 }
 
 } // namespace

--- a/core/ebpf/plugin/agentsight/AgentsightManager.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.cpp
@@ -124,6 +124,20 @@ static const std::vector<BuiltinCmdlineAllowRule>& GetBuiltinCmdlineAllowRules()
     return kRules;
 }
 
+static const std::vector<const char*>& GetBuiltinDomainAllowRules() {
+    static const std::vector<const char*> kRules = {
+        "api.openai.com",
+        "*.openai.com",
+        "dashscope.aliyuncs.com",
+        "*.dashscope.aliyuncs.com",
+        "dashscope-intl.aliyuncs.com",
+        "*.dashscope-intl.aliyuncs.com",
+        "api.anthropic.com",
+        "*.anthropic.com",
+    };
+    return kRules;
+}
+
 /// Join argv glob patterns for a stable FFI `agent_name` label (not used for matching).
 std::string DeriveAgentsightAliasBase(const std::vector<std::string>& patterns) {
     std::string s;
@@ -141,7 +155,7 @@ void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
                                   const SecurityOptions& opts) {
     const bool injectBuiltinCmdlineAllow
         = opts.mAgentsightCmdlineWhitelist.empty() && opts.mAgentsightCmdlineBlacklist.empty();
-    const bool wantDomain = !opts.mAgentsightDomainWhitelist.empty();
+    const bool injectBuiltinDomainAllow = opts.mAgentsightDomainWhitelist.empty();
 
     if (!sym || !sym->config_add_cmdline_rule) {
         LOG_WARNING(sLogger,
@@ -150,10 +164,12 @@ void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
                         "user_blacklist_rows", opts.mAgentsightCmdlineBlacklist.size())("builtin_allow_injected",
                                                                                         injectBuiltinCmdlineAllow));
     }
-    if (wantDomain && (!sym || !sym->config_add_domain_rule)) {
+    if ((injectBuiltinDomainAllow || !opts.mAgentsightDomainWhitelist.empty())
+        && (!sym || !sym->config_add_domain_rule)) {
         LOG_WARNING(sLogger,
-                    ("AgentSight", "domain rules configured but agentsight_config_add_domain_rule is missing; skipped")(
-                        "domain_whitelist", opts.mAgentsightDomainWhitelist.size()));
+                    ("AgentSight", "domain rules required but agentsight_config_add_domain_rule is missing; skipped")(
+                        "user_domain_rows", opts.mAgentsightDomainWhitelist.size())(
+                        "builtin_domain_injected", injectBuiltinDomainAllow));
     }
 
     std::vector<std::pair<std::string, std::vector<std::string>>> allowRowsToApply;
@@ -208,9 +224,18 @@ void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
         }
     }
 
+    size_t domainRowsApplied = 0;
     if (sym && sym->config_add_domain_rule) {
-        for (const auto& d : opts.mAgentsightDomainWhitelist) {
-            sym->config_add_domain_rule(cfg, d.c_str());
+        if (injectBuiltinDomainAllow) {
+            for (const char* d : GetBuiltinDomainAllowRules()) {
+                sym->config_add_domain_rule(cfg, d);
+                ++domainRowsApplied;
+            }
+        } else {
+            for (const auto& d : opts.mAgentsightDomainWhitelist) {
+                sym->config_add_domain_rule(cfg, d.c_str());
+                ++domainRowsApplied;
+            }
         }
     }
 
@@ -220,8 +245,10 @@ void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
             "user_cmdline_blacklist", opts.mAgentsightCmdlineBlacklist.size())(
             "builtin_cmdline_allow_injected", injectBuiltinCmdlineAllow)("cmdline_allow_rows_applied",
                                                                          allowRowsToApply.size())(
-            "domain_whitelist", opts.mAgentsightDomainWhitelist.size())("whitelist_alias_collisions", aliasCollisions)(
-            "cmdline_api", sym && sym->config_add_cmdline_rule)("domain_api", sym && sym->config_add_domain_rule));
+            "user_domain_whitelist", opts.mAgentsightDomainWhitelist.size())(
+            "builtin_domain_allow_injected", injectBuiltinDomainAllow)("domain_rows_applied", domainRowsApplied)(
+            "whitelist_alias_collisions", aliasCollisions)("cmdline_api", sym && sym->config_add_cmdline_rule)(
+            "domain_api", sym && sym->config_add_domain_rule));
 }
 
 } // namespace

--- a/core/unittest/ebpf/AgentsightManagerUnittest.cpp
+++ b/core/unittest/ebpf/AgentsightManagerUnittest.cpp
@@ -506,7 +506,7 @@ void AgentsightManagerUnittest::TestBuiltinCmdlineRulesInjectedWhenCmdlineOmitte
     APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 0, nullptr, asVariant()));
     APSARA_TEST_EQUAL(9, g_ut_cmdline_allow_calls);
     APSARA_TEST_EQUAL(0, g_ut_cmdline_deny_calls);
-    APSARA_TEST_EQUAL(8, g_ut_domain_rule_calls);
+    APSARA_TEST_EQUAL(6, g_ut_domain_rule_calls);
     mgr->RemoveConfig("p1");
     mgr->Destroy();
 }
@@ -522,7 +522,7 @@ void AgentsightManagerUnittest::TestUserBlacklistOnlySkipsBuiltinAllowInjection(
     APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 0, nullptr, asVariant()));
     APSARA_TEST_EQUAL(0, g_ut_cmdline_allow_calls);
     APSARA_TEST_EQUAL(1, g_ut_cmdline_deny_calls);
-    APSARA_TEST_EQUAL(8, g_ut_domain_rule_calls);
+    APSARA_TEST_EQUAL(6, g_ut_domain_rule_calls);
     mgr->RemoveConfig("p1");
     mgr->Destroy();
 }

--- a/core/unittest/ebpf/AgentsightManagerUnittest.cpp
+++ b/core/unittest/ebpf/AgentsightManagerUnittest.cpp
@@ -222,7 +222,7 @@ public:
         auto& o = agentsightOptions();
         o.mAgentsightCmdlineWhitelist.clear();
         o.mAgentsightCmdlineBlacklist.clear();
-        o.mAgentsightDomainRules.clear();
+        o.mAgentsightDomainWhitelist.clear();
     }
 
     void TearDown() override {
@@ -273,6 +273,8 @@ public:
     void TestDestroyTwice();
     void TestGetPluginType();
     void TestCmdlineAndDomainRulesInvokedOnAddOrUpdate();
+    void TestBuiltinCmdlineRulesInjectedWhenCmdlineOmitted();
+    void TestUserBlacklistOnlySkipsBuiltinAllowInjection();
 
 protected:
     std::shared_ptr<AgentSightTestEBPFAdapter> mAgentSightAdapter;
@@ -482,7 +484,7 @@ void AgentsightManagerUnittest::TestCmdlineAndDomainRulesInvokedOnAddOrUpdate() 
     auto& o = agentsightOptions();
     o.mAgentsightCmdlineWhitelist = {{"node", "*claude*"}, {"node", "*claude*"}};
     o.mAgentsightCmdlineBlacklist = {{"node", "*webpack*"}};
-    o.mAgentsightDomainRules = {"*.openai.com", "*.anthropic.com"};
+    o.mAgentsightDomainWhitelist = {"*.openai.com", "*.anthropic.com"};
 
     auto mgr = makeManager();
     CollectionPipelineContext ctx;
@@ -492,6 +494,34 @@ void AgentsightManagerUnittest::TestCmdlineAndDomainRulesInvokedOnAddOrUpdate() 
     APSARA_TEST_EQUAL(2, g_ut_cmdline_allow_calls);
     APSARA_TEST_EQUAL(1, g_ut_cmdline_deny_calls);
     APSARA_TEST_EQUAL(2, g_ut_domain_rule_calls);
+    mgr->RemoveConfig("p1");
+    mgr->Destroy();
+}
+
+void AgentsightManagerUnittest::TestBuiltinCmdlineRulesInjectedWhenCmdlineOmitted() {
+    auto mgr = makeManager();
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName("p1");
+    ctx.SetProcessQueueKey(1);
+    APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 0, nullptr, asVariant()));
+    APSARA_TEST_EQUAL(9, g_ut_cmdline_allow_calls);
+    APSARA_TEST_EQUAL(0, g_ut_cmdline_deny_calls);
+    APSARA_TEST_EQUAL(0, g_ut_domain_rule_calls);
+    mgr->RemoveConfig("p1");
+    mgr->Destroy();
+}
+
+void AgentsightManagerUnittest::TestUserBlacklistOnlySkipsBuiltinAllowInjection() {
+    auto& o = agentsightOptions();
+    o.mAgentsightCmdlineBlacklist = {{"node", "*webpack*"}};
+
+    auto mgr = makeManager();
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName("p1");
+    ctx.SetProcessQueueKey(1);
+    APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 0, nullptr, asVariant()));
+    APSARA_TEST_EQUAL(0, g_ut_cmdline_allow_calls);
+    APSARA_TEST_EQUAL(1, g_ut_cmdline_deny_calls);
     mgr->RemoveConfig("p1");
     mgr->Destroy();
 }
@@ -512,5 +542,7 @@ UNIT_TEST_CASE(AgentsightManagerUnittest, TestResumeWithNoRegistration);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestSuspend);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestDestroyTwice);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestCmdlineAndDomainRulesInvokedOnAddOrUpdate);
+UNIT_TEST_CASE(AgentsightManagerUnittest, TestBuiltinCmdlineRulesInjectedWhenCmdlineOmitted);
+UNIT_TEST_CASE(AgentsightManagerUnittest, TestUserBlacklistOnlySkipsBuiltinAllowInjection);
 
 UNIT_TEST_MAIN

--- a/core/unittest/ebpf/AgentsightManagerUnittest.cpp
+++ b/core/unittest/ebpf/AgentsightManagerUnittest.cpp
@@ -506,7 +506,7 @@ void AgentsightManagerUnittest::TestBuiltinCmdlineRulesInjectedWhenCmdlineOmitte
     APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 0, nullptr, asVariant()));
     APSARA_TEST_EQUAL(9, g_ut_cmdline_allow_calls);
     APSARA_TEST_EQUAL(0, g_ut_cmdline_deny_calls);
-    APSARA_TEST_EQUAL(6, g_ut_domain_rule_calls);
+    APSARA_TEST_EQUAL(4, g_ut_domain_rule_calls);
     mgr->RemoveConfig("p1");
     mgr->Destroy();
 }
@@ -522,7 +522,7 @@ void AgentsightManagerUnittest::TestUserBlacklistOnlySkipsBuiltinAllowInjection(
     APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 0, nullptr, asVariant()));
     APSARA_TEST_EQUAL(0, g_ut_cmdline_allow_calls);
     APSARA_TEST_EQUAL(1, g_ut_cmdline_deny_calls);
-    APSARA_TEST_EQUAL(6, g_ut_domain_rule_calls);
+    APSARA_TEST_EQUAL(4, g_ut_domain_rule_calls);
     mgr->RemoveConfig("p1");
     mgr->Destroy();
 }

--- a/core/unittest/ebpf/AgentsightManagerUnittest.cpp
+++ b/core/unittest/ebpf/AgentsightManagerUnittest.cpp
@@ -70,6 +70,30 @@ void fake_config_set_log_path(AgentsightConfigHandle* c, const char* p) {
     (void)p;
 }
 
+int g_ut_cmdline_allow_calls = 0;
+int g_ut_cmdline_deny_calls = 0;
+int g_ut_domain_rule_calls = 0;
+
+void fake_config_add_cmdline_rule(AgentsightConfigHandle* cfg,
+                                  const char* const* rule,
+                                  const char* agent_name,
+                                  int allow) {
+    (void)cfg;
+    (void)rule;
+    (void)agent_name;
+    if (allow != 0) {
+        ++g_ut_cmdline_allow_calls;
+    } else {
+        ++g_ut_cmdline_deny_calls;
+    }
+}
+
+void fake_config_add_domain_rule(AgentsightConfigHandle* cfg, const char* rule) {
+    (void)cfg;
+    (void)rule;
+    ++g_ut_domain_rule_calls;
+}
+
 AgentsightHandle* fake_handle_new(AgentsightConfigHandle* cfg) {
     (void)cfg;
     return gFakeHandle;
@@ -144,6 +168,8 @@ std::unique_ptr<AgentSightSymbolTable> makeFullSymbolTable() {
     t->config_free = fake_config_free;
     t->config_set_verbose = fake_config_set_verbose;
     t->config_set_log_path = fake_config_set_log_path;
+    t->config_add_cmdline_rule = fake_config_add_cmdline_rule;
+    t->config_add_domain_rule = fake_config_add_domain_rule;
     t->handle_new = fake_handle_new;
     t->handle_free = fake_handle_free;
     t->handle_start = fake_handle_start;
@@ -190,6 +216,13 @@ public:
         gRead = decltype(gRead){};
         gRead.start_ret = 0;
         g_config_new_null = false;
+        g_ut_cmdline_allow_calls = 0;
+        g_ut_cmdline_deny_calls = 0;
+        g_ut_domain_rule_calls = 0;
+        auto& o = agentsightOptions();
+        o.mAgentsightCmdlineWhitelist.clear();
+        o.mAgentsightCmdlineBlacklist.clear();
+        o.mAgentsightDomainRules.clear();
     }
 
     void TearDown() override {
@@ -239,6 +272,7 @@ public:
     void TestSuspend();
     void TestDestroyTwice();
     void TestGetPluginType();
+    void TestCmdlineAndDomainRulesInvokedOnAddOrUpdate();
 
 protected:
     std::shared_ptr<AgentSightTestEBPFAdapter> mAgentSightAdapter;
@@ -444,6 +478,24 @@ void AgentsightManagerUnittest::TestDestroyTwice() {
     APSARA_TEST_EQUAL(0, mgr->Destroy());
 }
 
+void AgentsightManagerUnittest::TestCmdlineAndDomainRulesInvokedOnAddOrUpdate() {
+    auto& o = agentsightOptions();
+    o.mAgentsightCmdlineWhitelist = {{"node", "*claude*"}, {"node", "*claude*"}};
+    o.mAgentsightCmdlineBlacklist = {{"node", "*webpack*"}};
+    o.mAgentsightDomainRules = {"*.openai.com", "*.anthropic.com"};
+
+    auto mgr = makeManager();
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName("p1");
+    ctx.SetProcessQueueKey(1);
+    APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 0, nullptr, asVariant()));
+    APSARA_TEST_EQUAL(2, g_ut_cmdline_allow_calls);
+    APSARA_TEST_EQUAL(1, g_ut_cmdline_deny_calls);
+    APSARA_TEST_EQUAL(2, g_ut_domain_rule_calls);
+    mgr->RemoveConfig("p1");
+    mgr->Destroy();
+}
+
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestGetPluginType);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestAddOrUpdateValidation);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestAddOrUpdateNoSymbols);
@@ -459,5 +511,6 @@ UNIT_TEST_CASE(AgentsightManagerUnittest, TestResumeInvalidOptions);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestResumeWithNoRegistration);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestSuspend);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestDestroyTwice);
+UNIT_TEST_CASE(AgentsightManagerUnittest, TestCmdlineAndDomainRulesInvokedOnAddOrUpdate);
 
 UNIT_TEST_MAIN

--- a/core/unittest/ebpf/AgentsightManagerUnittest.cpp
+++ b/core/unittest/ebpf/AgentsightManagerUnittest.cpp
@@ -506,7 +506,7 @@ void AgentsightManagerUnittest::TestBuiltinCmdlineRulesInjectedWhenCmdlineOmitte
     APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 0, nullptr, asVariant()));
     APSARA_TEST_EQUAL(9, g_ut_cmdline_allow_calls);
     APSARA_TEST_EQUAL(0, g_ut_cmdline_deny_calls);
-    APSARA_TEST_EQUAL(0, g_ut_domain_rule_calls);
+    APSARA_TEST_EQUAL(8, g_ut_domain_rule_calls);
     mgr->RemoveConfig("p1");
     mgr->Destroy();
 }
@@ -522,6 +522,7 @@ void AgentsightManagerUnittest::TestUserBlacklistOnlySkipsBuiltinAllowInjection(
     APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 0, nullptr, asVariant()));
     APSARA_TEST_EQUAL(0, g_ut_cmdline_allow_calls);
     APSARA_TEST_EQUAL(1, g_ut_cmdline_deny_calls);
+    APSARA_TEST_EQUAL(8, g_ut_domain_rule_calls);
     mgr->RemoveConfig("p1");
     mgr->Destroy();
 }

--- a/core/unittest/ebpf/SecurityOptionsUnittest.cpp
+++ b/core/unittest/ebpf/SecurityOptionsUnittest.cpp
@@ -27,7 +27,10 @@ public:
     void TestAgentsightProbeConfigParsesOptionalFields();
     void TestAgentsightProbeConfigOptionalInvalidTypes();
     void TestAgentsightVerboseClampedWhenNegative();
-    void TestAgentsightParsesCmdlineRulesAndDomainRules();
+    void TestAgentsightParsesFlatCmdlineAndDomainWhitelist();
+    void TestAgentsightLegacyNestedCmdlineAndDomainRules();
+    void TestAgentsightFlatCmdlineOverridesLegacyNested();
+    void TestAgentsightDomainWhitelistOverridesDomainRules();
 };
 
 void SecurityOptionsUnittest::TestAgentsightNoProbeConfigReturnsTrue() {
@@ -40,7 +43,7 @@ void SecurityOptionsUnittest::TestAgentsightNoProbeConfigReturnsTrue() {
     APSARA_TEST_TRUE(opt.mLogPath.empty());
     APSARA_TEST_TRUE(opt.mAgentsightCmdlineWhitelist.empty());
     APSARA_TEST_TRUE(opt.mAgentsightCmdlineBlacklist.empty());
-    APSARA_TEST_TRUE(opt.mAgentsightDomainRules.empty());
+    APSARA_TEST_TRUE(opt.mAgentsightDomainWhitelist.empty());
 }
 
 void SecurityOptionsUnittest::TestAgentsightProbeConfigWrongTypeWarns() {
@@ -89,14 +92,14 @@ void SecurityOptionsUnittest::TestAgentsightVerboseClampedWhenNegative() {
     APSARA_TEST_EQUAL(opt.mVerbose, 0);
 }
 
-void SecurityOptionsUnittest::TestAgentsightParsesCmdlineRulesAndDomainRules() {
+void SecurityOptionsUnittest::TestAgentsightParsesFlatCmdlineAndDomainWhitelist() {
     CollectionPipelineContext ctx;
     ctx.SetConfigName("cfg1");
     SecurityOptions opt;
     std::string err;
     Json::Value config;
     APSARA_TEST_TRUE(ParseJsonTable(
-        R"({"ProbeConfig":{"Verbose":0,"LogPath":"","CmdlineRules":{"whitelist":[["node","*claude*"],["npm","run","*"]],"blacklist":[["node","*webpack*"]]},"DomainRules":["*.openai.com","*.anthropic.com"]}})",
+        R"({"ProbeConfig":{"Verbose":0,"LogPath":"","CmdlineWhitelist":[["node","*claude*"],["npm","run","*"]],"CmdlineBlacklist":[["node","*webpack*"]],"DomainWhitelist":["*.openai.com","*.anthropic.com"]}})",
         config,
         err));
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
@@ -107,8 +110,57 @@ void SecurityOptionsUnittest::TestAgentsightParsesCmdlineRulesAndDomainRules() {
     APSARA_TEST_EQUAL(3UL, opt.mAgentsightCmdlineWhitelist[1].size());
     APSARA_TEST_EQUAL(1UL, opt.mAgentsightCmdlineBlacklist.size());
     APSARA_TEST_EQUAL("*webpack*", opt.mAgentsightCmdlineBlacklist[0][1]);
-    APSARA_TEST_EQUAL(2UL, opt.mAgentsightDomainRules.size());
-    APSARA_TEST_EQUAL("*.openai.com", opt.mAgentsightDomainRules[0]);
+    APSARA_TEST_EQUAL(2UL, opt.mAgentsightDomainWhitelist.size());
+    APSARA_TEST_EQUAL("*.openai.com", opt.mAgentsightDomainWhitelist[0]);
+}
+
+void SecurityOptionsUnittest::TestAgentsightLegacyNestedCmdlineAndDomainRules() {
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName("cfg1");
+    SecurityOptions opt;
+    std::string err;
+    Json::Value config;
+    APSARA_TEST_TRUE(ParseJsonTable(
+        R"({"ProbeConfig":{"Verbose":0,"LogPath":"","CmdlineRules":{"whitelist":[["a","b"]],"blacklist":[["c","d"]]},"DomainRules":["x.y"]}})",
+        config,
+        err));
+    APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
+    APSARA_TEST_EQUAL(1UL, opt.mAgentsightCmdlineWhitelist.size());
+    APSARA_TEST_EQUAL(1UL, opt.mAgentsightCmdlineBlacklist.size());
+    APSARA_TEST_EQUAL(1UL, opt.mAgentsightDomainWhitelist.size());
+    APSARA_TEST_EQUAL("x.y", opt.mAgentsightDomainWhitelist[0]);
+}
+
+void SecurityOptionsUnittest::TestAgentsightFlatCmdlineOverridesLegacyNested() {
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName("cfg1");
+    SecurityOptions opt;
+    std::string err;
+    Json::Value config;
+    APSARA_TEST_TRUE(ParseJsonTable(
+        R"({"ProbeConfig":{"CmdlineWhitelist":[["from","flat"]],"CmdlineRules":{"whitelist":[["from","nested"]]}}})",
+        config,
+        err));
+    APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
+    APSARA_TEST_EQUAL(1UL, opt.mAgentsightCmdlineWhitelist.size());
+    APSARA_TEST_EQUAL("from", opt.mAgentsightCmdlineWhitelist[0][0]);
+    APSARA_TEST_EQUAL("flat", opt.mAgentsightCmdlineWhitelist[0][1]);
+    APSARA_TEST_TRUE(opt.mAgentsightCmdlineBlacklist.empty());
+}
+
+void SecurityOptionsUnittest::TestAgentsightDomainWhitelistOverridesDomainRules() {
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName("cfg1");
+    SecurityOptions opt;
+    std::string err;
+    Json::Value config;
+    APSARA_TEST_TRUE(ParseJsonTable(
+        R"({"ProbeConfig":{"DomainWhitelist":["only.this"],"DomainRules":["ignored.example"]}})",
+        config,
+        err));
+    APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
+    APSARA_TEST_EQUAL(1UL, opt.mAgentsightDomainWhitelist.size());
+    APSARA_TEST_EQUAL("only.this", opt.mAgentsightDomainWhitelist[0]);
 }
 
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightNoProbeConfigReturnsTrue)
@@ -116,6 +168,9 @@ UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightProbeConfigWrongTypeWarns)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightProbeConfigParsesOptionalFields)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightProbeConfigOptionalInvalidTypes)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightVerboseClampedWhenNegative)
-UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightParsesCmdlineRulesAndDomainRules)
+UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightParsesFlatCmdlineAndDomainWhitelist)
+UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightLegacyNestedCmdlineAndDomainRules)
+UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightFlatCmdlineOverridesLegacyNested)
+UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightDomainWhitelistOverridesDomainRules)
 
 UNIT_TEST_MAIN

--- a/core/unittest/ebpf/SecurityOptionsUnittest.cpp
+++ b/core/unittest/ebpf/SecurityOptionsUnittest.cpp
@@ -27,6 +27,7 @@ public:
     void TestAgentsightProbeConfigParsesOptionalFields();
     void TestAgentsightProbeConfigOptionalInvalidTypes();
     void TestAgentsightVerboseClampedWhenNegative();
+    void TestAgentsightParsesCmdlineRulesAndDomainRules();
 };
 
 void SecurityOptionsUnittest::TestAgentsightNoProbeConfigReturnsTrue() {
@@ -37,6 +38,9 @@ void SecurityOptionsUnittest::TestAgentsightNoProbeConfigReturnsTrue() {
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
     APSARA_TEST_EQUAL(opt.mVerbose, 0);
     APSARA_TEST_TRUE(opt.mLogPath.empty());
+    APSARA_TEST_TRUE(opt.mAgentsightCmdlineWhitelist.empty());
+    APSARA_TEST_TRUE(opt.mAgentsightCmdlineBlacklist.empty());
+    APSARA_TEST_TRUE(opt.mAgentsightDomainRules.empty());
 }
 
 void SecurityOptionsUnittest::TestAgentsightProbeConfigWrongTypeWarns() {
@@ -85,10 +89,33 @@ void SecurityOptionsUnittest::TestAgentsightVerboseClampedWhenNegative() {
     APSARA_TEST_EQUAL(opt.mVerbose, 0);
 }
 
+void SecurityOptionsUnittest::TestAgentsightParsesCmdlineRulesAndDomainRules() {
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName("cfg1");
+    SecurityOptions opt;
+    std::string err;
+    Json::Value config;
+    APSARA_TEST_TRUE(ParseJsonTable(
+        R"({"ProbeConfig":{"Verbose":0,"LogPath":"","CmdlineRules":{"whitelist":[["node","*claude*"],["npm","run","*"]],"blacklist":[["node","*webpack*"]]},"DomainRules":["*.openai.com","*.anthropic.com"]}})",
+        config,
+        err));
+    APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
+    APSARA_TEST_EQUAL(2UL, opt.mAgentsightCmdlineWhitelist.size());
+    APSARA_TEST_EQUAL(2UL, opt.mAgentsightCmdlineWhitelist[0].size());
+    APSARA_TEST_EQUAL("node", opt.mAgentsightCmdlineWhitelist[0][0]);
+    APSARA_TEST_EQUAL("*claude*", opt.mAgentsightCmdlineWhitelist[0][1]);
+    APSARA_TEST_EQUAL(3UL, opt.mAgentsightCmdlineWhitelist[1].size());
+    APSARA_TEST_EQUAL(1UL, opt.mAgentsightCmdlineBlacklist.size());
+    APSARA_TEST_EQUAL("*webpack*", opt.mAgentsightCmdlineBlacklist[0][1]);
+    APSARA_TEST_EQUAL(2UL, opt.mAgentsightDomainRules.size());
+    APSARA_TEST_EQUAL("*.openai.com", opt.mAgentsightDomainRules[0]);
+}
+
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightNoProbeConfigReturnsTrue)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightProbeConfigWrongTypeWarns)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightProbeConfigParsesOptionalFields)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightProbeConfigOptionalInvalidTypes)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightVerboseClampedWhenNegative)
+UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightParsesCmdlineRulesAndDomainRules)
 
 UNIT_TEST_MAIN

--- a/core/unittest/ebpf/SecurityOptionsUnittest.cpp
+++ b/core/unittest/ebpf/SecurityOptionsUnittest.cpp
@@ -28,9 +28,7 @@ public:
     void TestAgentsightProbeConfigOptionalInvalidTypes();
     void TestAgentsightVerboseClampedWhenNegative();
     void TestAgentsightParsesFlatCmdlineAndDomainWhitelist();
-    void TestAgentsightLegacyNestedCmdlineAndDomainRules();
-    void TestAgentsightFlatCmdlineOverridesLegacyNested();
-    void TestAgentsightDomainWhitelistOverridesDomainRules();
+    void TestAgentsightIgnoresLegacyCmdlineRulesAndDomainRules();
 };
 
 void SecurityOptionsUnittest::TestAgentsightNoProbeConfigReturnsTrue() {
@@ -114,51 +112,20 @@ void SecurityOptionsUnittest::TestAgentsightParsesFlatCmdlineAndDomainWhitelist(
     APSARA_TEST_EQUAL("*.openai.com", opt.mAgentsightDomainWhitelist[0]);
 }
 
-void SecurityOptionsUnittest::TestAgentsightLegacyNestedCmdlineAndDomainRules() {
+void SecurityOptionsUnittest::TestAgentsightIgnoresLegacyCmdlineRulesAndDomainRules() {
     CollectionPipelineContext ctx;
     ctx.SetConfigName("cfg1");
     SecurityOptions opt;
     std::string err;
     Json::Value config;
     APSARA_TEST_TRUE(ParseJsonTable(
-        R"({"ProbeConfig":{"Verbose":0,"LogPath":"","CmdlineRules":{"whitelist":[["a","b"]],"blacklist":[["c","d"]]},"DomainRules":["x.y"]}})",
+        R"({"ProbeConfig":{"CmdlineRules":{"whitelist":[["a","b"]],"blacklist":[["c","d"]]},"DomainRules":["x.y"]}})",
         config,
         err));
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
-    APSARA_TEST_EQUAL(1UL, opt.mAgentsightCmdlineWhitelist.size());
-    APSARA_TEST_EQUAL(1UL, opt.mAgentsightCmdlineBlacklist.size());
-    APSARA_TEST_EQUAL(1UL, opt.mAgentsightDomainWhitelist.size());
-    APSARA_TEST_EQUAL("x.y", opt.mAgentsightDomainWhitelist[0]);
-}
-
-void SecurityOptionsUnittest::TestAgentsightFlatCmdlineOverridesLegacyNested() {
-    CollectionPipelineContext ctx;
-    ctx.SetConfigName("cfg1");
-    SecurityOptions opt;
-    std::string err;
-    Json::Value config;
-    APSARA_TEST_TRUE(ParseJsonTable(
-        R"({"ProbeConfig":{"CmdlineWhitelist":[["from","flat"]],"CmdlineRules":{"whitelist":[["from","nested"]]}}})",
-        config,
-        err));
-    APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
-    APSARA_TEST_EQUAL(1UL, opt.mAgentsightCmdlineWhitelist.size());
-    APSARA_TEST_EQUAL("from", opt.mAgentsightCmdlineWhitelist[0][0]);
-    APSARA_TEST_EQUAL("flat", opt.mAgentsightCmdlineWhitelist[0][1]);
+    APSARA_TEST_TRUE(opt.mAgentsightCmdlineWhitelist.empty());
     APSARA_TEST_TRUE(opt.mAgentsightCmdlineBlacklist.empty());
-}
-
-void SecurityOptionsUnittest::TestAgentsightDomainWhitelistOverridesDomainRules() {
-    CollectionPipelineContext ctx;
-    ctx.SetConfigName("cfg1");
-    SecurityOptions opt;
-    std::string err;
-    Json::Value config;
-    APSARA_TEST_TRUE(ParseJsonTable(
-        R"({"ProbeConfig":{"DomainWhitelist":["only.this"],"DomainRules":["ignored.example"]}})", config, err));
-    APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
-    APSARA_TEST_EQUAL(1UL, opt.mAgentsightDomainWhitelist.size());
-    APSARA_TEST_EQUAL("only.this", opt.mAgentsightDomainWhitelist[0]);
+    APSARA_TEST_TRUE(opt.mAgentsightDomainWhitelist.empty());
 }
 
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightNoProbeConfigReturnsTrue)
@@ -167,8 +134,6 @@ UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightProbeConfigParsesOptionalF
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightProbeConfigOptionalInvalidTypes)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightVerboseClampedWhenNegative)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightParsesFlatCmdlineAndDomainWhitelist)
-UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightLegacyNestedCmdlineAndDomainRules)
-UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightFlatCmdlineOverridesLegacyNested)
-UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightDomainWhitelistOverridesDomainRules)
+UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightIgnoresLegacyCmdlineRulesAndDomainRules)
 
 UNIT_TEST_MAIN

--- a/core/unittest/ebpf/SecurityOptionsUnittest.cpp
+++ b/core/unittest/ebpf/SecurityOptionsUnittest.cpp
@@ -155,9 +155,7 @@ void SecurityOptionsUnittest::TestAgentsightDomainWhitelistOverridesDomainRules(
     std::string err;
     Json::Value config;
     APSARA_TEST_TRUE(ParseJsonTable(
-        R"({"ProbeConfig":{"DomainWhitelist":["only.this"],"DomainRules":["ignored.example"]}})",
-        config,
-        err));
+        R"({"ProbeConfig":{"DomainWhitelist":["only.this"],"DomainRules":["ignored.example"]}})", config, err));
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
     APSARA_TEST_EQUAL(1UL, opt.mAgentsightDomainWhitelist.size());
     APSARA_TEST_EQUAL("only.this", opt.mAgentsightDomainWhitelist[0]);

--- a/docs/cn/plugins/input/native/input_agentsight.md
+++ b/docs/cn/plugins/input/native/input_agentsight.md
@@ -20,6 +20,17 @@ dev
 |  ProbeConfig  |  object  |  否  |  /  |  插件配置参数列表  |
 |  ProbeConfig.Verbose  |  uint  |  否  |  /  |  是否打印ebpf的详细日志，1代表开启，0代表关闭  |
 |  ProbeConfig.LogPath  |  string  |  否  |  ""  | ebpf日志的输出位置 |
+|  ProbeConfig.CmdlineRules  |  object  |  否  |  /  |  进程命令行匹配规则，透传至 AgentSight `agentsight_config_add_cmdline_rule`，见下表  |
+|  ProbeConfig.DomainRules  |  array  |  否  |  /  |  域名 glob 白名单列表（字符串数组），透传至 `agentsight_config_add_domain_rule`；与 Prometheus 等插件中的 `array` 配置类似，每一项为字符串  |
+
+### ProbeConfig.CmdlineRules
+
+|  **参数**  |  **类型**  |  **必填**  |  **默认值**  |  **说明**  |
+| --- | --- | --- | --- | --- |
+|  whitelist  |  array  |  否  |  /  |  进程白名单：每一项为 **字符串数组**，按 argv 下标与进程命令行逐段做 glob 前缀匹配（语义以 AgentSight / coolbpf 文档为准）。多条规则独立生效。  |
+|  blacklist  |  array  |  否  |  /  |  进程黑名单：格式同 `whitelist`；命中则不 attach，且优先级高于白名单。  |
+
+白名单在底层仍会传入 `agent_name` 字段，仅作 **规则挂名（展示用）**，**不参与匹配**。LoongCollector 会按每条规则的 pattern 用 `|` 拼接生成挂名；若多条规则拼接结果相同，将自动追加 `_2`、`_3` 等后缀以免冲突。
 
 ## 输出格式
 
@@ -29,7 +40,7 @@ dev
 | `gen_ai.turn.id` | string | 同一会话中其中一次对话的 id |
 | `gen_ai.response.id` | string | 一次对话中其中一次对大模型请求的回复 id |
 | `pid` | string | 进程号（十进制字符串） |
-| `process_name` | string | 进程名称 |
+| `comm` | string | 进程名称 |
 | `gen_ai.agent.name` | string | agent 名称 |
 | `gen_ai.request.timestamp` | string | 一次对大模型请求开始的时间，毫秒时间戳（十进制字符串） |
 | `gen_ai.response.duration` | string | 一次对大模型请求到大模型回复的耗时，毫秒（十进制字符串） |
@@ -68,6 +79,15 @@ inputs:
     ProbeConfig:
       Verbose: 1
       LogPath: ""
+      CmdlineRules:
+        whitelist:
+          - ["node", "*claude*"]
+          - ["node", "*hermes*"]
+        blacklist:
+          - ["node", "*webpack*"]
+      DomainRules:
+        - "*.openai.com"
+        - "*.anthropic.com"
 flushers:
   - Type: flusher_stdout
     OnlyStdout: true
@@ -120,7 +140,7 @@ flushers:
   "is_sse": "1",
   "is_usage_from_api": "true",
   "pid": "705127",
-  "process_name": "openclaw-gatewa",
+  "comm": "openclaw-gatewa",
   "server.address": "dashscope.aliyuncs.com",
   "server.port": "80",
   "gen_ai.session.id": "dea5eed6-4a08-436c-b117-5ea14c9de39a",

--- a/docs/cn/plugins/input/native/input_agentsight.md
+++ b/docs/cn/plugins/input/native/input_agentsight.md
@@ -20,96 +20,95 @@ dev
 |  ProbeConfig  |  object  |  否  |  /  |  插件配置参数列表  |
 |  ProbeConfig.Verbose  |  uint  |  否  |  /  |  是否打印ebpf的详细日志，1代表开启，0代表关闭  |
 |  ProbeConfig.LogPath  |  string  |  否  |  ""  | ebpf日志的输出位置  |
-|  ProbeConfig.CmdlineWhitelist  |  array  |  否  |  /  |  进程命令行 **白名单**：数组的每一项为 **字符串数组**，与进程 `argv` 按位置一一 glob 匹配；由 AgentSight 进程匹配引擎消费。见下文「优先级与默认值」。  |
+|  ProbeConfig.CmdlineWhitelist  |  array  |  否  |  /  |  进程命令行 **白名单**：数组的每一项为 **字符串数组**，与进程 `argv` 按位置一一 glob 匹配。见下文「优先级与默认值」。  |
 |  ProbeConfig.CmdlineBlacklist  |  array  |  否  |  /  |  进程命令行 **黑名单**，格式同 `CmdlineWhitelist`；命中则不 attach。**优先级高于白名单**（见下文）。  |
-|  ProbeConfig.DomainWhitelist  |  array  |  否  |  /  |  域名 glob **白名单**（字符串数组），用于 AgentSight **DNS/SNI 阶段**的域名过滤；与 Prometheus 等插件中的 `array` 类似，每一项为字符串。未配置时不注入域名规则（见下文）。  |
-
-为兼容旧配置，仍支持 **`ProbeConfig.CmdlineRules`**（内含 `whitelist` / `blacklist`）与 **`ProbeConfig.DomainRules`**：仅当 **未** 出现 **`CmdlineWhitelist` 与 `CmdlineBlacklist` 任一键**（YAML 中均未写字段）时才读取 `CmdlineRules`；域名在 **未** 出现 **`DomainWhitelist` 键**时才回退读取 **`DomainRules`**。若新旧键同时存在，**以拍平键为准**（嵌套/旧键中与之重叠的部分不再生效）。
+|  ProbeConfig.DomainWhitelist  |  array  |  否  |  /  |  域名 glob **白名单**（字符串数组），用于 AgentSight **DNS/SNI 阶段**的域名过滤。见下文「优先级与默认值」。  |
 
 ### 优先级与默认值
 
-**Cmdline（进程命令行）**
+#### Cmdline 与 Domain 同时存在时
 
-1. **黑名单优先于白名单**：同一进程若同时命中黑名单与白名单中的规则，**黑名单生效**（不 attach），语义与 AgentSight / coolbpf 一致。
-2. **多条白名单规则之间**：为 **OR** 关系，任一 allow 规则匹配即可参与后续阶段（具体 attach 逻辑以 AgentSight 为准）。
-3. **默认白名单注入**：当 **`CmdlineWhitelist` 与 `CmdlineBlacklist` 在解析结果中均为空**（未写拍平键且未使用兼容的 `CmdlineRules`，或写了但数组解析后仍无任何有效行）时，LoongCollector 会注入与内置文件 `core/_thirdparty/coolbpf/src/agentsight/agentsight.json` 中 `cmdline.allow` 一致的 **9 条**默认进程白名单（Hermes×3、Cosh×4、OpenClaw×2）。  
-   一旦配置了 **任意一条** 用户 cmdline 白名单或黑名单（含「仅黑名单」），则 **不再** 注入上述内置白名单，完全以用户配置为准。
+先按 **cmdline**（进程 `argv`）判定，未 attach 时再按 **DNS 域名** 判定；同类规则内均为 **OR**。语义以 AgentSight 为准。
 
-**Domain（域名）**
+```mermaid
+graph TD
+    A["是否 attach?"] --> B{"命中 CmdlineBlacklist?"}
+    B -->|是| N["不 attach"]
+    B -->|否| C{"命中 CmdlineWhitelist?"}
+    C -->|是| Y["attach"]
+    C -->|否| D{"DNS 命中 DomainWhitelist?"}
+    D -->|是| Y
+    D -->|否| N
+```
 
-1. **多条域名规则之间**：为 **OR**，任一 glob 命中即视为命中该阶段白名单（语义以 AgentSight 为准）。
-2. **默认值**：**不注入** 内置域名列表；未配置 `DomainWhitelist`（且未回退到 `DomainRules`）时，不向 AgentSight 注册域名规则，行为由 AgentSight 默认策略决定。
-3. **与 cmdline 的关系**：进程/cmdline 与域名分阶段参与决策；若配置了 `DomainWhitelist`，仅命中域名列表的连接才会在域名阶段满足白名单（整体 attach 逻辑以 AgentSight 文档为准）。
+未配置 cmdline / domain 时，分别注入下文默认表；二者 **独立**（例如只配了 cmdline 黑名单，仍会注入默认域名）。
 
-### Cmdline 规则怎么写（含示例）
+#### Cmdline 规则优先级
 
-配置里**每一项**是一条规则，对应进程启动时的 **`argv` 分段**（与 shell 解析后的参数一致）。请先在本机用下面命令看真实命令行，再对照写数组：
+1. **黑名单优先于白名单**：同一进程同时命中黑/白名单时，**黑名单生效**。
+2. **多条白名单之间**：**OR**，命中任一条即可。
+3. **默认注入条件**：`CmdlineWhitelist` 与 `CmdlineBlacklist` **均为空** 时，注入下表；一旦配置了 **任意一条** 用户 cmdline 白名单或黑名单，则 **不再** 注入默认 cmdline。
+
+**默认 `CmdlineWhitelist`（9 条）**
+
+| agent 名称 | 规则（`argv` 各段 glob） |
+| --- | --- |
+| Hermes | `hermes*` |
+| Hermes | `*python*`, `*hermes*` |
+| Hermes | `*python*`, `-m`, `*hermes*` |
+| Cosh | `node*`, `*/usr/bin/co*` |
+| Cosh | `node*`, `*/usr/bin/cosh*` |
+| Cosh | `node*`, `*/usr/bin/copliot*` |
+| Cosh | `node*`, `*copilot-shell*` |
+| OpenClaw | `*openclaw-gatewa*` |
+| OpenClaw | `node*`, `*openclaw*` |
+
+#### Domain 规则优先级
+
+1. **多条域名之间**：**OR**，命中任一条即可。
+2. **默认注入条件**：`DomainWhitelist` **为空** 时，注入下表；一旦配置了 **任意一条** 用户域名，则 **不再** 注入默认域名。
+
+**默认 `DomainWhitelist`（8 条）**
+
+| 域名 glob |
+| --- |
+| `api.openai.com` |
+| `*.openai.com` |
+| `dashscope.aliyuncs.com` |
+| `*.dashscope.aliyuncs.com` |
+| `dashscope-intl.aliyuncs.com` |
+| `*.dashscope-intl.aliyuncs.com` |
+| `api.anthropic.com` |
+| `*.anthropic.com` |
+
+### Cmdline 规则怎么写
+
+配置里**每一项**是一条规则，对应 `argv` 各段（与 `/proc/<PID>/cmdline` 一致）。先在本机查看真实命令行，再写 glob：
 
 ```bash
 tr '\0' ' ' < /proc/<PID>/cmdline; echo
 ```
 
-**示例 A：Node 起脚本**
-
-若输出为：
-
-`node /opt/app/openclaw/cli.js gateway`
-
-则常见写法是**两段**规则：第一段对 `argv[0]`，第二段对 `argv[1]`（一般是脚本路径）：
+每一段用 **glob** 匹配，不关心的位置写 `"*"`。示例：
 
 ```yaml
 CmdlineWhitelist:
-  - ["node", "*openclaw*"]   # argv0≈node，argv1 路径里含 openclaw（见下通配符）
+  - ["node*", "*openclaw*"]   # 见 /proc/<PID>/cmdline 后调整各段
 ```
 
-**示例 B：单段可执行文件**
+### Domain 规则怎么写
 
-若输出只有：
-
-`openclaw-gateway`
-
-则第一段就要能描述整个 argv0，例如：
-
-```yaml
-CmdlineWhitelist:
-  - ["openclaw-gateway"]
-  - ["*openclaw-gatewa*"]    # 若希望兼容带路径的前缀，可用 glob
-```
-
-**第一个参数写 `node`，`/usr/bin/node` 能匹配吗？**
-
-不一定。`argv[0]` 往往是**实际传入的第一段字符串**：可能是 `node`，也可能是 `/usr/bin/node`。规则里每一段都是 **glob**，是否命中取决于 AgentSight 的 glob 语义（见 coolbpf AgentSight 文档：**按位置对 `cmdline[i]` 做 glob 匹配**）。
-
-- 若实际是 **`/usr/bin/node`**，只写 **`node`** 常常**对不上**整段路径。
-- 更稳妥的写法是让第一段也带通配，例如 **`node*`**（内置规则里有 `node*` 形态）或 **`*node*`**，以你在目标进程上看到的 `cmdline` 为准。
-
-**`*` 是什么？还支持别的吗？**
-
-- 通配符来自 **glob** 语义，不是正则表达式。
-- 文档中明确强调：不关心的参数位可写 **`"*"`** 表示「该段任意」。
-- **域名规则**侧 coolbpf 文档写明支持 **`*`**（任意字符序列）与 **`?`**（单个字符）。
-- **cmdline 规则**侧文档对 `*` 说明最充分；**`?` 等是否可用于每一段以当前 AgentSight / coolbpf 版本为准**（不确定时先用 `*` 或对照 `agentsight.json` 里已有写法）。
-
-**大小写**
-
-cmdline 与域名的 glob 匹配在 AgentSight 侧均为 **不区分大小写**（见 coolbpf `agentsight-c-ffi-api` 说明）。配置里写 `Node` 与 `node` 效果相同。
-
-### Domain 规则怎么写（含示例）
-
-`DomainWhitelist` 里每一项是一条 **域名 glob**，用于 **SNI / HTTP Host** 等阶段（以 AgentSight 为准）。多条规则为 **OR**：命中任意一条即可。
-
-**示例**
+`DomainWhitelist` 里每一项是一条域名 glob（SNI / HTTP Host 等阶段，以 AgentSight 为准）。示例：
 
 ```yaml
 DomainWhitelist:
-  - "api.openai.com"           # 精确主机名（仍走 glob 匹配，大小写不敏感）
-  - "*.anthropic.com"          # 子域：如 claude.anthropic.com
-  - "*openai.com"              # 更宽的后缀匹配（按 glob 语义）
+  - "api.openai.com"
+  - "*.anthropic.com"
 ```
 
-从请求里取到的主机名会去掉端口再匹配，例如 `Host: Api.OpenAI.Com:443` 与 `api.openai.com` 视为同类（**不区分大小写**）。
+通配符使用 `*`；匹配 **不区分大小写**。
 
-通配符：**`*`**、**`?`**（单字符）；**不是正则**。
+> **建议**：为减少无关进程的采集量，若使用默认 `DomainWhitelist`（或未收窄域名列表），请尽量同时配置 `CmdlineWhitelist` / `CmdlineBlacklist`，限定目标 agent 进程；仅依赖默认域名时，任意访问 OpenAI / DashScope / Anthropic 等域名的进程都可能触发 attach，数据量偏大。
 
 ## 输出格式
 
@@ -159,10 +158,10 @@ inputs:
       Verbose: 1
       LogPath: ""
       CmdlineWhitelist:
-        - ["node", "*claude*"]
-        - ["node", "*hermes*"]
+        - ["node*", "*claude*"]
+        - ["node*", "*hermes*"]
       CmdlineBlacklist:
-        - ["node", "*webpack*"]
+        - ["node*", "*webpack*"]
       DomainWhitelist:
         - "api.openai.com"
         - "*.anthropic.com"

--- a/docs/cn/plugins/input/native/input_agentsight.md
+++ b/docs/cn/plugins/input/native/input_agentsight.md
@@ -20,28 +20,35 @@ dev
 |  ProbeConfig  |  object  |  否  |  /  |  插件配置参数列表  |
 |  ProbeConfig.Verbose  |  uint  |  否  |  /  |  是否打印ebpf的详细日志，1代表开启，0代表关闭  |
 |  ProbeConfig.LogPath  |  string  |  否  |  ""  | ebpf日志的输出位置  |
-|  ProbeConfig.CmdlineWhitelist  |  array  |  否  |  /  |  进程命令行 **白名单**：数组的每一项为 **字符串数组**，与进程 `argv` 按位置一一 glob 匹配。见下文「优先级与默认值」。  |
-|  ProbeConfig.CmdlineBlacklist  |  array  |  否  |  /  |  进程命令行 **黑名单**，格式同 `CmdlineWhitelist`；命中则不 attach。**优先级高于白名单**（见下文）。  |
-|  ProbeConfig.DomainWhitelist  |  array  |  否  |  /  |  域名 glob **白名单**（字符串数组），用于 AgentSight **DNS/SNI 阶段**的域名过滤。见下文「优先级与默认值」。  |
+|  ProbeConfig.CmdlineWhitelist  |  array  |  否  |  /  |  进程 **agent 筛选白名单**：每一项为一条规则（**字符串数组**），与进程启动参数 `argv` 按位置做 glob 匹配；**整条规则各段均匹配则视为命中**，表示该进程符合待采集的 agent 特征，可纳入采集（见下文流程图）。未配置且黑名单也为空时注入默认规则。  |
+|  ProbeConfig.CmdlineBlacklist  |  array  |  否  |  /  |  进程 **agent 筛选黑名单**，规则格式同白名单；**命中则视为排除该进程**，不采集。**优先级高于白名单**：同一进程同时命中黑/白名单时，以黑名单为准。  |
+|  ProbeConfig.DomainWhitelist  |  array  |  否  |  /  |  域名 **白名单**（字符串数组）：**访问白名单内域名的进程将被识别为 AI Agent 采集目标**。未配置时注入默认精确主机名列表，见下文「优先级与默认值」。  |
 
 ### 优先级与默认值
 
-#### Cmdline 与 Domain 同时存在时
+#### 黑白名单判定逻辑
 
-先按 **cmdline**（进程 `argv`）判定，未 attach 时再按 **DNS 域名** 判定；同类规则内均为 **OR**。语义以 AgentSight 为准。
+进程是否纳入采集，按下列**固定顺序**判定（**不要求** `CmdlineBlacklist`、`CmdlineWhitelist`、`DomainWhitelist` 同时配置；三类名单相互独立，未配置项见下文「默认值」）：
+
+1. 命中 `CmdlineBlacklist` → **不采集**（cmdline 黑名单优先）
+2. 未命中黑名单，且命中 `CmdlineWhitelist` → **纳入采集**
+3. 仍未纳入，且进程访问域名命中 `DomainWhitelist` → **纳入采集**
+4. 以上均未命中 → **不采集**
+
+同一名单内的多条规则之间为 **OR**（命中任一条即可）。
 
 ```mermaid
 graph TD
-    A["是否 attach?"] --> B{"命中 CmdlineBlacklist?"}
-    B -->|是| N["不 attach"]
+    A["是否纳入采集?"] --> B{"命中 CmdlineBlacklist?"}
+    B -->|是| N["不采集"]
     B -->|否| C{"命中 CmdlineWhitelist?"}
-    C -->|是| Y["attach"]
-    C -->|否| D{"DNS 命中 DomainWhitelist?"}
+    C -->|是| Y["纳入采集"]
+    C -->|否| D{"访问域名命中 DomainWhitelist?"}
     D -->|是| Y
     D -->|否| N
 ```
 
-未配置 cmdline / domain 时，分别注入下文默认表；二者 **独立**（例如只配了 cmdline 黑名单，仍会注入默认域名）。
+例如：只配置了 cmdline 黑名单、未配域名时，仍会注入默认 `DomainWhitelist`；只配域名、未配 cmdline 时，仍会注入默认 cmdline 白名单（当黑/白名单均为空时）。
 
 #### Cmdline 规则优先级
 
@@ -68,16 +75,14 @@ graph TD
 1. **多条域名之间**：**OR**，命中任一条即可。
 2. **默认注入条件**：`DomainWhitelist` **为空** 时，注入下表；一旦配置了 **任意一条** 用户域名，则 **不再** 注入默认域名。
 
-**默认 `DomainWhitelist`（6 条）**
+**默认 `DomainWhitelist`（4 条，精确主机名）**
 
-| 域名 glob | 说明 |
-| --- | --- |
-| `*.openai.com` | 含 `api.openai.com` 等子域 |
-| `*.anthropic.com` | 含 `api.anthropic.com` 等子域 |
-| `dashscope.aliyuncs.com` | 国内 DashScope 根域（`*.dashscope...` 不匹配无子域前缀的该主机名） |
-| `*.dashscope.aliyuncs.com` | 如 `api.dashscope.aliyuncs.com` |
-| `dashscope-intl.aliyuncs.com` | 国际站根域 |
-| `*.dashscope-intl.aliyuncs.com` | 国际站子域 |
+| 域名 |
+| --- |
+| `api.openai.com` |
+| `api.anthropic.com` |
+| `dashscope.aliyuncs.com` |
+| `dashscope-intl.aliyuncs.com` |
 
 ### Cmdline 规则怎么写
 
@@ -96,17 +101,15 @@ CmdlineWhitelist:
 
 ### Domain 规则怎么写
 
-`DomainWhitelist` 里每一项是一条域名 glob（SNI / HTTP Host 等阶段，以 AgentSight 为准）。示例：
+`DomainWhitelist` 里每一项用于匹配进程访问的大模型 API 主机名。**默认注入为精确主机名**；自行配置时也可写 glob（如 `*.anthropic.com`），通配符为 `*`，匹配 **不区分大小写**。示例：
 
 ```yaml
 DomainWhitelist:
   - "api.openai.com"
-  - "*.anthropic.com"
+  - "dashscope.aliyuncs.com"
 ```
 
-通配符使用 `*`；匹配 **不区分大小写**。
-
-> **建议**：为减少无关进程的采集量，若使用默认 `DomainWhitelist`（或未收窄域名列表），请尽量同时配置 `CmdlineWhitelist` / `CmdlineBlacklist`，限定目标 agent 进程；仅依赖默认域名时，任意访问 OpenAI / DashScope / Anthropic 等域名的进程都可能触发 attach，数据量偏大。
+> **建议**：尽量用 `CmdlineWhitelist` / `CmdlineBlacklist` **准确描述**待采集 agent 的命令行（先在本机查看 `/proc/<PID>/cmdline` 再写 glob），缩小采集范围、减少无关进程数据。`DomainWhitelist` 只能判断进程是否访问过大模型 API，**无法区分**具体是哪一个 agent；若 cmdline 规则过宽或未配置，凡访问默认域名（OpenAI、DashScope、Anthropic 等）的进程仍可能被纳入采集。
 
 ## 输出格式
 
@@ -127,7 +130,7 @@ DomainWhitelist:
 | `status_code` | string | 一次请求的状态码，同 HTTP 状态码（十进制字符串，如 `200`） |
 | `is_sse` | string | 是否为 SSE（Server-Sent Events）连接；日志中取值为 `1`（是）或 `0`（否） |
 | `gen_ai.response.finish_reasons` | string | 大模型停止产生 token 的原因 |
-| `is_usage_from_api` | string | 数据来源标识，true 表示来自 LLM API response usage 字段（精确值），false 表示由 AgentSight 本地 tokenizer 计算（近似值） |
+| `is_usage_from_api` | string | 数据来源标识，true 表示来自 LLM API response usage 字段（精确值），false 表示由插件本地估算（近似值） |
 | `gen_ai.usage.input_tokens` | string | 发送给模型的 token 数量（十进制字符串） |
 | `gen_ai.usage.output_tokens` | string | 模型实际生成的回复内容长度（十进制字符串） |
 | `gen_ai.usage.total_tokens` | string | 一次请求消耗的 Token 总量（十进制字符串） |
@@ -162,7 +165,6 @@ inputs:
         - ["node*", "*webpack*"]
       DomainWhitelist:
         - "api.openai.com"
-        - "*.anthropic.com"
 flushers:
   - Type: flusher_stdout
     OnlyStdout: true

--- a/docs/cn/plugins/input/native/input_agentsight.md
+++ b/docs/cn/plugins/input/native/input_agentsight.md
@@ -68,18 +68,16 @@ graph TD
 1. **多条域名之间**：**OR**，命中任一条即可。
 2. **默认注入条件**：`DomainWhitelist` **为空** 时，注入下表；一旦配置了 **任意一条** 用户域名，则 **不再** 注入默认域名。
 
-**默认 `DomainWhitelist`（8 条）**
+**默认 `DomainWhitelist`（6 条）**
 
-| 域名 glob |
-| --- |
-| `api.openai.com` |
-| `*.openai.com` |
-| `dashscope.aliyuncs.com` |
-| `*.dashscope.aliyuncs.com` |
-| `dashscope-intl.aliyuncs.com` |
-| `*.dashscope-intl.aliyuncs.com` |
-| `api.anthropic.com` |
-| `*.anthropic.com` |
+| 域名 glob | 说明 |
+| --- | --- |
+| `*.openai.com` | 含 `api.openai.com` 等子域 |
+| `*.anthropic.com` | 含 `api.anthropic.com` 等子域 |
+| `dashscope.aliyuncs.com` | 国内 DashScope 根域（`*.dashscope...` 不匹配无子域前缀的该主机名） |
+| `*.dashscope.aliyuncs.com` | 如 `api.dashscope.aliyuncs.com` |
+| `dashscope-intl.aliyuncs.com` | 国际站根域 |
+| `*.dashscope-intl.aliyuncs.com` | 国际站子域 |
 
 ### Cmdline 规则怎么写
 

--- a/docs/cn/plugins/input/native/input_agentsight.md
+++ b/docs/cn/plugins/input/native/input_agentsight.md
@@ -19,18 +19,97 @@ dev
 |  Type  |  string  |  是  |  /  |  插件类型。固定为 `input_agentsight`  |
 |  ProbeConfig  |  object  |  否  |  /  |  插件配置参数列表  |
 |  ProbeConfig.Verbose  |  uint  |  否  |  /  |  是否打印ebpf的详细日志，1代表开启，0代表关闭  |
-|  ProbeConfig.LogPath  |  string  |  否  |  ""  | ebpf日志的输出位置 |
-|  ProbeConfig.CmdlineRules  |  object  |  否  |  /  |  进程命令行匹配规则，透传至 AgentSight `agentsight_config_add_cmdline_rule`，见下表  |
-|  ProbeConfig.DomainRules  |  array  |  否  |  /  |  域名 glob 白名单列表（字符串数组），透传至 `agentsight_config_add_domain_rule`；与 Prometheus 等插件中的 `array` 配置类似，每一项为字符串  |
+|  ProbeConfig.LogPath  |  string  |  否  |  ""  | ebpf日志的输出位置  |
+|  ProbeConfig.CmdlineWhitelist  |  array  |  否  |  /  |  进程命令行 **白名单**：数组的每一项为 **字符串数组**，与进程 `argv` 按位置一一 glob 匹配；由 AgentSight 进程匹配引擎消费。见下文「优先级与默认值」。  |
+|  ProbeConfig.CmdlineBlacklist  |  array  |  否  |  /  |  进程命令行 **黑名单**，格式同 `CmdlineWhitelist`；命中则不 attach。**优先级高于白名单**（见下文）。  |
+|  ProbeConfig.DomainWhitelist  |  array  |  否  |  /  |  域名 glob **白名单**（字符串数组），用于 AgentSight **DNS/SNI 阶段**的域名过滤；与 Prometheus 等插件中的 `array` 类似，每一项为字符串。未配置时不注入域名规则（见下文）。  |
 
-### ProbeConfig.CmdlineRules
+为兼容旧配置，仍支持 **`ProbeConfig.CmdlineRules`**（内含 `whitelist` / `blacklist`）与 **`ProbeConfig.DomainRules`**：仅当 **未** 出现 **`CmdlineWhitelist` 与 `CmdlineBlacklist` 任一键**（YAML 中均未写字段）时才读取 `CmdlineRules`；域名在 **未** 出现 **`DomainWhitelist` 键**时才回退读取 **`DomainRules`**。若新旧键同时存在，**以拍平键为准**（嵌套/旧键中与之重叠的部分不再生效）。
 
-|  **参数**  |  **类型**  |  **必填**  |  **默认值**  |  **说明**  |
-| --- | --- | --- | --- | --- |
-|  whitelist  |  array  |  否  |  /  |  进程白名单：每一项为 **字符串数组**，按 argv 下标与进程命令行逐段做 glob 前缀匹配（语义以 AgentSight / coolbpf 文档为准）。多条规则独立生效。  |
-|  blacklist  |  array  |  否  |  /  |  进程黑名单：格式同 `whitelist`；命中则不 attach，且优先级高于白名单。  |
+### 优先级与默认值
 
-白名单在底层仍会传入 `agent_name` 字段，仅作 **规则挂名（展示用）**，**不参与匹配**。LoongCollector 会按每条规则的 pattern 用 `|` 拼接生成挂名；若多条规则拼接结果相同，将自动追加 `_2`、`_3` 等后缀以免冲突。
+**Cmdline（进程命令行）**
+
+1. **黑名单优先于白名单**：同一进程若同时命中黑名单与白名单中的规则，**黑名单生效**（不 attach），语义与 AgentSight / coolbpf 一致。
+2. **多条白名单规则之间**：为 **OR** 关系，任一 allow 规则匹配即可参与后续阶段（具体 attach 逻辑以 AgentSight 为准）。
+3. **默认白名单注入**：当 **`CmdlineWhitelist` 与 `CmdlineBlacklist` 在解析结果中均为空**（未写拍平键且未使用兼容的 `CmdlineRules`，或写了但数组解析后仍无任何有效行）时，LoongCollector 会注入与内置文件 `core/_thirdparty/coolbpf/src/agentsight/agentsight.json` 中 `cmdline.allow` 一致的 **9 条**默认进程白名单（Hermes×3、Cosh×4、OpenClaw×2）。  
+   一旦配置了 **任意一条** 用户 cmdline 白名单或黑名单（含「仅黑名单」），则 **不再** 注入上述内置白名单，完全以用户配置为准。
+
+**Domain（域名）**
+
+1. **多条域名规则之间**：为 **OR**，任一 glob 命中即视为命中该阶段白名单（语义以 AgentSight 为准）。
+2. **默认值**：**不注入** 内置域名列表；未配置 `DomainWhitelist`（且未回退到 `DomainRules`）时，不向 AgentSight 注册域名规则，行为由 AgentSight 默认策略决定。
+3. **与 cmdline 的关系**：进程/cmdline 与域名分阶段参与决策；若配置了 `DomainWhitelist`，仅命中域名列表的连接才会在域名阶段满足白名单（整体 attach 逻辑以 AgentSight 文档为准）。
+
+### Cmdline 规则怎么写（含示例）
+
+配置里**每一项**是一条规则，对应进程启动时的 **`argv` 分段**（与 shell 解析后的参数一致）。请先在本机用下面命令看真实命令行，再对照写数组：
+
+```bash
+tr '\0' ' ' < /proc/<PID>/cmdline; echo
+```
+
+**示例 A：Node 起脚本**
+
+若输出为：
+
+`node /opt/app/openclaw/cli.js gateway`
+
+则常见写法是**两段**规则：第一段对 `argv[0]`，第二段对 `argv[1]`（一般是脚本路径）：
+
+```yaml
+CmdlineWhitelist:
+  - ["node", "*openclaw*"]   # argv0≈node，argv1 路径里含 openclaw（见下通配符）
+```
+
+**示例 B：单段可执行文件**
+
+若输出只有：
+
+`openclaw-gateway`
+
+则第一段就要能描述整个 argv0，例如：
+
+```yaml
+CmdlineWhitelist:
+  - ["openclaw-gateway"]
+  - ["*openclaw-gatewa*"]    # 若希望兼容带路径的前缀，可用 glob
+```
+
+**第一个参数写 `node`，`/usr/bin/node` 能匹配吗？**
+
+不一定。`argv[0]` 往往是**实际传入的第一段字符串**：可能是 `node`，也可能是 `/usr/bin/node`。规则里每一段都是 **glob**，是否命中取决于 AgentSight 的 glob 语义（见 coolbpf AgentSight 文档：**按位置对 `cmdline[i]` 做 glob 匹配**）。
+
+- 若实际是 **`/usr/bin/node`**，只写 **`node`** 常常**对不上**整段路径。
+- 更稳妥的写法是让第一段也带通配，例如 **`node*`**（内置规则里有 `node*` 形态）或 **`*node*`**，以你在目标进程上看到的 `cmdline` 为准。
+
+**`*` 是什么？还支持别的吗？**
+
+- 通配符来自 **glob** 语义，不是正则表达式。
+- 文档中明确强调：不关心的参数位可写 **`"*"`** 表示「该段任意」。
+- **域名规则**侧 coolbpf 文档写明支持 **`*`**（任意字符序列）与 **`?`**（单个字符）。
+- **cmdline 规则**侧文档对 `*` 说明最充分；**`?` 等是否可用于每一段以当前 AgentSight / coolbpf 版本为准**（不确定时先用 `*` 或对照 `agentsight.json` 里已有写法）。
+
+**大小写**
+
+cmdline 与域名的 glob 匹配在 AgentSight 侧均为 **不区分大小写**（见 coolbpf `agentsight-c-ffi-api` 说明）。配置里写 `Node` 与 `node` 效果相同。
+
+### Domain 规则怎么写（含示例）
+
+`DomainWhitelist` 里每一项是一条 **域名 glob**，用于 **SNI / HTTP Host** 等阶段（以 AgentSight 为准）。多条规则为 **OR**：命中任意一条即可。
+
+**示例**
+
+```yaml
+DomainWhitelist:
+  - "api.openai.com"           # 精确主机名（仍走 glob 匹配，大小写不敏感）
+  - "*.anthropic.com"          # 子域：如 claude.anthropic.com
+  - "*openai.com"              # 更宽的后缀匹配（按 glob 语义）
+```
+
+从请求里取到的主机名会去掉端口再匹配，例如 `Host: Api.OpenAI.Com:443` 与 `api.openai.com` 视为同类（**不区分大小写**）。
+
+通配符：**`*`**、**`?`**（单字符）；**不是正则**。
 
 ## 输出格式
 
@@ -79,14 +158,13 @@ inputs:
     ProbeConfig:
       Verbose: 1
       LogPath: ""
-      CmdlineRules:
-        whitelist:
-          - ["node", "*claude*"]
-          - ["node", "*hermes*"]
-        blacklist:
-          - ["node", "*webpack*"]
-      DomainRules:
-        - "*.openai.com"
+      CmdlineWhitelist:
+        - ["node", "*claude*"]
+        - ["node", "*hermes*"]
+      CmdlineBlacklist:
+        - ["node", "*webpack*"]
+      DomainWhitelist:
+        - "api.openai.com"
         - "*.anthropic.com"
 flushers:
   - Type: flusher_stdout

--- a/docs/cn/plugins/input/native/input_agentsight.md
+++ b/docs/cn/plugins/input/native/input_agentsight.md
@@ -20,8 +20,8 @@ dev
 |  ProbeConfig  |  object  |  否  |  /  |  插件配置参数列表  |
 |  ProbeConfig.Verbose  |  uint  |  否  |  /  |  是否打印ebpf的详细日志，1代表开启，0代表关闭  |
 |  ProbeConfig.LogPath  |  string  |  否  |  ""  | ebpf日志的输出位置  |
-|  ProbeConfig.CmdlineWhitelist  |  array  |  否  |  /  |  进程 **agent 筛选白名单**：每一项为一条规则（**字符串数组**），与进程启动参数 `argv` 按位置做 glob 匹配；**整条规则各段均匹配则视为命中**，表示该进程符合待采集的 agent 特征，可纳入采集（见下文流程图）。未配置且黑名单也为空时注入默认规则。  |
-|  ProbeConfig.CmdlineBlacklist  |  array  |  否  |  /  |  进程 **agent 筛选黑名单**，规则格式同白名单；**命中则视为排除该进程**，不采集。**优先级高于白名单**：同一进程同时命中黑/白名单时，以黑名单为准。  |
+|  ProbeConfig.CmdlineWhitelist  |  array  |  否  |  /  |  进程 **agent 筛选白名单**：每一项为一条规则（**字符串数组**），与进程 `argv` 按位置做 glob 匹配；规则比 `argv` 短时**仅前缀匹配**（多余参数忽略）。规则各段均匹配则视为命中，可纳入采集（见下文）。未配置且黑名单也为空时注入默认规则。  |
+|  ProbeConfig.CmdlineBlacklist  |  array  |  否  |  /  |  进程 **agent 筛选黑名单**，规则格式同白名单（含前缀匹配语义）；**命中则排除**，不采集。**优先级高于白名单**。  |
 |  ProbeConfig.DomainWhitelist  |  array  |  否  |  /  |  域名 **白名单**（字符串数组）：**访问白名单内域名的进程将被识别为 AI Agent 采集目标**。未配置时注入默认精确主机名列表，见下文「优先级与默认值」。  |
 
 ### 优先级与默认值
@@ -50,7 +50,7 @@ graph TD
 
 例如：只配置了 cmdline 黑名单、未配域名时，仍会注入默认 `DomainWhitelist`；只配域名、未配 cmdline 时，仍会注入默认 cmdline 白名单（当黑/白名单均为空时）。
 
-#### Cmdline 规则优先级
+#### Cmdline 规则优先级和默认注入值
 
 1. **黑名单优先于白名单**：同一进程同时命中黑/白名单时，**黑名单生效**。
 2. **多条白名单之间**：**OR**，命中任一条即可。
@@ -70,7 +70,7 @@ graph TD
 | OpenClaw | `*openclaw-gatewa*` |
 | OpenClaw | `node*`, `*openclaw*` |
 
-#### Domain 规则优先级
+#### Domain 规则优先级和默认注入值
 
 1. **多条域名之间**：**OR**，命中任一条即可。
 2. **默认注入条件**：`DomainWhitelist` **为空** 时，注入下表；一旦配置了 **任意一条** 用户域名，则 **不再** 注入默认域名。
@@ -84,7 +84,7 @@ graph TD
 | `dashscope.aliyuncs.com` |
 | `dashscope-intl.aliyuncs.com` |
 
-### Cmdline 规则怎么写
+### Cmdline 规则自定义写法
 
 配置里**每一项**是一条规则，对应 `argv` 各段（与 `/proc/<PID>/cmdline` 一致）。先在本机查看真实命令行，再写 glob：
 
@@ -92,14 +92,18 @@ graph TD
 tr '\0' ' ' < /proc/<PID>/cmdline; echo
 ```
 
-每一段用 **glob** 匹配，不关心的位置写 `"*"`。示例：
+每一段用 **glob** 匹配，不关心的位置写 `"*"`。
+
+**前缀匹配**：当规则的段数**少于** `argv` 时，只对前 N 段按位置做 glob 匹配，**后面多出来的参数不参与匹配**。例如规则 `["node*", "*openclaw*"]` 可命中 `node openclaw.js gateway`（第三段 `gateway` 被忽略）。若需约束后续参数，须在规则中继续写出对应段（如 `["node*", "*openclaw*", "gateway"]`）。反之，规则段数**多于** `argv` 时则不命中。
+
+示例：
 
 ```yaml
 CmdlineWhitelist:
   - ["node*", "*openclaw*"]   # 见 /proc/<PID>/cmdline 后调整各段
 ```
 
-### Domain 规则怎么写
+### Domain 规则自定义写法
 
 `DomainWhitelist` 里每一项用于匹配进程访问的大模型 API 主机名。**默认注入为精确主机名**；自行配置时也可写 glob（如 `*.anthropic.com`），通配符为 `*`，匹配 **不区分大小写**。示例：
 
@@ -108,8 +112,6 @@ DomainWhitelist:
   - "api.openai.com"
   - "dashscope.aliyuncs.com"
 ```
-
-> **建议**：尽量用 `CmdlineWhitelist` / `CmdlineBlacklist` **准确描述**待采集 agent 的命令行（先在本机查看 `/proc/<PID>/cmdline` 再写 glob），缩小采集范围、减少无关进程数据。`DomainWhitelist` 只能判断进程是否访问过大模型 API，**无法区分**具体是哪一个 agent；若 cmdline 规则过宽或未配置，凡访问默认域名（OpenAI、DashScope、Anthropic 等）的进程仍可能被纳入采集。
 
 ## 输出格式
 


### PR DESCRIPTION
## Summary
本 PR 在 LoongCollector 侧完成 `input_agentsight` 与 AgentSight（coolbpf）的 cmdline / domain 筛选能力对接，统一配置形态并补齐文档与单测。
- **配置扁平化**：`ProbeConfig` 使用 `CmdlineWhitelist`、`CmdlineBlacklist`、`DomainWhitelist` 三项配置，移除嵌套的 `CmdlineRules` / `DomainRules` 结构，降低配置成本。
- **规则下发**：在 `AgentsightManager` 中通过 `agentsight_config_add_cmdline_rule` / `agentsight_config_add_domain_rule` 将用户规则或内置默认规则写入 AgentSight；cmdline / domain 默认规则注入相互独立。
- **内置默认规则**：
  - **Cmdline**：黑/白名单均为空时注入 9 条 allow 规则（Hermes、Cosh、OpenClaw 等，与 `agentsight.json` 对齐）。
  - **Domain**：未配置时注入 `api.openai.com`、`api.anthropic.com`、`dashscope.aliyuncs.com`、`dashscope-intl.aliyuncs.com` 四条精确主机名。
- **判定逻辑**（与 AgentSight 运行时一致）：黑名单 → cmdline 白名单 → 域名白名单；同名单内多条规则为 OR；cmdline 支持按 `argv` 位置 glob、前缀匹配（规则短于 cmdline 时多余参数忽略，长于 cmdline 则不命中）。
- **文档**：重写 `input_agentsight.md` 中参数说明、判定流程图、默认规则表及 cmdline/domain 自定义写法。
- **单测**：补充 `SecurityOptionsUnittest`、`AgentsightManagerUnittest` 对配置解析与规则下发的覆盖。
## 涉及 Commit
| Commit | 说明 |
|--------|------|
| f2028e5 | LoongCollector 适配 AgentSight cmdline / domain 筛选 |
| 4e9b063 | 扁平化 CmdlineWhitelist / DomainWhitelist，更新解析与文档 |
| b004a5d | SecurityOptionsUnittest JSON 解析格式整理 |
| 00aca2e | 移除 legacy 嵌套配置，内置 domain allow 规则 |
| 640cc37 | 调整默认 domain 规则与单测 |
| 76b1857 | 默认域名改为精确 API 主机名，同步文档 |
| de74cf0 | 完善 cmdline 前缀匹配等文档说明 