### PR TITLE
Implement centralized memory lock limit adjustment for eBPF plugins

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
   "mounts": [
     { "source": "/sys", "target": "/sys", "type": "bind" },
     { "source": "/", "target": "/logtail_host", "type": "bind" },
-    { "source": "loongcollector-dind-data-${localWorkspaceFolderBasename}", "target": "/var/lib/docker", "type": "volume" }
+    { "source": "loongcollector-dind-data", "target": "/var/lib/docker", "type": "volume" }
   ],
   "runArgs": [
     "--cap-add=SYS_PTRACE",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
   "mounts": [
     { "source": "/sys", "target": "/sys", "type": "bind" },
     { "source": "/", "target": "/logtail_host", "type": "bind" },
-    { "source": "loongcollector-dind-data", "target": "/var/lib/docker", "type": "volume" }
+    { "source": "loongcollector-dind-data-${localWorkspaceFolderBasename}", "target": "/var/lib/docker", "type": "volume" }
   ],
   "runArgs": [
     "--cap-add=SYS_PTRACE",

--- a/core/ebpf/EBPFServer.cpp
+++ b/core/ebpf/EBPFServer.cpp
@@ -14,7 +14,10 @@
 
 #include "ebpf/EBPFServer.h"
 
+#include <sys/resource.h>
+
 #include <cerrno>
+#include <cstring>
 
 #include <future>
 #include <shared_mutex>
@@ -49,6 +52,41 @@ namespace logtail::ebpf {
 static const uint16_t kKernelVersion310 = 3010; // for centos7
 static const std::string kKernelNameCentos = "CentOS";
 static const uint16_t kKernelCentosMinVersion = 7006;
+
+namespace {
+
+// Raise RLIMIT_MEMLOCK to RLIM_INFINITY for the whole process before any eBPF map / program is
+// created. Centralised here so every eBPF plugin (driver-based ones via start_plugin and
+// AgentSight via libagentsight FFI) shares the same one-shot setup. setrlimit is per-process, so
+// a single successful call covers all subsequent BPF loads regardless of which plugin triggers
+// them.
+//
+// Notes:
+// - Idempotent: extra calls are cheap and have no side effects.
+// - Requires CAP_SYS_RESOURCE to raise the hard limit above what the container runtime / systemd
+//   inherited; failure (EPERM) is logged but not fatal — modern kernels (>= 5.11) account BPF
+//   memory via memcg, so a low memlock hard limit alone usually does not block BPF loading.
+// - Diagnostic: success path also logs the effective rlim_cur/rlim_max via getrlimit so operators
+//   can tell whether the bump was clamped by an upper limit (e.g. dockerd default ulimit).
+void BumpMemlockRlimit() {
+    struct rlimit rlimNew = {RLIM_INFINITY, RLIM_INFINITY};
+    if (setrlimit(RLIMIT_MEMLOCK, &rlimNew) != 0) {
+        const int err = errno;
+        LOG_WARNING(sLogger,
+                    ("eBPF", "setrlimit(RLIMIT_MEMLOCK, INFINITY) failed; BPF map creation may "
+                             "fail on older kernels or memlock-constrained containers")(
+                        "errno", err)("errstr", std::strerror(err)));
+        return;
+    }
+    struct rlimit rlimCur{};
+    if (getrlimit(RLIMIT_MEMLOCK, &rlimCur) == 0) {
+        LOG_INFO(sLogger,
+                 ("eBPF", "setrlimit(RLIMIT_MEMLOCK) ok")("rlim_cur", rlimCur.rlim_cur)(
+                     "rlim_max", rlimCur.rlim_max));
+    }
+}
+
+} // namespace
 
 bool EnvManager::IsSupportedEnv(PluginType type) {
     if (!mInited) {
@@ -220,6 +258,12 @@ void EBPFServer::Init() {
     }
     mInited = true;
     mRunning = true;
+
+    // Raise RLIMIT_MEMLOCK once for the whole process before any plugin starts loading BPF
+    // programs/maps. Previously this was duplicated inside eBPFDriver::start_plugin (which the
+    // AgentSight path bypasses) and AgentsightManager::Init; centralising it here covers every
+    // eBPF plugin, driver-based or FFI-based.
+    BumpMemlockRlimit();
 
     AsynCurlRunner::GetInstance()->Init();
     mEBPFAdapter->Init(); // Idempotent; loads optional AgentSight symbols before poller threads run.

--- a/core/ebpf/EBPFServer.cpp
+++ b/core/ebpf/EBPFServer.cpp
@@ -14,10 +14,9 @@
 
 #include "ebpf/EBPFServer.h"
 
-#include <sys/resource.h>
-
 #include <cerrno>
 #include <cstring>
+#include <sys/resource.h>
 
 #include <future>
 #include <shared_mutex>
@@ -72,17 +71,17 @@ void BumpMemlockRlimit() {
     struct rlimit rlimNew = {RLIM_INFINITY, RLIM_INFINITY};
     if (setrlimit(RLIMIT_MEMLOCK, &rlimNew) != 0) {
         const int err = errno;
-        LOG_WARNING(sLogger,
-                    ("eBPF", "setrlimit(RLIMIT_MEMLOCK, INFINITY) failed; BPF map creation may "
-                             "fail on older kernels or memlock-constrained containers")(
-                        "errno", err)("errstr", std::strerror(err)));
+        LOG_WARNING(
+            sLogger,
+            ("eBPF",
+             "setrlimit(RLIMIT_MEMLOCK, INFINITY) failed; BPF map creation may "
+             "fail on older kernels or memlock-constrained containers")("errno", err)("errstr", std::strerror(err)));
         return;
     }
-    struct rlimit rlimCur{};
+    struct rlimit rlimCur {};
     if (getrlimit(RLIMIT_MEMLOCK, &rlimCur) == 0) {
         LOG_INFO(sLogger,
-                 ("eBPF", "setrlimit(RLIMIT_MEMLOCK) ok")("rlim_cur", rlimCur.rlim_cur)(
-                     "rlim_max", rlimCur.rlim_max));
+                 ("eBPF", "setrlimit(RLIMIT_MEMLOCK) ok")("rlim_cur", rlimCur.rlim_cur)("rlim_max", rlimCur.rlim_max));
     }
 }
 

--- a/core/ebpf/driver/eBPFDriver.cpp
+++ b/core/ebpf/driver/eBPFDriver.cpp
@@ -28,7 +28,6 @@ extern "C" {
 #include <coolbpf/security/bpf_process_event_type.h>
 #include <coolbpf/security/data_msg.h>
 #include <coolbpf/security/msg_type.h>
-#include <sys/resource.h>
 
 #include "ebpf/driver/eBPFDriver.h"
 }
@@ -51,19 +50,6 @@ void* __wrap_memcpy(void* dest, const void* src, size_t n) {
 
 int set_logger(logtail::ebpf::eBPFLogHandler fn) {
     set_log_handler(fn);
-    return 0;
-}
-
-int bump_memlock_rlimit(void) {
-    struct rlimit rlim_new = {
-        .rlim_cur = RLIM_INFINITY,
-        .rlim_max = RLIM_INFINITY,
-    };
-
-    if (0 != setrlimit(RLIMIT_MEMLOCK, &rlim_new)) {
-        EBPF_LOG(logtail::ebpf::eBPFLogType::NAMI_LOG_TYPE_WARN, "Failed to increase RLIMIT_MEMLOCK limit!\n");
-        return -1;
-    }
     return 0;
 }
 
@@ -171,10 +157,9 @@ int start_plugin(logtail::ebpf::PluginConfig* arg) {
     // 1. load skeleton
     // 2. start consumer
     // 3. attach prog
+    // RLIMIT_MEMLOCK is bumped once in EBPFServer::Init() for the whole process, so individual
+    // plugin start paths no longer need to call setrlimit themselves.
     EBPF_LOG(logtail::ebpf::eBPFLogType::NAMI_LOG_TYPE_DEBUG, "enter start_plugin, arg is null: %d \n", arg == nullptr);
-    if (0 != bump_memlock_rlimit()) {
-        return -1;
-    }
 
     // TODO: The coolbpf_set_loglevel API isn't ideal anyway
     libbpf_set_print(libbpf_printf);

--- a/core/ebpf/driver/eBPFDriver.cpp
+++ b/core/ebpf/driver/eBPFDriver.cpp
@@ -157,7 +157,6 @@ int start_plugin(logtail::ebpf::PluginConfig* arg) {
     // 1. load skeleton
     // 2. start consumer
     // 3. attach prog
-    // RLIMIT_MEMLOCK is bumped once in EBPFServer::Init() for the whole process, so individual
     // plugin start paths no longer need to call setrlimit themselves.
     EBPF_LOG(logtail::ebpf::eBPFLogType::NAMI_LOG_TYPE_DEBUG, "enter start_plugin, arg is null: %d \n", arg == nullptr);
 

--- a/docs/cn/plugins/input/native/input_agentsight.md
+++ b/docs/cn/plugins/input/native/input_agentsight.md
@@ -10,7 +10,7 @@ dev
 
 ## 版本说明
 
-* 推荐版本：LoongCollector v3.1.4 及以上
+* 推荐版本：LoongCollector v3.3.4 及以上
 
 ## 配置参数
 


### PR DESCRIPTION
Background
==========
RLIMIT_MEMLOCK was being raised inside eBPFDriver::start_plugin, which is only
invoked by NETWORK_OBSERVE / NETWORK_SECURITY / FILE_SECURITY / PROCESS_SECURITY.
The AgentSight plugin bypasses start_plugin entirely (AgentsightManager calls
libagentsight FFI handle_new directly), so when AgentSight is the only active
eBPF plugin, no setrlimit ever runs and BPF map creation fails on containers
with the dockerd/containerd default 64 KiB memlock hard limit.

This was masked previously because:
- non-container hosts default to high or unlimited memlock;
- when other eBPF plugins were enabled alongside AgentSight, their start_plugin
  bumped the rlimit process-wide and AgentSight inherited it.

Changes
=======
- Move the bump to EBPFServer::Init() so it runs once per process, regardless
  of which eBPF plugin is enabled (driver-based or FFI-based).
- Add diagnostic logging: errno+strerror on failure, effective rlim_cur/rlim_max
  via getrlimit on success (helps detect container-runtime clamp).
- Drop bump_memlock_rlimit from eBPFDriver.cpp; it has no external callers
  (not exposed via eBPFDriver.h, not registered in EBPFAdapter::ebpf_func).

No behavioural change for environments that already had multiple eBPF plugins
enabled. Fixes AgentSight-only deployments in memlock-constrained sidecars.