### PR TITLE
Add AgentSight LLM tool definitions passthrough

### DIFF
--- a/core/ebpf/plugin/agentsight/AgentsightEvents.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightEvents.cpp
@@ -28,8 +28,8 @@ static std::string CopyCStr(const char* s) {
 }
 
 static std::string CopyBuffer(const char* p, uint32_t len) {
-    // agentsight.h: request_messages / response_messages are (ptr, len), not necessarily NUL-terminated
-    // in the middle; copy exactly len bytes (no read past len).
+    // agentsight.h: request_messages / response_messages / tools are (ptr, len), not necessarily
+    // NUL-terminated in the middle; copy exactly len bytes (no read past len).
     if (!p || len == 0) {
         return {};
     }
@@ -64,6 +64,7 @@ AgentsightLlmRecord::AgentsightLlmRecord(std::string pipelineConfigName, const A
     mFinishReason = CopyCStr(d.finish_reason);
     mRequestMessagesJson = CopyBuffer(d.request_messages, d.request_messages_len);
     mResponseMessagesJson = CopyBuffer(d.response_messages, d.response_messages_len);
+    mToolDefinitionsJson = CopyBuffer(d.tools, d.tools_len);
 }
 
 } // namespace logtail::ebpf

--- a/core/ebpf/plugin/agentsight/AgentsightEvents.h
+++ b/core/ebpf/plugin/agentsight/AgentsightEvents.h
@@ -56,6 +56,7 @@ public:
     std::string mFinishReason;
     std::string mRequestMessagesJson;
     std::string mResponseMessagesJson;
+    std::string mToolDefinitionsJson;
 };
 
 } // namespace logtail::ebpf

--- a/core/ebpf/plugin/agentsight/AgentsightManager.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.cpp
@@ -580,6 +580,7 @@ int AgentsightManager::HandleEvent(const std::shared_ptr<CommonEvent>& event) {
 
     setStr(StringView("gen_ai.input.messages"), rec->mRequestMessagesJson);
     setStr(StringView("gen_ai.output.messages"), rec->mResponseMessagesJson);
+    setStr(StringView("gen_ai.tool.definitions"), rec->mToolDefinitionsJson);
 
     std::unique_ptr<ProcessQueueItem> item = std::make_unique<ProcessQueueItem>(std::move(eventGroup), pluginIndex);
     if (QueueStatus::OK == ProcessQueueManager::GetInstance()->PushQueue(queueKey, std::move(item))) {

--- a/core/unittest/ebpf/AgentsightEventsUnittest.cpp
+++ b/core/unittest/ebpf/AgentsightEventsUnittest.cpp
@@ -26,16 +26,20 @@ public:
 void AgentsightEventsUnittest::TestLlmRecordCopiesNonNullSizedBuffers() {
     static const char kReq[] = {'{', 'a'};
     static const char kRes[] = {'b', 'c', 'd'};
+    static const char kTools[] = {'[', '{', '}', ']'};
 
     AgentsightLLMData d{};
     d.request_messages = kReq;
     d.request_messages_len = 2;
     d.response_messages = kRes;
     d.response_messages_len = 3;
+    d.tools = kTools;
+    d.tools_len = 4;
 
     AgentsightLlmRecord r("pipe-a", d);
     APSARA_TEST_EQUAL(r.mRequestMessagesJson, "{a");
     APSARA_TEST_EQUAL(r.mResponseMessagesJson, "bcd");
+    APSARA_TEST_EQUAL(r.mToolDefinitionsJson, "[{}]");
 }
 
 UNIT_TEST_CASE(AgentsightEventsUnittest, TestLlmRecordCopiesNonNullSizedBuffers)

--- a/docs/cn/plugins/input/native/input_agentsight.md
+++ b/docs/cn/plugins/input/native/input_agentsight.md
@@ -196,6 +196,7 @@ DomainWhitelist:
 | `gen_ai.usage.cache_read.input_tokens` | string | 本次请求中，直接从已有缓存中命中并读取的输入 Token 数量（十进制字符串） |
 | `gen_ai.input.messages` | string | 大模型请求 message 的序列化 json |
 | `gen_ai.output.messages` | string | 大模型回复 message 的序列化 json |
+| `gen_ai.tool.definitions` | string | 大模型请求中提供的工具（function/tool 定义）数组的序列化 json，例如 OpenAI 的 `tools` 字段、Anthropic 的 `tools` 字段。无工具时为 `[]`，请求未携带该字段时不输出。 |
 
 本表字段均由插件 `SetContent` 写入日志内容，**键值类型均为字符串**。其中带数值语义的字段以十进制文本（或 `is_sse` 的 `1`/`0`）落盘，与实现一致；并非日志 schema 中的强类型整型/浮点列。
 
@@ -261,6 +262,22 @@ flushers:
         }
       ],
       "finish_reason": "stop"
+    }
+  ],
+  "gen_ai.tool.definitions": [
+    {
+      "type": "function",
+      "function": {
+        "name": "read",
+        "description": "Read file contents",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "path": {"type": "string"}
+          },
+          "required": ["path"]
+        }
+      }
     }
   ],
   "gen_ai.provider.name": "openai",


### PR DESCRIPTION
## Background
The `agentsight` FFI added a new `tools` field on `AgentsightLLMData` (function / tool definitions carried in the
request), which needs to be forwarded from the Rust side into the `gen_ai.tool.definitions` log field so downstream
can see the tool set available to a single LLM call.

## Scope of Changes
1. **Third-party dependency**: Bumps the `core/_thirdparty/coolbpf` submodule to pick up the new
   `AgentsightLLMData.tools / tools_len` fields.
2. **Event record**: Adds `mToolDefinitionsJson` to `AgentsightLlmRecord`, reusing the same `CopyBuffer(ptr, len)`
   deep-copy path as messages.
3. **Log field**: `AgentsightManager::HandleEvent` emits `gen_ai.tool.definitions` via `setStr`, keeping the
   empty-string-skipped semantics.
4. **Tests and docs**: Extends `AgentsightEventsUnittest` to cover the tools copy; updates `input_agentsight.md`
   output table and the sample JSON to include the new field.