### PR TITLE
Refactor input_agentsight configuration: flat structure, object-style rules, and full doc rewrite

### DIFF
--- a/core/ebpf/Config.cpp
+++ b/core/ebpf/Config.cpp
@@ -516,7 +516,23 @@ void WarnSecurityProbeConfigIgnore(const CollectionPipelineContext* mContext,
 
 namespace {
 
-constexpr const char* kAgentsightDefaultAllowAgentName = "Custom Agent";
+bool ParseAgentsightAgentTypeField(const Json::Value& row,
+                                   const std::string& contextLabel,
+                                   size_t rowIndex,
+                                   std::string& agentType,
+                                   std::string& errorMsg) {
+    const std::string prefix = contextLabel + " row " + std::to_string(rowIndex);
+    if (!row.isMember("AgentType") || !row["AgentType"].isString()) {
+        errorMsg = prefix + " must have non-empty AgentType (string)";
+        return false;
+    }
+    agentType = row["AgentType"].asString();
+    if (agentType.empty()) {
+        errorMsg = prefix + " AgentType must be non-empty";
+        return false;
+    }
+    return true;
+}
 
 bool ParseAgentsightCmdlinePatternsArray(const Json::Value& row,
                                          const std::string& contextLabel,
@@ -568,9 +584,8 @@ void ParseAgentsightCmdlineRowArray(const Json::Value& rows,
     }
 }
 
-/// Fills `dest` with allow rules. Each entry is either a string array (legacy) or
-/// `{"agent_name": "...", "rule": [...]}`.
-void ParseAgentsightCmdlineAllowRuleArray(const Json::Value& rows,
+/// Fills `dest` with allow rules. Each entry must be `{"AgentType": "...", "Rule": [...]}`.
+bool ParseAgentsightCmdlineAllowRuleArray(const Json::Value& rows,
                                           const std::string& contextLabel,
                                           std::vector<AgentsightCmdlineAllowRule>& dest,
                                           std::string& errorMsg,
@@ -578,54 +593,43 @@ void ParseAgentsightCmdlineAllowRuleArray(const Json::Value& rows,
     if (!rows.isArray()) {
         errorMsg = contextLabel + " must be an array";
         warn();
-        return;
+        return false;
+    }
+    if (rows.empty()) {
+        errorMsg = contextLabel + " must contain at least one rule";
+        warn();
+        return false;
     }
     for (Json::ArrayIndex i = 0; i < rows.size(); ++i) {
         const Json::Value& row = rows[i];
-        if (row.isArray()) {
-            std::vector<std::string> patterns;
-            if (!ParseAgentsightCmdlinePatternsArray(row, contextLabel, i, "entry", patterns, errorMsg)) {
-                warn();
-                continue;
-            }
-            dest.push_back(AgentsightCmdlineAllowRule {kAgentsightDefaultAllowAgentName, std::move(patterns)});
-            continue;
-        }
         if (!row.isObject()) {
-            errorMsg = contextLabel + " row " + std::to_string(i)
-                       + " must be a string array or object with agent_name and rule";
+            errorMsg = contextLabel + " row " + std::to_string(i) + " must be an object with AgentType and Rule";
             warn();
             continue;
         }
-        if (!row.isMember("agent_name") || !row["agent_name"].isString() || row["agent_name"].asString().empty()) {
-            errorMsg = contextLabel + " row " + std::to_string(i) + " object must have non-empty agent_name";
+        std::string agentType;
+        if (!ParseAgentsightAgentTypeField(row, contextLabel, i, agentType, errorMsg)) {
             warn();
             continue;
         }
-        if (!row.isMember("rule")) {
-            errorMsg = contextLabel + " row " + std::to_string(i) + " object must have rule";
+        if (!row.isMember("Rule")) {
+            errorMsg = contextLabel + " row " + std::to_string(i) + " object must have Rule";
             warn();
             continue;
         }
         std::vector<std::string> patterns;
-        if (!ParseAgentsightCmdlinePatternsArray(row["rule"], contextLabel, i, "rule", patterns, errorMsg)) {
+        if (!ParseAgentsightCmdlinePatternsArray(row["Rule"], contextLabel, i, "Rule", patterns, errorMsg)) {
             warn();
             continue;
         }
-        dest.push_back(AgentsightCmdlineAllowRule {row["agent_name"].asString(), std::move(patterns)});
+        dest.push_back(AgentsightCmdlineAllowRule {std::move(agentType), std::move(patterns)});
     }
-}
-
-void ParseAgentsightCmdlineAllowFromOptionalKey(const Json::Value& innerConfig,
-                                                const char* key,
-                                                const std::string& contextLabel,
-                                                std::vector<AgentsightCmdlineAllowRule>& dest,
-                                                std::string& errorMsg,
-                                                const std::function<void()>& warn) {
-    if (!innerConfig.isMember(key)) {
-        return;
+    if (dest.empty()) {
+        errorMsg = contextLabel + " has no valid rules";
+        warn();
+        return false;
     }
-    ParseAgentsightCmdlineAllowRuleArray(innerConfig[key], contextLabel, dest, errorMsg, warn);
+    return true;
 }
 
 void ParseAgentsightCmdlineFromOptionalKey(const Json::Value& innerConfig,
@@ -692,6 +696,7 @@ bool SecurityOptions::Init(SecurityProbeType probeType,
             WarnSecurityProbeConfigIgnore(mContext, errorMsg, sName);
         }
         if (probeType == SecurityProbeType::AGENTSIGHT_OBSERVE) {
+            // No ProbeConfig means AgentsightManager will fall back to built-in defaults.
             return true;
         }
     } else {
@@ -710,12 +715,17 @@ bool SecurityOptions::Init(SecurityProbeType probeType,
                 if (!GetOptionalStringParam(innerConfig, "LogPath", mLogPath, errorMsg)) {
                     warnOptionalParse();
                 }
-                ParseAgentsightCmdlineAllowFromOptionalKey(innerConfig,
-                                                           "CmdlineWhitelist",
-                                                           "ProbeConfig.CmdlineWhitelist",
-                                                           mAgentsightCmdlineWhitelist,
-                                                           errorMsg,
-                                                           warnOptionalParse);
+                // CmdlineWhitelist is optional: when absent, AgentsightManager injects the
+                // built-in cmdline rules. When present, it must contain valid rules.
+                if (innerConfig.isMember("CmdlineWhitelist")) {
+                    if (!ParseAgentsightCmdlineAllowRuleArray(innerConfig["CmdlineWhitelist"],
+                                                              "ProbeConfig.CmdlineWhitelist",
+                                                              mAgentsightCmdlineWhitelist,
+                                                              errorMsg,
+                                                              warnOptionalParse)) {
+                        return false;
+                    }
+                }
                 ParseAgentsightCmdlineFromOptionalKey(innerConfig,
                                                       "CmdlineBlacklist",
                                                       "ProbeConfig.CmdlineBlacklist",

--- a/core/ebpf/Config.cpp
+++ b/core/ebpf/Config.cpp
@@ -622,7 +622,7 @@ bool ParseAgentsightCmdlineAllowRuleArray(const Json::Value& rows,
             warn();
             continue;
         }
-        dest.push_back(AgentsightCmdlineAllowRule {std::move(agentType), std::move(patterns)});
+        dest.push_back(AgentsightCmdlineAllowRule{std::move(agentType), std::move(patterns)});
     }
     if (dest.empty()) {
         errorMsg = contextLabel + " has no valid rules";

--- a/core/ebpf/Config.cpp
+++ b/core/ebpf/Config.cpp
@@ -563,7 +563,7 @@ bool ParseAgentsightCmdlinePatternsArray(const Json::Value& row,
 
 } // namespace
 
-/// Fills `dest` with argv-glob rows from `rows` (must be JSON array of string arrays).
+/// Fills `dest` with cmdline-arg-glob rows from `rows` (must be JSON array of string arrays).
 void ParseAgentsightCmdlineRowArray(const Json::Value& rows,
                                     const std::string& contextLabel,
                                     std::vector<std::vector<std::string>>& dest,
@@ -584,7 +584,7 @@ void ParseAgentsightCmdlineRowArray(const Json::Value& rows,
     }
 }
 
-/// Fills `dest` with allow rules. Each entry must be `{"AgentType": "...", "Rule": [...]}`.
+/// Fills `dest` with allow rules. Each entry must be `{"AgentType": "...", "Args": [...]}`.
 bool ParseAgentsightCmdlineAllowRuleArray(const Json::Value& rows,
                                           const std::string& contextLabel,
                                           std::vector<AgentsightCmdlineAllowRule>& dest,
@@ -603,7 +603,7 @@ bool ParseAgentsightCmdlineAllowRuleArray(const Json::Value& rows,
     for (Json::ArrayIndex i = 0; i < rows.size(); ++i) {
         const Json::Value& row = rows[i];
         if (!row.isObject()) {
-            errorMsg = contextLabel + " row " + std::to_string(i) + " must be an object with AgentType and Rule";
+            errorMsg = contextLabel + " row " + std::to_string(i) + " must be an object with AgentType and Args";
             warn();
             continue;
         }
@@ -612,13 +612,13 @@ bool ParseAgentsightCmdlineAllowRuleArray(const Json::Value& rows,
             warn();
             continue;
         }
-        if (!row.isMember("Rule")) {
-            errorMsg = contextLabel + " row " + std::to_string(i) + " object must have Rule";
+        if (!row.isMember("Args")) {
+            errorMsg = contextLabel + " row " + std::to_string(i) + " object must have Args";
             warn();
             continue;
         }
         std::vector<std::string> patterns;
-        if (!ParseAgentsightCmdlinePatternsArray(row["Rule"], contextLabel, i, "Rule", patterns, errorMsg)) {
+        if (!ParseAgentsightCmdlinePatternsArray(row["Args"], contextLabel, i, "Args", patterns, errorMsg)) {
             warn();
             continue;
         }

--- a/core/ebpf/Config.cpp
+++ b/core/ebpf/Config.cpp
@@ -514,6 +514,39 @@ void WarnSecurityProbeConfigIgnore(const CollectionPipelineContext* mContext,
                          mContext->GetRegion());
 }
 
+namespace {
+
+constexpr const char* kAgentsightDefaultAllowAgentName = "Custom Agent";
+
+bool ParseAgentsightCmdlinePatternsArray(const Json::Value& row,
+                                         const std::string& contextLabel,
+                                         size_t rowIndex,
+                                         const char* fieldHint,
+                                         std::vector<std::string>& patterns,
+                                         std::string& errorMsg) {
+    const std::string prefix = contextLabel + " row " + std::to_string(rowIndex) + " " + fieldHint;
+    if (!row.isArray()) {
+        errorMsg = prefix + " must be a string array";
+        return false;
+    }
+    patterns.clear();
+    patterns.reserve(row.size());
+    for (const auto& cell : row) {
+        if (!cell.isString()) {
+            errorMsg = prefix + " contains non-string element";
+            return false;
+        }
+        patterns.emplace_back(cell.asString());
+    }
+    if (patterns.empty()) {
+        errorMsg = prefix + " is empty";
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
 /// Fills `dest` with argv-glob rows from `rows` (must be JSON array of string arrays).
 void ParseAgentsightCmdlineRowArray(const Json::Value& rows,
                                     const std::string& contextLabel,
@@ -526,34 +559,73 @@ void ParseAgentsightCmdlineRowArray(const Json::Value& rows,
         return;
     }
     for (Json::ArrayIndex i = 0; i < rows.size(); ++i) {
-        const Json::Value& row = rows[i];
-        if (!row.isArray()) {
-            errorMsg = contextLabel + " row " + std::to_string(i) + " must be a string array";
-            warn();
-            continue;
-        }
         std::vector<std::string> patterns;
-        patterns.reserve(row.size());
-        bool rowOk = true;
-        for (const auto& cell : row) {
-            if (!cell.isString()) {
-                errorMsg = contextLabel + " row " + std::to_string(i) + " contains non-string element";
-                warn();
-                rowOk = false;
-                break;
-            }
-            patterns.emplace_back(cell.asString());
-        }
-        if (!rowOk) {
-            continue;
-        }
-        if (patterns.empty()) {
-            errorMsg = contextLabel + " row " + std::to_string(i) + " is empty";
+        if (!ParseAgentsightCmdlinePatternsArray(rows[i], contextLabel, i, "entry", patterns, errorMsg)) {
             warn();
             continue;
         }
         dest.emplace_back(std::move(patterns));
     }
+}
+
+/// Fills `dest` with allow rules. Each entry is either a string array (legacy) or
+/// `{"agent_name": "...", "rule": [...]}`.
+void ParseAgentsightCmdlineAllowRuleArray(const Json::Value& rows,
+                                          const std::string& contextLabel,
+                                          std::vector<AgentsightCmdlineAllowRule>& dest,
+                                          std::string& errorMsg,
+                                          const std::function<void()>& warn) {
+    if (!rows.isArray()) {
+        errorMsg = contextLabel + " must be an array";
+        warn();
+        return;
+    }
+    for (Json::ArrayIndex i = 0; i < rows.size(); ++i) {
+        const Json::Value& row = rows[i];
+        if (row.isArray()) {
+            std::vector<std::string> patterns;
+            if (!ParseAgentsightCmdlinePatternsArray(row, contextLabel, i, "entry", patterns, errorMsg)) {
+                warn();
+                continue;
+            }
+            dest.push_back(AgentsightCmdlineAllowRule {kAgentsightDefaultAllowAgentName, std::move(patterns)});
+            continue;
+        }
+        if (!row.isObject()) {
+            errorMsg = contextLabel + " row " + std::to_string(i)
+                       + " must be a string array or object with agent_name and rule";
+            warn();
+            continue;
+        }
+        if (!row.isMember("agent_name") || !row["agent_name"].isString() || row["agent_name"].asString().empty()) {
+            errorMsg = contextLabel + " row " + std::to_string(i) + " object must have non-empty agent_name";
+            warn();
+            continue;
+        }
+        if (!row.isMember("rule")) {
+            errorMsg = contextLabel + " row " + std::to_string(i) + " object must have rule";
+            warn();
+            continue;
+        }
+        std::vector<std::string> patterns;
+        if (!ParseAgentsightCmdlinePatternsArray(row["rule"], contextLabel, i, "rule", patterns, errorMsg)) {
+            warn();
+            continue;
+        }
+        dest.push_back(AgentsightCmdlineAllowRule {row["agent_name"].asString(), std::move(patterns)});
+    }
+}
+
+void ParseAgentsightCmdlineAllowFromOptionalKey(const Json::Value& innerConfig,
+                                                const char* key,
+                                                const std::string& contextLabel,
+                                                std::vector<AgentsightCmdlineAllowRule>& dest,
+                                                std::string& errorMsg,
+                                                const std::function<void()>& warn) {
+    if (!innerConfig.isMember(key)) {
+        return;
+    }
+    ParseAgentsightCmdlineAllowRuleArray(innerConfig[key], contextLabel, dest, errorMsg, warn);
 }
 
 void ParseAgentsightCmdlineFromOptionalKey(const Json::Value& innerConfig,
@@ -638,12 +710,12 @@ bool SecurityOptions::Init(SecurityProbeType probeType,
                 if (!GetOptionalStringParam(innerConfig, "LogPath", mLogPath, errorMsg)) {
                     warnOptionalParse();
                 }
-                ParseAgentsightCmdlineFromOptionalKey(innerConfig,
-                                                      "CmdlineWhitelist",
-                                                      "ProbeConfig.CmdlineWhitelist",
-                                                      mAgentsightCmdlineWhitelist,
-                                                      errorMsg,
-                                                      warnOptionalParse);
+                ParseAgentsightCmdlineAllowFromOptionalKey(innerConfig,
+                                                           "CmdlineWhitelist",
+                                                           "ProbeConfig.CmdlineWhitelist",
+                                                           mAgentsightCmdlineWhitelist,
+                                                           errorMsg,
+                                                           warnOptionalParse);
                 ParseAgentsightCmdlineFromOptionalKey(innerConfig,
                                                       "CmdlineBlacklist",
                                                       "ProbeConfig.CmdlineBlacklist",

--- a/core/ebpf/Config.h
+++ b/core/ebpf/Config.h
@@ -39,6 +39,12 @@ bool InitObserverNetworkOption(const Json::Value& config,
 
 enum class SecurityProbeType { PROCESS, FILE, NETWORK, AGENTSIGHT_OBSERVE, MAX };
 
+/// One cmdline allow rule: glob patterns plus the agent name reported as `gen_ai.agent.name`.
+struct AgentsightCmdlineAllowRule {
+    std::string agentName;
+    std::vector<std::string> patterns;
+};
+
 class SecurityOptions {
 public:
     bool Init(SecurityProbeType filterType,
@@ -52,8 +58,8 @@ public:
     // Valid when mProbeType == SecurityProbeType::AGENTSIGHT_OBSERVE (AgentSight input).
     int32_t mVerbose = 0;
     std::string mLogPath;
-    /// Cmdline argv glob rows (allow=1) for AgentSight process matching.
-    std::vector<std::vector<std::string>> mAgentsightCmdlineWhitelist;
+    /// Cmdline allow rules (argv globs + agent display name).
+    std::vector<AgentsightCmdlineAllowRule> mAgentsightCmdlineWhitelist;
     /// Cmdline argv glob rows (allow=0) for AgentSight process matching.
     std::vector<std::vector<std::string>> mAgentsightCmdlineBlacklist;
     /// Domain glob strings (whitelist) for AgentSight SNI / domain filtering.

--- a/core/ebpf/Config.h
+++ b/core/ebpf/Config.h
@@ -39,9 +39,9 @@ bool InitObserverNetworkOption(const Json::Value& config,
 
 enum class SecurityProbeType { PROCESS, FILE, NETWORK, AGENTSIGHT_OBSERVE, MAX };
 
-/// One cmdline allow rule: glob patterns plus the agent name reported as `gen_ai.agent.name`.
+/// One cmdline allow rule: glob patterns plus the agent type reported as `gen_ai.agent.type`.
 struct AgentsightCmdlineAllowRule {
-    std::string agentName;
+    std::string agentType;
     std::vector<std::string> patterns;
 };
 

--- a/core/ebpf/plugin/agentsight/AgentsightEvents.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightEvents.cpp
@@ -57,7 +57,7 @@ AgentsightLlmRecord::AgentsightLlmRecord(std::string pipelineConfigName, const A
     mCacheCreationInputTokens = d.cache_creation_input_tokens;
     mCacheReadInputTokens = d.cache_read_input_tokens;
     mProcessName = CopyProcessName(d.process_name);
-    mAgentName = CopyCStr(d.agent_name);
+    mAgentType = CopyCStr(d.agent_name);
     mRequestUrl = CopyCStr(d.request_url);
     mProvider = CopyCStr(d.provider);
     mModel = CopyCStr(d.model);

--- a/core/ebpf/plugin/agentsight/AgentsightEvents.h
+++ b/core/ebpf/plugin/agentsight/AgentsightEvents.h
@@ -49,7 +49,7 @@ public:
     uint32_t mCacheCreationInputTokens = 0;
     uint32_t mCacheReadInputTokens = 0;
     std::string mProcessName;
-    std::string mAgentName;
+    std::string mAgentType;
     std::string mRequestUrl;
     std::string mProvider;
     std::string mModel;

--- a/core/ebpf/plugin/agentsight/AgentsightManager.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.cpp
@@ -101,24 +101,26 @@ bool ParseHostAndPortFromRequestUrl(const std::string& url, std::string& host, s
     return !host.empty();
 }
 
-/// Builtin cmdline allow rules — keep in sync with
-/// `core/_thirdparty/coolbpf/src/agentsight/agentsight.json` (`cmdline.allow`).
+/// Builtin cmdline allow rules used when the user does not configure any whitelist/blacklist.
+/// `agent_type` values follow the LoongSuite naming convention (lowercase + hyphen) and are
+/// kept in sync with the recommended template in
+/// `docs/cn/plugins/input/native/input_agentsight.md`.
 struct BuiltinCmdlineAllowRule {
-    const char* agent_name;
+    const char* agent_type;
     std::vector<std::string> argv_globs;
 };
 
 static const std::vector<BuiltinCmdlineAllowRule>& GetBuiltinCmdlineAllowRules() {
     static const std::vector<BuiltinCmdlineAllowRule> kRules = {
-        {"Hermes", {"hermes*"}},
-        {"Hermes", {"*python*", "*hermes*"}},
-        {"Hermes", {"*python*", "-m", "*hermes*"}},
-        {"Cosh", {"node*", "*/usr/bin/co*"}},
-        {"Cosh", {"node*", "*/usr/bin/cosh*"}},
-        {"Cosh", {"node*", "*/usr/bin/copliot*"}},
-        {"Cosh", {"node*", "*copilot-shell*"}},
-        {"OpenClaw", {"*openclaw-gatewa*"}},
-        {"OpenClaw", {"node*", "*openclaw*"}},
+        {"hermes", {"hermes*"}},
+        {"hermes", {"*python*", "*hermes*"}},
+        {"hermes", {"*python*", "-m", "*hermes*"}},
+        {"cosh", {"node*", "*/usr/bin/co*"}},
+        {"cosh", {"node*", "*/usr/bin/cosh*"}},
+        {"cosh", {"node*", "*/usr/bin/copliot*"}},
+        {"cosh", {"node*", "*copilot-shell*"}},
+        {"openclaw", {"*openclaw-gatewa*"}},
+        {"openclaw", {"node*", "*openclaw*"}},
     };
     return kRules;
 }
@@ -136,6 +138,9 @@ static const std::vector<const char*>& GetBuiltinDomainAllowRules() {
 void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
                                   const AgentSightSymbolTable* sym,
                                   const SecurityOptions& opts) {
+    // Built-in cmdline rules are injected only when the user did not supply either whitelist
+    // or blacklist. Once any user rule is present, we use the user configuration verbatim so
+    // strict matching scenarios are not silently broadened.
     const bool injectBuiltinCmdlineAllow
         = opts.mAgentsightCmdlineWhitelist.empty() && opts.mAgentsightCmdlineBlacklist.empty();
     const bool injectBuiltinDomainAllow = opts.mAgentsightDomainWhitelist.empty();
@@ -145,7 +150,7 @@ void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
                     ("AgentSight",
                      "cmdline rules configured but agentsight_config_add_cmdline_rule symbol not found; skipping")(
                         "user_whitelist_rows", opts.mAgentsightCmdlineWhitelist.size())(
-                        "user_blacklist_rows", opts.mAgentsightCmdlineBlacklist.size())("builtin_allow_injected",
+                        "user_blacklist_rows", opts.mAgentsightCmdlineBlacklist.size())("builtin_cmdline_injected",
                                                                                         injectBuiltinCmdlineAllow));
     }
     if (!sym || !sym->config_add_domain_rule) {
@@ -157,17 +162,16 @@ void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
     }
 
     std::vector<std::pair<std::string, std::vector<std::string>>> allowRowsToApply;
-
     if (injectBuiltinCmdlineAllow) {
         const auto& builtins = GetBuiltinCmdlineAllowRules();
         allowRowsToApply.reserve(builtins.size());
         for (const auto& br : builtins) {
-            allowRowsToApply.emplace_back(std::string(br.agent_name), br.argv_globs);
+            allowRowsToApply.emplace_back(std::string(br.agent_type), br.argv_globs);
         }
     } else {
         allowRowsToApply.reserve(opts.mAgentsightCmdlineWhitelist.size());
         for (const auto& rule : opts.mAgentsightCmdlineWhitelist) {
-            allowRowsToApply.emplace_back(rule.agentName, rule.patterns);
+            allowRowsToApply.emplace_back(rule.agentType, rule.patterns);
         }
     }
 
@@ -210,8 +214,8 @@ void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
 
     LOG_INFO(sLogger,
              ("AgentSight", "applied config rules")("user_cmdline_whitelist", opts.mAgentsightCmdlineWhitelist.size())(
-                 "user_cmdline_blacklist", opts.mAgentsightCmdlineBlacklist.size())("builtin_cmdline_allow_injected",
-                                                                                    injectBuiltinCmdlineAllow)(
+                 "user_cmdline_blacklist", opts.mAgentsightCmdlineBlacklist.size())(
+                 "builtin_cmdline_allow_injected", injectBuiltinCmdlineAllow)(
                  "cmdline_allow_rows_applied", allowRowsToApply.size())("user_domain_whitelist",
                                                                         opts.mAgentsightDomainWhitelist.size())(
                  "builtin_domain_allow_injected", injectBuiltinDomainAllow)("domain_rows_applied", domainRowsApplied)(
@@ -548,7 +552,7 @@ int AgentsightManager::HandleEvent(const std::shared_ptr<CommonEvent>& event) {
         log->SetContent("pid", std::to_string(rec->mPid));
     }
     setStr(StringView("comm"), rec->mProcessName);
-    setStr(StringView("gen_ai.agent.name"), rec->mAgentName);
+    setStr(StringView("gen_ai.agent.type"), rec->mAgentType);
 
     log->SetContent("gen_ai.request.timestamp", std::to_string(rec->mTimestampNs / 1000000ULL));
     log->SetContent("gen_ai.response.duration", std::to_string(rec->mDurationNs / 1000000ULL));

--- a/core/ebpf/plugin/agentsight/AgentsightManager.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.cpp
@@ -214,13 +214,12 @@ void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
 
     LOG_INFO(sLogger,
              ("AgentSight", "applied config rules")("user_cmdline_whitelist", opts.mAgentsightCmdlineWhitelist.size())(
-                 "user_cmdline_blacklist", opts.mAgentsightCmdlineBlacklist.size())(
-                 "builtin_cmdline_allow_injected", injectBuiltinCmdlineAllow)(
+                 "user_cmdline_blacklist", opts.mAgentsightCmdlineBlacklist.size())("builtin_cmdline_allow_injected",
+                                                                                    injectBuiltinCmdlineAllow)(
                  "cmdline_allow_rows_applied", allowRowsToApply.size())("user_domain_whitelist",
                                                                         opts.mAgentsightDomainWhitelist.size())(
                  "builtin_domain_allow_injected", injectBuiltinDomainAllow)("domain_rows_applied", domainRowsApplied)(
-                 "cmdline_api", sym && sym->config_add_cmdline_rule)(
-                 "domain_api", sym && sym->config_add_domain_rule));
+                 "cmdline_api", sym && sym->config_add_cmdline_rule)("domain_api", sym && sym->config_add_domain_rule));
 }
 
 } // namespace

--- a/core/ebpf/plugin/agentsight/AgentsightManager.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.cpp
@@ -15,7 +15,6 @@
 #include "ebpf/plugin/agentsight/AgentsightManager.h"
 
 #include <algorithm>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -134,18 +133,6 @@ static const std::vector<const char*>& GetBuiltinDomainAllowRules() {
     return kRules;
 }
 
-/// Join argv glob patterns for a stable FFI `agent_name` label (not used for matching).
-std::string DeriveAgentsightAliasBase(const std::vector<std::string>& patterns) {
-    std::string s;
-    for (size_t i = 0; i < patterns.size(); ++i) {
-        if (i > 0) {
-            s += '|';
-        }
-        s += patterns[i];
-    }
-    return s;
-}
-
 void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
                                   const AgentSightSymbolTable* sym,
                                   const SecurityOptions& opts) {
@@ -170,7 +157,6 @@ void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
     }
 
     std::vector<std::pair<std::string, std::vector<std::string>>> allowRowsToApply;
-    size_t aliasCollisions = 0;
 
     if (injectBuiltinCmdlineAllow) {
         const auto& builtins = GetBuiltinCmdlineAllowRules();
@@ -179,23 +165,9 @@ void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
             allowRowsToApply.emplace_back(std::string(br.agent_name), br.argv_globs);
         }
     } else {
-        std::unordered_map<std::string, int> aliasOrdinal;
-        std::vector<std::string> whitelistAliases;
-        whitelistAliases.reserve(opts.mAgentsightCmdlineWhitelist.size());
-        for (const auto& row : opts.mAgentsightCmdlineWhitelist) {
-            const std::string base = DeriveAgentsightAliasBase(row);
-            int& n = aliasOrdinal[base];
-            ++n;
-            if (n == 1) {
-                whitelistAliases.push_back(base);
-            } else {
-                ++aliasCollisions;
-                whitelistAliases.push_back(base + "_" + std::to_string(n));
-            }
-        }
         allowRowsToApply.reserve(opts.mAgentsightCmdlineWhitelist.size());
-        for (size_t i = 0; i < opts.mAgentsightCmdlineWhitelist.size(); ++i) {
-            allowRowsToApply.emplace_back(std::move(whitelistAliases[i]), opts.mAgentsightCmdlineWhitelist[i]);
+        for (const auto& rule : opts.mAgentsightCmdlineWhitelist) {
+            allowRowsToApply.emplace_back(rule.agentName, rule.patterns);
         }
     }
 
@@ -243,7 +215,7 @@ void ApplyAgentsightRulesToConfig(AgentsightConfigHandle* cfg,
                  "cmdline_allow_rows_applied", allowRowsToApply.size())("user_domain_whitelist",
                                                                         opts.mAgentsightDomainWhitelist.size())(
                  "builtin_domain_allow_injected", injectBuiltinDomainAllow)("domain_rows_applied", domainRowsApplied)(
-                 "whitelist_alias_collisions", aliasCollisions)("cmdline_api", sym && sym->config_add_cmdline_rule)(
+                 "cmdline_api", sym && sym->config_add_cmdline_rule)(
                  "domain_api", sym && sym->config_add_domain_rule));
 }
 

--- a/core/unittest/ebpf/AgentsightManagerUnittest.cpp
+++ b/core/unittest/ebpf/AgentsightManagerUnittest.cpp
@@ -482,7 +482,8 @@ void AgentsightManagerUnittest::TestDestroyTwice() {
 
 void AgentsightManagerUnittest::TestCmdlineAndDomainRulesInvokedOnAddOrUpdate() {
     auto& o = agentsightOptions();
-    o.mAgentsightCmdlineWhitelist = {{"node", "*claude*"}, {"node", "*claude*"}};
+    o.mAgentsightCmdlineWhitelist = {AgentsightCmdlineAllowRule {"Claude", {"node", "*claude*"}},
+                                     AgentsightCmdlineAllowRule {"Claude", {"node", "*claude*"}}};
     o.mAgentsightCmdlineBlacklist = {{"node", "*webpack*"}};
     o.mAgentsightDomainWhitelist = {"*.openai.com", "*.anthropic.com"};
 

--- a/core/unittest/ebpf/AgentsightManagerUnittest.cpp
+++ b/core/unittest/ebpf/AgentsightManagerUnittest.cpp
@@ -482,8 +482,8 @@ void AgentsightManagerUnittest::TestDestroyTwice() {
 
 void AgentsightManagerUnittest::TestCmdlineAndDomainRulesInvokedOnAddOrUpdate() {
     auto& o = agentsightOptions();
-    o.mAgentsightCmdlineWhitelist = {AgentsightCmdlineAllowRule {"claude-code", {"node", "*claude*"}},
-                                     AgentsightCmdlineAllowRule {"claude-code", {"node", "*claude*"}}};
+    o.mAgentsightCmdlineWhitelist = {AgentsightCmdlineAllowRule{"claude-code", {"node", "*claude*"}},
+                                     AgentsightCmdlineAllowRule{"claude-code", {"node", "*claude*"}}};
     o.mAgentsightCmdlineBlacklist = {{"node", "*webpack*"}};
     o.mAgentsightDomainWhitelist = {"*.openai.com", "*.anthropic.com"};
 

--- a/core/unittest/ebpf/AgentsightManagerUnittest.cpp
+++ b/core/unittest/ebpf/AgentsightManagerUnittest.cpp
@@ -482,8 +482,8 @@ void AgentsightManagerUnittest::TestDestroyTwice() {
 
 void AgentsightManagerUnittest::TestCmdlineAndDomainRulesInvokedOnAddOrUpdate() {
     auto& o = agentsightOptions();
-    o.mAgentsightCmdlineWhitelist = {AgentsightCmdlineAllowRule {"Claude", {"node", "*claude*"}},
-                                     AgentsightCmdlineAllowRule {"Claude", {"node", "*claude*"}}};
+    o.mAgentsightCmdlineWhitelist = {AgentsightCmdlineAllowRule {"claude-code", {"node", "*claude*"}},
+                                     AgentsightCmdlineAllowRule {"claude-code", {"node", "*claude*"}}};
     o.mAgentsightCmdlineBlacklist = {{"node", "*webpack*"}};
     o.mAgentsightDomainWhitelist = {"*.openai.com", "*.anthropic.com"};
 

--- a/core/unittest/ebpf/SecurityOptionsUnittest.cpp
+++ b/core/unittest/ebpf/SecurityOptionsUnittest.cpp
@@ -28,6 +28,7 @@ public:
     void TestAgentsightProbeConfigOptionalInvalidTypes();
     void TestAgentsightVerboseClampedWhenNegative();
     void TestAgentsightParsesFlatCmdlineAndDomainWhitelist();
+    void TestAgentsightParsesCmdlineWhitelistWithAgentName();
     void TestAgentsightIgnoresLegacyCmdlineRulesAndDomainRules();
 };
 
@@ -102,14 +103,34 @@ void SecurityOptionsUnittest::TestAgentsightParsesFlatCmdlineAndDomainWhitelist(
         err));
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
     APSARA_TEST_EQUAL(2UL, opt.mAgentsightCmdlineWhitelist.size());
-    APSARA_TEST_EQUAL(2UL, opt.mAgentsightCmdlineWhitelist[0].size());
-    APSARA_TEST_EQUAL("node", opt.mAgentsightCmdlineWhitelist[0][0]);
-    APSARA_TEST_EQUAL("*claude*", opt.mAgentsightCmdlineWhitelist[0][1]);
-    APSARA_TEST_EQUAL(3UL, opt.mAgentsightCmdlineWhitelist[1].size());
+    APSARA_TEST_EQUAL("Custom Agent", opt.mAgentsightCmdlineWhitelist[0].agentName);
+    APSARA_TEST_EQUAL(2UL, opt.mAgentsightCmdlineWhitelist[0].patterns.size());
+    APSARA_TEST_EQUAL("node", opt.mAgentsightCmdlineWhitelist[0].patterns[0]);
+    APSARA_TEST_EQUAL("*claude*", opt.mAgentsightCmdlineWhitelist[0].patterns[1]);
+    APSARA_TEST_EQUAL("Custom Agent", opt.mAgentsightCmdlineWhitelist[1].agentName);
+    APSARA_TEST_EQUAL(3UL, opt.mAgentsightCmdlineWhitelist[1].patterns.size());
     APSARA_TEST_EQUAL(1UL, opt.mAgentsightCmdlineBlacklist.size());
     APSARA_TEST_EQUAL("*webpack*", opt.mAgentsightCmdlineBlacklist[0][1]);
     APSARA_TEST_EQUAL(2UL, opt.mAgentsightDomainWhitelist.size());
     APSARA_TEST_EQUAL("*.openai.com", opt.mAgentsightDomainWhitelist[0]);
+}
+
+void SecurityOptionsUnittest::TestAgentsightParsesCmdlineWhitelistWithAgentName() {
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName("cfg1");
+    SecurityOptions opt;
+    std::string err;
+    Json::Value config;
+    APSARA_TEST_TRUE(ParseJsonTable(
+        R"({"ProbeConfig":{"CmdlineWhitelist":[{"agent_name":"OpenClaw","rule":["node*","*openclaw*"]},{"agent_name":"Hermes","rule":["*python*","*hermes*"]}]}})",
+        config,
+        err));
+    APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
+    APSARA_TEST_EQUAL(2UL, opt.mAgentsightCmdlineWhitelist.size());
+    APSARA_TEST_EQUAL("OpenClaw", opt.mAgentsightCmdlineWhitelist[0].agentName);
+    APSARA_TEST_EQUAL("node*", opt.mAgentsightCmdlineWhitelist[0].patterns[0]);
+    APSARA_TEST_EQUAL("*openclaw*", opt.mAgentsightCmdlineWhitelist[0].patterns[1]);
+    APSARA_TEST_EQUAL("Hermes", opt.mAgentsightCmdlineWhitelist[1].agentName);
 }
 
 void SecurityOptionsUnittest::TestAgentsightIgnoresLegacyCmdlineRulesAndDomainRules() {
@@ -134,6 +155,7 @@ UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightProbeConfigParsesOptionalF
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightProbeConfigOptionalInvalidTypes)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightVerboseClampedWhenNegative)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightParsesFlatCmdlineAndDomainWhitelist)
+UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightParsesCmdlineWhitelistWithAgentName)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightIgnoresLegacyCmdlineRulesAndDomainRules)
 
 UNIT_TEST_MAIN

--- a/core/unittest/ebpf/SecurityOptionsUnittest.cpp
+++ b/core/unittest/ebpf/SecurityOptionsUnittest.cpp
@@ -62,7 +62,7 @@ void SecurityOptionsUnittest::TestAgentsightProbeConfigParsesOptionalFields() {
     std::string err;
     Json::Value config;
     APSARA_TEST_TRUE(ParseJsonTable(
-        R"({"ProbeConfig":{"Verbose":2,"LogPath":"/tmp/as","CmdlineWhitelist":[{"AgentType":"openclaw","Rule":["node*","*openclaw*"]}]}})",
+        R"({"ProbeConfig":{"Verbose":2,"LogPath":"/tmp/as","CmdlineWhitelist":[{"AgentType":"openclaw","Args":["node*","*openclaw*"]}]}})",
         config,
         err));
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
@@ -79,7 +79,7 @@ void SecurityOptionsUnittest::TestAgentsightProbeConfigOptionalInvalidTypes() {
     std::string err;
     Json::Value config;
     APSARA_TEST_TRUE(ParseJsonTable(
-        R"({"ProbeConfig":{"Verbose":"bad","LogPath":1,"CmdlineWhitelist":[{"AgentType":"openclaw","Rule":["node*"]}]}})",
+        R"({"ProbeConfig":{"Verbose":"bad","LogPath":1,"CmdlineWhitelist":[{"AgentType":"openclaw","Args":["node*"]}]}})",
         config,
         err));
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
@@ -93,7 +93,7 @@ void SecurityOptionsUnittest::TestAgentsightVerboseClampedWhenNegative() {
     std::string err;
     Json::Value config;
     APSARA_TEST_TRUE(ParseJsonTable(
-        R"({"ProbeConfig":{"Verbose":-9,"CmdlineWhitelist":[{"AgentType":"openclaw","Rule":["*openclaw*"]}]}})",
+        R"({"ProbeConfig":{"Verbose":-9,"CmdlineWhitelist":[{"AgentType":"openclaw","Args":["*openclaw*"]}]}})",
         config,
         err));
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
@@ -128,7 +128,7 @@ void SecurityOptionsUnittest::TestAgentsightParsesCmdlineWhitelistWithAgentType(
     std::string err;
     Json::Value config;
     APSARA_TEST_TRUE(ParseJsonTable(
-        R"({"ProbeConfig":{"CmdlineWhitelist":[{"AgentType":"openclaw","Rule":["node*","*openclaw*"]},{"AgentType":"hermes","Rule":["*python*","*hermes*"]}]}})",
+        R"({"ProbeConfig":{"CmdlineWhitelist":[{"AgentType":"openclaw","Args":["node*","*openclaw*"]},{"AgentType":"hermes","Args":["*python*","*hermes*"]}]}})",
         config,
         err));
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
@@ -147,7 +147,7 @@ void SecurityOptionsUnittest::TestAgentsightAcceptsAnyAgentTypeShape() {
     std::string err;
     Json::Value config;
     APSARA_TEST_TRUE(ParseJsonTable(
-        R"({"ProbeConfig":{"CmdlineWhitelist":[{"AgentType":"OpenClaw","Rule":["node*","*openclaw*"]},{"AgentType":"my_custom_agent","Rule":["*foo*"]}]}})",
+        R"({"ProbeConfig":{"CmdlineWhitelist":[{"AgentType":"OpenClaw","Args":["node*","*openclaw*"]},{"AgentType":"my_custom_agent","Args":["*foo*"]}]}})",
         config,
         err));
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));

--- a/core/unittest/ebpf/SecurityOptionsUnittest.cpp
+++ b/core/unittest/ebpf/SecurityOptionsUnittest.cpp
@@ -22,30 +22,29 @@ using namespace logtail::ebpf;
 
 class SecurityOptionsUnittest : public testing::Test {
 public:
-    void TestAgentsightNoProbeConfigReturnsTrue();
-    void TestAgentsightProbeConfigWrongTypeWarns();
+    void TestAgentsightNoProbeConfigFallsBackToBuiltin();
+    void TestAgentsightProbeConfigWrongTypeFallsBackToBuiltin();
     void TestAgentsightProbeConfigParsesOptionalFields();
     void TestAgentsightProbeConfigOptionalInvalidTypes();
     void TestAgentsightVerboseClampedWhenNegative();
-    void TestAgentsightParsesFlatCmdlineAndDomainWhitelist();
-    void TestAgentsightParsesCmdlineWhitelistWithAgentName();
+    void TestAgentsightMissingCmdlineWhitelistFallsBackToBuiltin();
+    void TestAgentsightParsesCmdlineWhitelistWithAgentType();
+    void TestAgentsightAcceptsAnyAgentTypeShape();
+    void TestAgentsightRejectsLegacyLowercaseKeys();
+    void TestAgentsightRejectsEmptyCmdlineWhitelistArray();
     void TestAgentsightIgnoresLegacyCmdlineRulesAndDomainRules();
 };
 
-void SecurityOptionsUnittest::TestAgentsightNoProbeConfigReturnsTrue() {
+void SecurityOptionsUnittest::TestAgentsightNoProbeConfigFallsBackToBuiltin() {
     CollectionPipelineContext ctx;
     ctx.SetConfigName("cfg1");
     SecurityOptions opt;
     Json::Value config;
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
-    APSARA_TEST_EQUAL(opt.mVerbose, 0);
-    APSARA_TEST_TRUE(opt.mLogPath.empty());
     APSARA_TEST_TRUE(opt.mAgentsightCmdlineWhitelist.empty());
-    APSARA_TEST_TRUE(opt.mAgentsightCmdlineBlacklist.empty());
-    APSARA_TEST_TRUE(opt.mAgentsightDomainWhitelist.empty());
 }
 
-void SecurityOptionsUnittest::TestAgentsightProbeConfigWrongTypeWarns() {
+void SecurityOptionsUnittest::TestAgentsightProbeConfigWrongTypeFallsBackToBuiltin() {
     CollectionPipelineContext ctx;
     ctx.SetConfigName("cfg1");
     SecurityOptions opt;
@@ -53,6 +52,7 @@ void SecurityOptionsUnittest::TestAgentsightProbeConfigWrongTypeWarns() {
     Json::Value config;
     APSARA_TEST_TRUE(ParseJsonTable(R"({"ProbeConfig": "not_a_map"})", config, err));
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
+    APSARA_TEST_TRUE(opt.mAgentsightCmdlineWhitelist.empty());
 }
 
 void SecurityOptionsUnittest::TestAgentsightProbeConfigParsesOptionalFields() {
@@ -61,11 +61,14 @@ void SecurityOptionsUnittest::TestAgentsightProbeConfigParsesOptionalFields() {
     SecurityOptions opt;
     std::string err;
     Json::Value config;
-    APSARA_TEST_TRUE(ParseJsonTable(R"({"ProbeConfig": {"Verbose": 2, "LogPath": "/tmp/as"}})", config, err));
+    APSARA_TEST_TRUE(ParseJsonTable(
+        R"({"ProbeConfig":{"Verbose":2,"LogPath":"/tmp/as","CmdlineWhitelist":[{"AgentType":"openclaw","Rule":["node*","*openclaw*"]}]}})",
+        config,
+        err));
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
     APSARA_TEST_EQUAL(opt.mVerbose, 2);
     APSARA_TEST_EQUAL(opt.mLogPath, "/tmp/as");
-    // AGENTSIGHT branch returns before mOptionList.emplace_back (see Config.cpp).
+    APSARA_TEST_EQUAL(1UL, opt.mAgentsightCmdlineWhitelist.size());
     APSARA_TEST_EQUAL(0UL, opt.mOptionList.size());
 }
 
@@ -75,7 +78,10 @@ void SecurityOptionsUnittest::TestAgentsightProbeConfigOptionalInvalidTypes() {
     SecurityOptions opt;
     std::string err;
     Json::Value config;
-    APSARA_TEST_TRUE(ParseJsonTable(R"({"ProbeConfig": {"Verbose": "bad", "LogPath": 1}})", config, err));
+    APSARA_TEST_TRUE(ParseJsonTable(
+        R"({"ProbeConfig":{"Verbose":"bad","LogPath":1,"CmdlineWhitelist":[{"AgentType":"openclaw","Rule":["node*"]}]}})",
+        config,
+        err));
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
     APSARA_TEST_EQUAL(0UL, opt.mOptionList.size());
 }
@@ -86,51 +92,81 @@ void SecurityOptionsUnittest::TestAgentsightVerboseClampedWhenNegative() {
     SecurityOptions opt;
     std::string err;
     Json::Value config;
-    APSARA_TEST_TRUE(ParseJsonTable(R"({"ProbeConfig": {"Verbose": -9}})", config, err));
+    APSARA_TEST_TRUE(ParseJsonTable(
+        R"({"ProbeConfig":{"Verbose":-9,"CmdlineWhitelist":[{"AgentType":"openclaw","Rule":["*openclaw*"]}]}})",
+        config,
+        err));
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
     APSARA_TEST_EQUAL(opt.mVerbose, 0);
 }
 
-void SecurityOptionsUnittest::TestAgentsightParsesFlatCmdlineAndDomainWhitelist() {
+void SecurityOptionsUnittest::TestAgentsightMissingCmdlineWhitelistFallsBackToBuiltin() {
     CollectionPipelineContext ctx;
     ctx.SetConfigName("cfg1");
     SecurityOptions opt;
     std::string err;
     Json::Value config;
-    APSARA_TEST_TRUE(ParseJsonTable(
-        R"({"ProbeConfig":{"Verbose":0,"LogPath":"","CmdlineWhitelist":[["node","*claude*"],["npm","run","*"]],"CmdlineBlacklist":[["node","*webpack*"]],"DomainWhitelist":["*.openai.com","*.anthropic.com"]}})",
-        config,
-        err));
+    APSARA_TEST_TRUE(ParseJsonTable(R"({"ProbeConfig":{"Verbose":0,"LogPath":""}})", config, err));
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
-    APSARA_TEST_EQUAL(2UL, opt.mAgentsightCmdlineWhitelist.size());
-    APSARA_TEST_EQUAL("Custom Agent", opt.mAgentsightCmdlineWhitelist[0].agentName);
-    APSARA_TEST_EQUAL(2UL, opt.mAgentsightCmdlineWhitelist[0].patterns.size());
-    APSARA_TEST_EQUAL("node", opt.mAgentsightCmdlineWhitelist[0].patterns[0]);
-    APSARA_TEST_EQUAL("*claude*", opt.mAgentsightCmdlineWhitelist[0].patterns[1]);
-    APSARA_TEST_EQUAL("Custom Agent", opt.mAgentsightCmdlineWhitelist[1].agentName);
-    APSARA_TEST_EQUAL(3UL, opt.mAgentsightCmdlineWhitelist[1].patterns.size());
-    APSARA_TEST_EQUAL(1UL, opt.mAgentsightCmdlineBlacklist.size());
-    APSARA_TEST_EQUAL("*webpack*", opt.mAgentsightCmdlineBlacklist[0][1]);
-    APSARA_TEST_EQUAL(2UL, opt.mAgentsightDomainWhitelist.size());
-    APSARA_TEST_EQUAL("*.openai.com", opt.mAgentsightDomainWhitelist[0]);
+    APSARA_TEST_TRUE(opt.mAgentsightCmdlineWhitelist.empty());
 }
 
-void SecurityOptionsUnittest::TestAgentsightParsesCmdlineWhitelistWithAgentName() {
+void SecurityOptionsUnittest::TestAgentsightRejectsEmptyCmdlineWhitelistArray() {
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName("cfg1");
+    SecurityOptions opt;
+    std::string err;
+    Json::Value config;
+    APSARA_TEST_TRUE(ParseJsonTable(R"({"ProbeConfig":{"CmdlineWhitelist":[]}})", config, err));
+    APSARA_TEST_FALSE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
+}
+
+void SecurityOptionsUnittest::TestAgentsightParsesCmdlineWhitelistWithAgentType() {
     CollectionPipelineContext ctx;
     ctx.SetConfigName("cfg1");
     SecurityOptions opt;
     std::string err;
     Json::Value config;
     APSARA_TEST_TRUE(ParseJsonTable(
-        R"({"ProbeConfig":{"CmdlineWhitelist":[{"agent_name":"OpenClaw","rule":["node*","*openclaw*"]},{"agent_name":"Hermes","rule":["*python*","*hermes*"]}]}})",
+        R"({"ProbeConfig":{"CmdlineWhitelist":[{"AgentType":"openclaw","Rule":["node*","*openclaw*"]},{"AgentType":"hermes","Rule":["*python*","*hermes*"]}]}})",
         config,
         err));
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
     APSARA_TEST_EQUAL(2UL, opt.mAgentsightCmdlineWhitelist.size());
-    APSARA_TEST_EQUAL("OpenClaw", opt.mAgentsightCmdlineWhitelist[0].agentName);
+    APSARA_TEST_EQUAL("openclaw", opt.mAgentsightCmdlineWhitelist[0].agentType);
     APSARA_TEST_EQUAL("node*", opt.mAgentsightCmdlineWhitelist[0].patterns[0]);
     APSARA_TEST_EQUAL("*openclaw*", opt.mAgentsightCmdlineWhitelist[0].patterns[1]);
-    APSARA_TEST_EQUAL("Hermes", opt.mAgentsightCmdlineWhitelist[1].agentName);
+    APSARA_TEST_EQUAL("hermes", opt.mAgentsightCmdlineWhitelist[1].agentType);
+}
+
+void SecurityOptionsUnittest::TestAgentsightAcceptsAnyAgentTypeShape() {
+    // AgentType is a free-form non-empty string; we recommend lowercase+hyphen but do not enforce.
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName("cfg1");
+    SecurityOptions opt;
+    std::string err;
+    Json::Value config;
+    APSARA_TEST_TRUE(ParseJsonTable(
+        R"({"ProbeConfig":{"CmdlineWhitelist":[{"AgentType":"OpenClaw","Rule":["node*","*openclaw*"]},{"AgentType":"my_custom_agent","Rule":["*foo*"]}]}})",
+        config,
+        err));
+    APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
+    APSARA_TEST_EQUAL(2UL, opt.mAgentsightCmdlineWhitelist.size());
+    APSARA_TEST_EQUAL("OpenClaw", opt.mAgentsightCmdlineWhitelist[0].agentType);
+    APSARA_TEST_EQUAL("my_custom_agent", opt.mAgentsightCmdlineWhitelist[1].agentType);
+}
+
+void SecurityOptionsUnittest::TestAgentsightRejectsLegacyLowercaseKeys() {
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName("cfg1");
+    SecurityOptions opt;
+    std::string err;
+    Json::Value config;
+    APSARA_TEST_TRUE(ParseJsonTable(
+        R"({"ProbeConfig":{"CmdlineWhitelist":[{"agent_type":"openclaw","rule":["node*","*openclaw*"]}]}})",
+        config,
+        err));
+    APSARA_TEST_FALSE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
 }
 
 void SecurityOptionsUnittest::TestAgentsightIgnoresLegacyCmdlineRulesAndDomainRules() {
@@ -149,13 +185,16 @@ void SecurityOptionsUnittest::TestAgentsightIgnoresLegacyCmdlineRulesAndDomainRu
     APSARA_TEST_TRUE(opt.mAgentsightDomainWhitelist.empty());
 }
 
-UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightNoProbeConfigReturnsTrue)
-UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightProbeConfigWrongTypeWarns)
+UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightNoProbeConfigFallsBackToBuiltin)
+UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightProbeConfigWrongTypeFallsBackToBuiltin)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightProbeConfigParsesOptionalFields)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightProbeConfigOptionalInvalidTypes)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightVerboseClampedWhenNegative)
-UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightParsesFlatCmdlineAndDomainWhitelist)
-UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightParsesCmdlineWhitelistWithAgentName)
+UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightMissingCmdlineWhitelistFallsBackToBuiltin)
+UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightParsesCmdlineWhitelistWithAgentType)
+UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightAcceptsAnyAgentTypeShape)
+UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightRejectsLegacyLowercaseKeys)
+UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightRejectsEmptyCmdlineWhitelistArray)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightIgnoresLegacyCmdlineRulesAndDomainRules)
 
 UNIT_TEST_MAIN

--- a/core/unittest/input/InputAgentSightUnittest.cpp
+++ b/core/unittest/input/InputAgentSightUnittest.cpp
@@ -58,11 +58,10 @@ void InputAgentSightUnittest::TestInitWithProbeConfig() {
     std::string err;
     Json::Value configJson;
     Json::Value optionalGoPipeline;
-    APSARA_TEST_TRUE(
-        ParseJsonTable(
-            R"({"Type":"input_agentsight","ProbeConfig":{"Verbose":0,"LogPath":"","CmdlineWhitelist":[{"AgentType":"openclaw","Args":["node*","*openclaw*"]}]}})",
-            configJson,
-            err));
+    APSARA_TEST_TRUE(ParseJsonTable(
+        R"({"Type":"input_agentsight","ProbeConfig":{"Verbose":0,"LogPath":"","CmdlineWhitelist":[{"AgentType":"openclaw","Args":["node*","*openclaw*"]}]}})",
+        configJson,
+        err));
     InputAgentSight input;
     input.SetContext(mContex);
     input.CreateMetricsRecordRef("t", "1");

--- a/core/unittest/input/InputAgentSightUnittest.cpp
+++ b/core/unittest/input/InputAgentSightUnittest.cpp
@@ -59,7 +59,10 @@ void InputAgentSightUnittest::TestInitWithProbeConfig() {
     Json::Value configJson;
     Json::Value optionalGoPipeline;
     APSARA_TEST_TRUE(
-        ParseJsonTable(R"({"Type":"input_agentsight","ProbeConfig":{"Verbose":0,"LogPath":""}})", configJson, err));
+        ParseJsonTable(
+            R"({"Type":"input_agentsight","ProbeConfig":{"Verbose":0,"LogPath":"","CmdlineWhitelist":[{"AgentType":"openclaw","Rule":["node*","*openclaw*"]}]}})",
+            configJson,
+            err));
     InputAgentSight input;
     input.SetContext(mContex);
     input.CreateMetricsRecordRef("t", "1");

--- a/core/unittest/input/InputAgentSightUnittest.cpp
+++ b/core/unittest/input/InputAgentSightUnittest.cpp
@@ -60,7 +60,7 @@ void InputAgentSightUnittest::TestInitWithProbeConfig() {
     Json::Value optionalGoPipeline;
     APSARA_TEST_TRUE(
         ParseJsonTable(
-            R"({"Type":"input_agentsight","ProbeConfig":{"Verbose":0,"LogPath":"","CmdlineWhitelist":[{"AgentType":"openclaw","Rule":["node*","*openclaw*"]}]}})",
+            R"({"Type":"input_agentsight","ProbeConfig":{"Verbose":0,"LogPath":"","CmdlineWhitelist":[{"AgentType":"openclaw","Args":["node*","*openclaw*"]}]}})",
             configJson,
             err));
     InputAgentSight input;

--- a/docs/cn/plugins/input/native/input_agentsight.md
+++ b/docs/cn/plugins/input/native/input_agentsight.md
@@ -2,7 +2,7 @@
 
 ## 简介
 
-`input_agentsight` 插件实现对当前openclaw，hermes等agent工具等采集，支持的大模型供应商包括OpenAI，Anthropic，以及国内的厂商协议
+`input_agentsight` 插件实现对当前 openclaw、hermes 等 agent 工具等采集，支持的大模型供应商包括 OpenAI、Anthropic，以及国内的厂商协议。
 
 ## 版本
 
@@ -17,18 +17,37 @@ dev
 |  **参数**  |  **类型**  |  **是否必填**  |  **默认值**  |  **说明**  |
 | --- | --- | --- | --- | --- |
 |  Type  |  string  |  是  |  /  |  插件类型。固定为 `input_agentsight`  |
-|  ProbeConfig  |  object  |  否  |  /  |  插件配置参数列表  |
-|  ProbeConfig.Verbose  |  uint  |  否  |  /  |  是否打印ebpf的详细日志，1代表开启，0代表关闭  |
-|  ProbeConfig.LogPath  |  string  |  否  |  ""  | ebpf日志的输出位置  |
-|  ProbeConfig.CmdlineWhitelist  |  array  |  否  |  /  |  进程 **agent 筛选白名单**。推荐每一项为对象：`agent_name`（上报字段 `gen_ai.agent.name`）+ `rule`（**字符串数组**，与 `argv` 按位置 glob 匹配）。仍支持仅写 glob 数组的简写（此时 `agent_name` 默认为 `Custom Agent`）。未配置且黑名单也为空时注入默认规则（内置名称如 `OpenClaw`、`Hermes`）。  |
-|  ProbeConfig.CmdlineBlacklist  |  array  |  否  |  /  |  进程 **agent 筛选黑名单**，规则格式同白名单（含前缀匹配语义）；**命中则排除**，不采集。**优先级高于白名单**。  |
-|  ProbeConfig.DomainWhitelist  |  array  |  否  |  /  |  域名 **白名单**（字符串数组）：**访问白名单内域名的进程将被识别为 AI Agent 采集目标**。未配置时注入默认精确主机名列表，见下文「优先级与默认值」。  |
+|  ProbeConfig  |  object  |  否  |  /  |  AgentSight 探测配置。**整体未配置**时所有子项走默认。  |
+|  ProbeConfig.Verbose  |  uint  |  否  |  `0`  |  是否打印 ebpf 的详细日志，`1` 代表开启，`0` 代表关闭  |
+|  ProbeConfig.LogPath  |  string  |  否  |  `""`  |  ebpf 日志的输出位置  |
+|  ProbeConfig.CmdlineWhitelist  |  array  |  否（**推荐填写**）  |  内置 9 条  |  进程 **agent 筛选白名单**。每一项为对象：`AgentType`（上报字段 `gen_ai.agent.type`）+ `Rule`（字符串数组，与 `argv` 按位置 glob 匹配）。**未配置**且 `CmdlineBlacklist` 也为空时注入「默认 `CmdlineWhitelist`」（见下文）；**填写后只使用用户规则**，不再叠加内置。空数组 `[]` 视为非法配置。  |
+|  ProbeConfig.CmdlineBlacklist  |  array  |  否  |  /  |  进程 **agent 筛选黑名单**，每项为 glob 字符串数组（无 `AgentType`）；**命中则排除**，不采集。**优先级高于白名单**。  |
+|  ProbeConfig.DomainWhitelist  |  array  |  否  |  /  |  域名 **白名单**（字符串数组）：访问白名单内域名的进程可被识别为采集目标。未配置时注入默认精确主机名列表，见下文。  |
+
+### `AgentType` 取值命名规范
+
+本插件通过 **cmdline 白名单** 设置的是 **agent 类型**，命中后写入日志的 `gen_ai.agent.type` 字段。
+
+**推荐**（非强制）的 `AgentType` 取值约定：
+
+- 仅使用 **小写字母**、**数字**、**连字符** `-`
+- 以字母或数字开头/结尾，**不**以 `-` 开头或结尾
+- 多个单词用 **单个** 连字符连接，不用空格、下划线或驼峰
+
+| 推荐 | 不推荐 |
+| --- | --- |
+| `openclaw` | `OpenClaw`、`open_claw` |
+| `claude-code` | `Claude Code`、`claude_code` |
+| `hermes` | `Hermes` |
+| `cosh` | `Cosh` |
+
+`AgentType` 必须是**非空字符串**；具体取值不做硬校验，写什么就上报什么到 `gen_ai.agent.type`。统一遵循上述规范便于跨产品聚合分析。
 
 ### 优先级与默认值
 
 #### 黑白名单判定逻辑
 
-进程是否纳入采集，按下列**固定顺序**判定（**不要求** `CmdlineBlacklist`、`CmdlineWhitelist`、`DomainWhitelist` 同时配置；三类名单相互独立，未配置项见下文「默认值」）：
+进程是否纳入采集，按下列**固定顺序**判定（三类名单相互独立，未配置项见下文「默认值」）：
 
 1. 命中 `CmdlineBlacklist` → **不采集**（cmdline 黑名单优先）
 2. 未命中黑名单，且命中 `CmdlineWhitelist` → **纳入采集**
@@ -48,27 +67,41 @@ graph TD
     D -->|否| N
 ```
 
-例如：只配置了 cmdline 黑名单、未配域名时，仍会注入默认 `DomainWhitelist`；只配域名、未配 cmdline 时，仍会注入默认 cmdline 白名单（当黑/白名单均为空时）。
+例如：只配置了 cmdline 黑名单、未配域名时，仍会注入默认 `DomainWhitelist`；只配域名、未配 cmdline 黑白名单时，仍会注入下文的默认 cmdline 白名单。
 
 #### Cmdline 规则优先级和默认注入值
 
 1. **黑名单优先于白名单**：同一进程同时命中黑/白名单时，**黑名单生效**。
 2. **多条白名单之间**：**OR**，命中任一条即可。
-3. **默认注入条件**：`CmdlineWhitelist` 与 `CmdlineBlacklist` **均为空** 时，注入下表；一旦配置了 **任意一条** 用户 cmdline 白名单或黑名单，则 **不再** 注入默认 cmdline。
+3. **默认注入条件**：`CmdlineWhitelist` 与 `CmdlineBlacklist` **均未配置**时，注入下表；一旦配置了 **任意一条** 用户 cmdline 白名单或黑名单，则 **不再** 注入默认 cmdline。
+4. **空数组拒绝**：显式写 `CmdlineWhitelist: []` 会被视为非法配置；不写该字段才会走默认注入。
 
 **默认 `CmdlineWhitelist`（9 条）**
 
-| agent 名称 | 规则（`argv` 各段 glob） |
+| AgentType | Rule（`argv` 各段 glob） |
 | --- | --- |
-| Hermes | `hermes*` |
-| Hermes | `*python*`, `*hermes*` |
-| Hermes | `*python*`, `-m`, `*hermes*` |
-| Cosh | `node*`, `*/usr/bin/co*` |
-| Cosh | `node*`, `*/usr/bin/cosh*` |
-| Cosh | `node*`, `*/usr/bin/copliot*` |
-| Cosh | `node*`, `*copilot-shell*` |
-| OpenClaw | `*openclaw-gatewa*` |
-| OpenClaw | `node*`, `*openclaw*` |
+| `hermes` | `hermes*` |
+| `hermes` | `*python*`, `*hermes*` |
+| `hermes` | `*python*`, `-m`, `*hermes*` |
+| `cosh` | `node*`, `*/usr/bin/co*` |
+| `cosh` | `node*`, `*/usr/bin/cosh*` |
+| `cosh` | `node*`, `*/usr/bin/copliot*` |
+| `cosh` | `node*`, `*copilot-shell*` |
+| `openclaw` | `*openclaw-gatewa*` |
+| `openclaw` | `node*`, `*openclaw*` |
+
+#### 自定义示例（覆盖默认）
+
+填写后只使用用户规则，不再叠加内置：
+
+```yaml
+ProbeConfig:
+  CmdlineWhitelist:
+    - AgentType: openclaw
+      Rule: ["node*", "*openclaw*"]
+    - AgentType: claude-code
+      Rule: ["node*", "*claude*"]
+```
 
 #### Domain 规则优先级和默认注入值
 
@@ -84,24 +117,24 @@ graph TD
 | `dashscope.aliyuncs.com` |
 | `dashscope-intl.aliyuncs.com` |
 
-#### `gen_ai.agent.name` 的取值规则
+#### `gen_ai.agent.type` 的取值规则
 
-`gen_ai.agent.name` 字段**只来自 cmdline 白名单**，与 `DomainWhitelist` 无关。按下列顺序确定：
+`gen_ai.agent.type` **只来自 cmdline 白名单**（用户配置或内置默认）中命中规则的 `AgentType`，与 `DomainWhitelist` 无直接映射关系。按下列顺序确定：
 
-1. 进程被 cmdline 白名单命中 → 取**第一条**命中规则的 `agent_name`（用户配置或内置名）。
-2. 进程仅靠 `DomainWhitelist` 命中（cmdline 没命中任何白名单） → 二次匹配 **内置 cmdline 规则**；命中则取内置名（如 `OpenClaw`、`Hermes`、`Cosh`）。
-3. 仍匹配不上 → **不输出 `gen_ai.agent.name`** 字段。
+1. 进程被当前生效的 cmdline 白名单命中 → 取**第一条**命中规则的 `AgentType`。
+2. 进程仅靠 `DomainWhitelist` 纳入采集，且 cmdline 未命中（用户已覆盖默认时）→ 二次匹配 **内置默认 9 条**；命中则输出对应类型（如 `openclaw`）。
+3. 仍匹配不上 → **不输出** `gen_ai.agent.type`。
 
-因此「只配 `DomainWhitelist`」时：若进程命令行恰好符合内置 9 条规则之一，会拿到内置名；否则字段缺失。**`DomainWhitelist` 中的域名本身不会作为 agent 名**。
+「只配 `DomainWhitelist`、不配 cmdline」是允许的：cmdline 走内置默认 9 条 + 域名走用户配置，互相独立生效。**`DomainWhitelist` 中的域名本身不会作为** `gen_ai.agent.type`。
 
 ### Cmdline 规则自定义写法
 
-配置里**每一项**是一条白名单规则，包含两部分：
+配置里**每一项**是一条白名单规则对象，包含两个字段：
 
 | 字段 | 说明 |
 | --- | --- |
-| `agent_name` | 命中该规则后，写入日志 `gen_ai.agent.name` 的名称（如 `OpenClaw`）。多条规则可使用相同名称。 |
-| `rule` | 与进程 `argv` 各段按位置做 glob 匹配的字符串数组（与 `/proc/<PID>/cmdline` 一致）。 |
+| `AgentType` | 命中该规则后，写入日志 `gen_ai.agent.type` 的类型标识（如 `openclaw`）。多条规则可使用相同 `AgentType`。取值规范见上文。 |
+| `Rule` | 与进程 `argv` 各段按位置做 glob 匹配的字符串数组（与 `/proc/<PID>/cmdline` 一致）。 |
 
 先在本机查看真实命令行，再写 glob：
 
@@ -111,26 +144,20 @@ tr '\0' ' ' < /proc/<PID>/cmdline; echo
 
 每一段用 **glob** 匹配，不关心的位置写 `"*"`。
 
-**前缀匹配**：当 `rule` 的段数**少于** `argv` 时，只对前 N 段按位置做 glob 匹配，**后面多出来的参数不参与匹配**。例如 `rule: ["node*", "*openclaw*"]` 可命中 `node openclaw.js gateway`（第三段 `gateway` 被忽略）。若需约束后续参数，须在 `rule` 中继续写出对应段。反之，`rule` 段数**多于** `argv` 时则不命中。
+**前缀匹配**：当 `Rule` 的段数**少于** `argv` 时，只对前 N 段按位置做 glob 匹配，**后面多出来的参数不参与匹配**。例如 `Rule: ["node*", "*openclaw*"]` 可命中 `node openclaw.js gateway`（第三段 `gateway` 被忽略）。若需约束后续参数，须在 `Rule` 中继续写出对应段。反之，`Rule` 段数**多于** `argv` 时则不命中。
 
-**推荐写法**（显式指定 agent 名称）：
-
-```yaml
-CmdlineWhitelist:
-  - agent_name: OpenClaw
-    rule: ["node*", "*openclaw*"]
-  - agent_name: Hermes
-    rule: ["*python*", "*hermes*"]
-```
-
-**简写**（仅 glob 数组，上报名为 `Custom Agent`）：
+**示例**（须写在 `ProbeConfig` 下）：
 
 ```yaml
-CmdlineWhitelist:
-  - ["node*", "*openclaw*"]
+ProbeConfig:
+  CmdlineWhitelist:
+    - AgentType: openclaw
+      Rule: ["node*", "*openclaw*"]
+    - AgentType: hermes
+      Rule: ["*python*", "*hermes*"]
 ```
 
-同一进程命中多条规则时，**采集仍生效**；`gen_ai.agent.name` 取**列表中第一条**命中规则的 `agent_name`。若需固定名称，把更具体的规则排在前面，或避免 glob 重叠。
+同一进程命中多条规则时，**采集仍生效**；`gen_ai.agent.type` 取**列表中第一条**命中规则的 `AgentType`。若需固定类型，把更具体的规则排在前面，或避免 glob 重叠。
 
 ### Domain 规则自定义写法
 
@@ -151,7 +178,7 @@ DomainWhitelist:
 | `gen_ai.response.id` | string | 一次对话中其中一次对大模型请求的回复 id |
 | `pid` | string | 进程号（十进制字符串） |
 | `comm` | string | 进程名称 |
-| `gen_ai.agent.name` | string | agent 名称 |
+| `gen_ai.agent.type` | string | Agent **类型**（如 `openclaw`、`claude-code`），来自 cmdline 白名单 |
 | `gen_ai.request.timestamp` | string | 一次对大模型请求开始的时间，毫秒时间戳（十进制字符串） |
 | `gen_ai.response.duration` | string | 一次对大模型请求到大模型回复的耗时，毫秒（十进制字符串） |
 | `server.address` | string | 从请求 URL 解析出的服务端主机名（有请求 URL 时输出） |
@@ -174,11 +201,11 @@ DomainWhitelist:
 
 ## 样例
 
-### 采集agent与llm交互数据
+### 采集 agent 与 llm 交互数据
 
 - 输入
 
-打开agent进行交流
+打开 agent 进行交流
 
 - 采集配置
 
@@ -190,10 +217,10 @@ inputs:
       Verbose: 1
       LogPath: ""
       CmdlineWhitelist:
-        - agent_name: Claude
-          rule: ["node*", "*claude*"]
-        - agent_name: Hermes
-          rule: ["node*", "*hermes*"]
+        - AgentType: claude-code
+          Rule: ["node*", "*claude*"]
+        - AgentType: hermes
+          Rule: ["node*", "*hermes*"]
       CmdlineBlacklist:
         - ["node*", "*webpack*"]
       DomainWhitelist:
@@ -207,7 +234,7 @@ flushers:
 - 输出
 
 {
-  "gen_ai.agent.name": "OpenClaw",
+  "gen_ai.agent.type": "openclaw",
   "gen_ai.turn.id": "c47ac487c54c2da859ba2a0e873eeeae",
   "gen_ai.input.messages": [
     {

--- a/docs/cn/plugins/input/native/input_agentsight.md
+++ b/docs/cn/plugins/input/native/input_agentsight.md
@@ -20,7 +20,7 @@ dev
 |  ProbeConfig  |  object  |  否  |  /  |  插件配置参数列表  |
 |  ProbeConfig.Verbose  |  uint  |  否  |  /  |  是否打印ebpf的详细日志，1代表开启，0代表关闭  |
 |  ProbeConfig.LogPath  |  string  |  否  |  ""  | ebpf日志的输出位置  |
-|  ProbeConfig.CmdlineWhitelist  |  array  |  否  |  /  |  进程 **agent 筛选白名单**：每一项为一条规则（**字符串数组**），与进程 `argv` 按位置做 glob 匹配；规则比 `argv` 短时**仅前缀匹配**（多余参数忽略）。规则各段均匹配则视为命中，可纳入采集（见下文）。未配置且黑名单也为空时注入默认规则。  |
+|  ProbeConfig.CmdlineWhitelist  |  array  |  否  |  /  |  进程 **agent 筛选白名单**。推荐每一项为对象：`agent_name`（上报字段 `gen_ai.agent.name`）+ `rule`（**字符串数组**，与 `argv` 按位置 glob 匹配）。仍支持仅写 glob 数组的简写（此时 `agent_name` 默认为 `Custom Agent`）。未配置且黑名单也为空时注入默认规则（内置名称如 `OpenClaw`、`Hermes`）。  |
 |  ProbeConfig.CmdlineBlacklist  |  array  |  否  |  /  |  进程 **agent 筛选黑名单**，规则格式同白名单（含前缀匹配语义）；**命中则排除**，不采集。**优先级高于白名单**。  |
 |  ProbeConfig.DomainWhitelist  |  array  |  否  |  /  |  域名 **白名单**（字符串数组）：**访问白名单内域名的进程将被识别为 AI Agent 采集目标**。未配置时注入默认精确主机名列表，见下文「优先级与默认值」。  |
 
@@ -84,9 +84,26 @@ graph TD
 | `dashscope.aliyuncs.com` |
 | `dashscope-intl.aliyuncs.com` |
 
+#### `gen_ai.agent.name` 的取值规则
+
+`gen_ai.agent.name` 字段**只来自 cmdline 白名单**，与 `DomainWhitelist` 无关。按下列顺序确定：
+
+1. 进程被 cmdline 白名单命中 → 取**第一条**命中规则的 `agent_name`（用户配置或内置名）。
+2. 进程仅靠 `DomainWhitelist` 命中（cmdline 没命中任何白名单） → 二次匹配 **内置 cmdline 规则**；命中则取内置名（如 `OpenClaw`、`Hermes`、`Cosh`）。
+3. 仍匹配不上 → **不输出 `gen_ai.agent.name`** 字段。
+
+因此「只配 `DomainWhitelist`」时：若进程命令行恰好符合内置 9 条规则之一，会拿到内置名；否则字段缺失。**`DomainWhitelist` 中的域名本身不会作为 agent 名**。
+
 ### Cmdline 规则自定义写法
 
-配置里**每一项**是一条规则，对应 `argv` 各段（与 `/proc/<PID>/cmdline` 一致）。先在本机查看真实命令行，再写 glob：
+配置里**每一项**是一条白名单规则，包含两部分：
+
+| 字段 | 说明 |
+| --- | --- |
+| `agent_name` | 命中该规则后，写入日志 `gen_ai.agent.name` 的名称（如 `OpenClaw`）。多条规则可使用相同名称。 |
+| `rule` | 与进程 `argv` 各段按位置做 glob 匹配的字符串数组（与 `/proc/<PID>/cmdline` 一致）。 |
+
+先在本机查看真实命令行，再写 glob：
 
 ```bash
 tr '\0' ' ' < /proc/<PID>/cmdline; echo
@@ -94,14 +111,26 @@ tr '\0' ' ' < /proc/<PID>/cmdline; echo
 
 每一段用 **glob** 匹配，不关心的位置写 `"*"`。
 
-**前缀匹配**：当规则的段数**少于** `argv` 时，只对前 N 段按位置做 glob 匹配，**后面多出来的参数不参与匹配**。例如规则 `["node*", "*openclaw*"]` 可命中 `node openclaw.js gateway`（第三段 `gateway` 被忽略）。若需约束后续参数，须在规则中继续写出对应段（如 `["node*", "*openclaw*", "gateway"]`）。反之，规则段数**多于** `argv` 时则不命中。
+**前缀匹配**：当 `rule` 的段数**少于** `argv` 时，只对前 N 段按位置做 glob 匹配，**后面多出来的参数不参与匹配**。例如 `rule: ["node*", "*openclaw*"]` 可命中 `node openclaw.js gateway`（第三段 `gateway` 被忽略）。若需约束后续参数，须在 `rule` 中继续写出对应段。反之，`rule` 段数**多于** `argv` 时则不命中。
 
-示例：
+**推荐写法**（显式指定 agent 名称）：
 
 ```yaml
 CmdlineWhitelist:
-  - ["node*", "*openclaw*"]   # 见 /proc/<PID>/cmdline 后调整各段
+  - agent_name: OpenClaw
+    rule: ["node*", "*openclaw*"]
+  - agent_name: Hermes
+    rule: ["*python*", "*hermes*"]
 ```
+
+**简写**（仅 glob 数组，上报名为 `Custom Agent`）：
+
+```yaml
+CmdlineWhitelist:
+  - ["node*", "*openclaw*"]
+```
+
+同一进程命中多条规则时，**采集仍生效**；`gen_ai.agent.name` 取**列表中第一条**命中规则的 `agent_name`。若需固定名称，把更具体的规则排在前面，或避免 glob 重叠。
 
 ### Domain 规则自定义写法
 
@@ -161,8 +190,10 @@ inputs:
       Verbose: 1
       LogPath: ""
       CmdlineWhitelist:
-        - ["node*", "*claude*"]
-        - ["node*", "*hermes*"]
+        - agent_name: Claude
+          rule: ["node*", "*claude*"]
+        - agent_name: Hermes
+          rule: ["node*", "*hermes*"]
       CmdlineBlacklist:
         - ["node*", "*webpack*"]
       DomainWhitelist:

--- a/docs/cn/plugins/input/native/input_agentsight.md
+++ b/docs/cn/plugins/input/native/input_agentsight.md
@@ -20,7 +20,7 @@ dev
 |  ProbeConfig  |  object  |  否  |  /  |  AgentSight 探测配置。**整体未配置**时所有子项走默认。  |
 |  ProbeConfig.Verbose  |  uint  |  否  |  `0`  |  是否打印 ebpf 的详细日志，`1` 代表开启，`0` 代表关闭  |
 |  ProbeConfig.LogPath  |  string  |  否  |  `""`  |  ebpf 日志的输出位置  |
-|  ProbeConfig.CmdlineWhitelist  |  array  |  否（**推荐填写**）  |  内置 9 条  |  进程 **agent 筛选白名单**。每一项为对象：`AgentType`（上报字段 `gen_ai.agent.type`）+ `Rule`（字符串数组，与 `argv` 按位置 glob 匹配）。**未配置**且 `CmdlineBlacklist` 也为空时注入「默认 `CmdlineWhitelist`」（见下文）；**填写后只使用用户规则**，不再叠加内置。空数组 `[]` 视为非法配置。  |
+|  ProbeConfig.CmdlineWhitelist  |  array  |  否（**推荐填写**）  |  内置 9 条  |  进程 **agent 筛选白名单**。每一项为对象：`AgentType`（上报字段 `gen_ai.agent.type`）+ `Args`（字符串数组，与进程 cmdline 各参数（即 `argv`）按位置 glob 匹配）。**未配置**且 `CmdlineBlacklist` 也为空时注入「默认 `CmdlineWhitelist`」（见下文）；**填写后只使用用户规则**，不再叠加内置。空数组 `[]` 视为非法配置。  |
 |  ProbeConfig.CmdlineBlacklist  |  array  |  否  |  /  |  进程 **agent 筛选黑名单**，每项为 glob 字符串数组（无 `AgentType`）；**命中则排除**，不采集。**优先级高于白名单**。  |
 |  ProbeConfig.DomainWhitelist  |  array  |  否  |  /  |  域名 **白名单**（字符串数组）：访问白名单内域名的进程可被识别为采集目标。未配置时注入默认精确主机名列表，见下文。  |
 
@@ -78,7 +78,7 @@ graph TD
 
 **默认 `CmdlineWhitelist`（9 条）**
 
-| AgentType | Rule（`argv` 各段 glob） |
+| AgentType | Args（cmdline 各段 glob） |
 | --- | --- |
 | `hermes` | `hermes*` |
 | `hermes` | `*python*`, `*hermes*` |
@@ -98,9 +98,9 @@ graph TD
 ProbeConfig:
   CmdlineWhitelist:
     - AgentType: openclaw
-      Rule: ["node*", "*openclaw*"]
+      Args: ["node*", "*openclaw*"]
     - AgentType: claude-code
-      Rule: ["node*", "*claude*"]
+      Args: ["node*", "*claude*"]
 ```
 
 #### Domain 规则优先级和默认注入值
@@ -134,7 +134,7 @@ ProbeConfig:
 | 字段 | 说明 |
 | --- | --- |
 | `AgentType` | 命中该规则后，写入日志 `gen_ai.agent.type` 的类型标识（如 `openclaw`）。多条规则可使用相同 `AgentType`。取值规范见上文。 |
-| `Rule` | 与进程 `argv` 各段按位置做 glob 匹配的字符串数组（与 `/proc/<PID>/cmdline` 一致）。 |
+| `Args` | 与进程 cmdline 各参数（即 `argv`，与 `/proc/<PID>/cmdline` 一致）按位置做 glob 匹配的字符串数组。 |
 
 先在本机查看真实命令行，再写 glob：
 
@@ -144,7 +144,7 @@ tr '\0' ' ' < /proc/<PID>/cmdline; echo
 
 每一段用 **glob** 匹配，不关心的位置写 `"*"`。
 
-**前缀匹配**：当 `Rule` 的段数**少于** `argv` 时，只对前 N 段按位置做 glob 匹配，**后面多出来的参数不参与匹配**。例如 `Rule: ["node*", "*openclaw*"]` 可命中 `node openclaw.js gateway`（第三段 `gateway` 被忽略）。若需约束后续参数，须在 `Rule` 中继续写出对应段。反之，`Rule` 段数**多于** `argv` 时则不命中。
+**前缀匹配**：当 `Args` 的段数**少于** cmdline 实际参数数时，只对前 N 段按位置做 glob 匹配，**后面多出来的参数不参与匹配**。例如 `Args: ["node*", "*openclaw*"]` 可命中 `node openclaw.js gateway`（第三段 `gateway` 被忽略）。若需约束后续参数，须在 `Args` 中继续写出对应段。反之，`Args` 段数**多于** cmdline 实际参数数时则不命中。
 
 **示例**（须写在 `ProbeConfig` 下）：
 
@@ -152,9 +152,9 @@ tr '\0' ' ' < /proc/<PID>/cmdline; echo
 ProbeConfig:
   CmdlineWhitelist:
     - AgentType: openclaw
-      Rule: ["node*", "*openclaw*"]
+      Args: ["node*", "*openclaw*"]
     - AgentType: hermes
-      Rule: ["*python*", "*hermes*"]
+      Args: ["*python*", "*hermes*"]
 ```
 
 同一进程命中多条规则时，**采集仍生效**；`gen_ai.agent.type` 取**列表中第一条**命中规则的 `AgentType`。若需固定类型，把更具体的规则排在前面，或避免 glob 重叠。
@@ -218,9 +218,9 @@ inputs:
       LogPath: ""
       CmdlineWhitelist:
         - AgentType: claude-code
-          Rule: ["node*", "*claude*"]
+          Args: ["node*", "*claude*"]
         - AgentType: hermes
-          Rule: ["node*", "*hermes*"]
+          Args: ["node*", "*hermes*"]
       CmdlineBlacklist:
         - ["node*", "*webpack*"]
       DomainWhitelist:


### PR DESCRIPTION
## Background
The original AgentSight configuration used a nested schema with bare string-array rules, which was hard to extend
and did not align with GenAI semantic conventions. This PR refactors the schema, field naming, and user docs.
## Scope of Changes
1. **Flatten the configuration schema**: Replaces nested `CmdlineRules` / `DomainRules` with flat
   `CmdlineWhitelist` / `CmdlineBlacklist` / `DomainWhitelist`, and explicitly rejects legacy forms.
2. **Promote rule entries to objects**: Each `CmdlineWhitelist` entry becomes a `{AgentType, Args}` object,
   allowing explicit agent naming and future field extension.
3. **Align output field with GenAI semantic conventions**: Renames the emitted field `gen_ai.agent.name` to
   `gen_ai.agent.type`; built-in default agent types are migrated to lowercase-hyphenated form
   (`openclaw` / `claude-code` / `hermes` / `cosh`).
4. **Third-party dependency bump**: Upgrades the `core/_thirdparty/coolbpf` submodule from `714a6b8e` to `e0fecfe3`.
5. **Tests and docs sync**: Updates unit tests (`SecurityOptionsUnittest`, etc.) and the user doc
   `input_agentsight.md` to reflect the new schema and field naming.
## Known Issues / Caveats
- **Breaking change**: Legacy `CmdlineRules` / `DomainRules`, lowercase keys, bare-array rules, and
  `gen_ai.agent.name` no longer work. Existing configs and downstream consumers must migrate; no deprecation
  warning layer is provided.
- The `coolbpf` submodule bump spans a large range; actual BPF program changes are not visible in this PR's diff
  and need independent validation under the production BPF environment.