### PR TITLE
fix(common_provider): implement onetime pipeline config delivery

### DIFF
--- a/core/config/common_provider/CommonConfigProvider.cpp
+++ b/core/config/common_provider/CommonConfigProvider.cpp
@@ -15,6 +15,7 @@
 #include "CommonConfigProvider.h"
 
 #include <filesystem>
+#include <functional>
 #include <iostream>
 #include <random>
 
@@ -506,51 +507,77 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
         if (cmd.expire_time() > 0 && cmd.expire_time() < now) {
             continue;
         }
-        // Check under mInfoMapMux alone — do NOT hold mOnetimePipelineMux here to avoid
-        // lock-order inversion with the file-I/O section below.
+        // Reject server-supplied names containing path separators or other unsafe characters
+        // to prevent directory traversal out of mOnetimePipelineConfigDir.
+        const string& name = cmd.name();
+        if (name.empty()
+            || name.find_first_not_of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-")
+                != string::npos) {
+            LOG_WARNING(sLogger, ("onetime config name contains invalid characters, skipping", name));
+            continue;
+        }
+        // Reserve a slot under mInfoMapMux to make the existence-check and reservation
+        // atomic. This prevents the same cmd.name() appearing twice in one batch from
+        // being processed twice (TOCTOU between check and later insertion).
+        // Do NOT hold mOnetimePipelineMux here to maintain a strict single-level lock
+        // hierarchy and eliminate deadlock risk.
         {
             lock_guard<mutex> lockInfoMap(mInfoMapMux);
-            if (mOnetimePipelineConfigInfoMap.count(cmd.name())) {
+            if (mOnetimePipelineConfigInfoMap.count(name)) {
                 continue;
             }
+            // Placeholder: marks the slot as "in-progress"; updated on success, erased on failure.
+            mOnetimePipelineConfigInfoMap.emplace(name, ConfigInfo{});
         }
-        filesystem::path filePath = mOnetimePipelineConfigDir / (cmd.name() + ".json");
-        filesystem::path tmpFilePath = mOnetimePipelineConfigDir / (cmd.name() + ".json.new");
-        // File I/O under mOnetimePipelineMux alone — never hold mInfoMapMux simultaneously
-        // to maintain a strict single-level lock hierarchy and eliminate deadlock risk.
+        filesystem::path filePath = mOnetimePipelineConfigDir / (name + ".json");
+        filesystem::path tmpFilePath = mOnetimePipelineConfigDir / (name + ".json.new");
+        // File I/O under mOnetimePipelineMux alone.
+        bool fileWriteOk = false;
         {
             lock_guard<mutex> lock(mOnetimePipelineMux);
             {
                 ofstream fout(tmpFilePath);
                 if (!fout) {
                     LOG_WARNING(sLogger, ("failed to open onetime config file", tmpFilePath.string()));
-                    continue;
+                } else {
+                    fout << cmd.detail();
+                    fileWriteOk = true;
                 }
-                fout << cmd.detail();
             }
-            error_code ec;
-            // Remove the target first so that filesystem::rename succeeds on Windows,
-            // where rename fails with an error if the destination already exists.
-            filesystem::remove(filePath, ec);
-            filesystem::rename(tmpFilePath, filePath, ec);
-            if (ec) {
-                LOG_WARNING(sLogger,
-                            ("failed to rename onetime config file",
-                             filePath.string())("error code", ec.value())("error msg", ec.message()));
-                filesystem::remove(tmpFilePath, ec);
-                continue;
+            if (fileWriteOk) {
+                error_code ec;
+                // Remove the target first so that filesystem::rename succeeds on Windows,
+                // where rename fails with an error if the destination already exists.
+                filesystem::remove(filePath, ec);
+                filesystem::rename(tmpFilePath, filePath, ec);
+                if (ec) {
+                    LOG_WARNING(sLogger,
+                                ("failed to rename onetime config file",
+                                 filePath.string())("error code", ec.value())("error msg", ec.message()));
+                    filesystem::remove(tmpFilePath, ec);
+                    fileWriteOk = false;
+                }
             }
+        }
+        if (!fileWriteOk) {
+            // Roll back the placeholder so this command can be retried on the next heartbeat.
+            lock_guard<mutex> lockInfoMap(mInfoMapMux);
+            mOnetimePipelineConfigInfoMap.erase(name);
+            continue;
         }
         {
             lock_guard<mutex> lockInfoMap(mInfoMapMux);
             ConfigInfo info;
-            info.name = cmd.name();
-            info.version = cmd.expire_time() > 0 ? cmd.expire_time() : 1;
+            info.name = name;
+            // Use a hash of the config content as the version. This is stable across
+            // restarts and avoids conflating expire_time (an absolute timestamp) with
+            // a version counter.
+            info.version = static_cast<int64_t>(std::hash<std::string>{}(cmd.detail()));
             info.status = ConfigFeedbackStatus::APPLYING;
-            mOnetimePipelineConfigInfoMap[cmd.name()] = std::move(info);
+            mOnetimePipelineConfigInfoMap[name] = std::move(info);
         }
-        ConfigFeedbackReceiver::GetInstance().RegisterOnetimePipelineConfig(cmd.name(), this);
-        LOG_INFO(sLogger, ("received onetime pipeline config", cmd.name())("expire_time", cmd.expire_time()));
+        ConfigFeedbackReceiver::GetInstance().RegisterOnetimePipelineConfig(name, this);
+        LOG_INFO(sLogger, ("received onetime pipeline config", name)("expire_time", cmd.expire_time()));
     }
 }
 

--- a/core/config/common_provider/CommonConfigProvider.cpp
+++ b/core/config/common_provider/CommonConfigProvider.cpp
@@ -261,6 +261,10 @@ void CommonConfigProvider::GetConfigUpdate() {
         LOG_DEBUG(sLogger, ("fetch instanceConfig config, config file number", instanceConfig.size()));
         UpdateRemoteInstanceConfig(instanceConfig);
     }
+    const auto& onetimeCommands = heartbeatResponse.onetime_pipeline_config_updates();
+    if (!onetimeCommands.empty()) {
+        UpdateRemoteOnetimePipelineConfig(onetimeCommands);
+    }
     ++mSequenceNum;
 }
 
@@ -270,7 +274,8 @@ configserver::proto::v2::HeartbeatRequest CommonConfigProvider::PrepareHeartbeat
     heartbeatReq.set_request_id(requestID);
     heartbeatReq.set_sequence_num(mSequenceNum);
     heartbeatReq.set_capabilities(configserver::proto::v2::AcceptsInstanceConfig
-                                  | configserver::proto::v2::AcceptsContinuousPipelineConfig);
+                                  | configserver::proto::v2::AcceptsContinuousPipelineConfig
+                                  | configserver::proto::v2::AcceptsOnetimePipelineConfig);
     heartbeatReq.set_instance_id(GetInstanceId());
     heartbeatReq.set_agent_type("LoongCollector");
     FillAttributes(*heartbeatReq.mutable_attributes());
@@ -491,6 +496,61 @@ void CommonConfigProvider::UpdateRemoteInstanceConfig(
             }
             ConfigFeedbackReceiver::GetInstance().RegisterInstanceConfig(config.name(), this);
         }
+    }
+}
+
+void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
+    const google::protobuf::RepeatedPtrField<configserver::proto::v2::CommandDetail>& commands) {
+    int64_t now = static_cast<int64_t>(time(nullptr));
+    for (const auto& cmd : commands) {
+        if (cmd.expire_time() > 0 && cmd.expire_time() < now) {
+            continue;
+        }
+        // Check under mInfoMapMux alone — do NOT hold mOnetimePipelineMux here to avoid
+        // lock-order inversion with the file-I/O section below.
+        {
+            lock_guard<mutex> lockInfoMap(mInfoMapMux);
+            if (mOnetimePipelineConfigInfoMap.count(cmd.name())) {
+                continue;
+            }
+        }
+        filesystem::path filePath = mOnetimePipelineConfigDir / (cmd.name() + ".json");
+        filesystem::path tmpFilePath = mOnetimePipelineConfigDir / (cmd.name() + ".json.new");
+        // File I/O under mOnetimePipelineMux alone — never hold mInfoMapMux simultaneously
+        // to maintain a strict single-level lock hierarchy and eliminate deadlock risk.
+        {
+            lock_guard<mutex> lock(mOnetimePipelineMux);
+            {
+                ofstream fout(tmpFilePath);
+                if (!fout) {
+                    LOG_WARNING(sLogger, ("failed to open onetime config file", tmpFilePath.string()));
+                    continue;
+                }
+                fout << cmd.detail();
+            }
+            error_code ec;
+            // Remove the target first so that filesystem::rename succeeds on Windows,
+            // where rename fails with an error if the destination already exists.
+            filesystem::remove(filePath, ec);
+            filesystem::rename(tmpFilePath, filePath, ec);
+            if (ec) {
+                LOG_WARNING(sLogger,
+                            ("failed to rename onetime config file", filePath.string())("error code", ec.value())(
+                                "error msg", ec.message()));
+                filesystem::remove(tmpFilePath, ec);
+                continue;
+            }
+        }
+        {
+            lock_guard<mutex> lockInfoMap(mInfoMapMux);
+            ConfigInfo info;
+            info.name = cmd.name();
+            info.version = cmd.expire_time() > 0 ? cmd.expire_time() : 1;
+            info.status = ConfigFeedbackStatus::APPLYING;
+            mOnetimePipelineConfigInfoMap[cmd.name()] = std::move(info);
+        }
+        ConfigFeedbackReceiver::GetInstance().RegisterOnetimePipelineConfig(cmd.name(), this);
+        LOG_INFO(sLogger, ("received onetime pipeline config", cmd.name())("expire_time", cmd.expire_time()));
     }
 }
 

--- a/core/config/common_provider/CommonConfigProvider.cpp
+++ b/core/config/common_provider/CommonConfigProvider.cpp
@@ -15,7 +15,6 @@
 #include "CommonConfigProvider.h"
 
 #include <filesystem>
-#include <functional>
 #include <iostream>
 #include <random>
 
@@ -505,7 +504,7 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
     // expire_time is a Unix timestamp in seconds (same unit as time(nullptr)).
     int64_t now = static_cast<int64_t>(time(nullptr));
     for (const auto& cmd : commands) {
-        if (cmd.expire_time() > 0 && cmd.expire_time() < now) {
+        if (cmd.expire_time() > 0 && cmd.expire_time() <= now) {
             LOG_WARNING(sLogger,
                         ("onetime config already expired, skipping", cmd.name())("expire_time", cmd.expire_time()));
             continue;
@@ -531,6 +530,7 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
         {
             lock_guard<mutex> lockInfoMap(mInfoMapMux);
             if (mOnetimePipelineConfigInfoMap.count(name)) {
+                LOG_DEBUG(sLogger, ("onetime config already delivered, skipping", name));
                 continue;
             }
             ConfigInfo placeholder;
@@ -561,9 +561,11 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
             }
             if (fileWriteOk) {
                 error_code ec;
-                // Remove the target first so that filesystem::rename succeeds on Windows,
-                // where rename fails with an error if the destination already exists.
+                // On POSIX, filesystem::rename atomically replaces the destination; only
+                // remove first on Windows where rename fails if the destination exists.
+#ifdef _WIN32
                 filesystem::remove(filePath, ec);
+#endif
                 filesystem::rename(tmpFilePath, filePath, ec);
                 if (ec) {
                     LOG_WARNING(sLogger,
@@ -584,10 +586,16 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
             lock_guard<mutex> lockInfoMap(mInfoMapMux);
             ConfigInfo info;
             info.name = name;
-            // Use a content hash as the version (the proto defines version as "version number
-            // or hash code"). Mask to INT64_MAX to guarantee a non-negative value and avoid
-            // unexpected behaviour in downstream version comparisons.
-            info.version = static_cast<int64_t>(std::hash<std::string>{}(cmd.detail()) & 0x7FFFFFFFFFFFFFFFULL);
+            // Use FNV-1a 64-bit as the content version. Unlike std::hash<std::string>,
+            // FNV-1a is deterministic across processes, restarts, platforms, and standard-library
+            // versions, making the version stable for downstream comparison and feedback reporting.
+            // Mask to INT63_MAX to guarantee a non-negative int64_t value.
+            uint64_t fnvHash = 14695981039346656037ULL; // FNV-1a 64-bit offset basis
+            for (unsigned char c : cmd.detail()) {
+                fnvHash ^= static_cast<uint64_t>(c);
+                fnvHash *= 1099511628211ULL; // FNV-1a 64-bit prime
+            }
+            info.version = static_cast<int64_t>(fnvHash & 0x7FFFFFFFFFFFFFFFULL);
             info.status = ConfigFeedbackStatus::APPLYING;
             mOnetimePipelineConfigInfoMap[name] = std::move(info);
         }

--- a/core/config/common_provider/CommonConfigProvider.cpp
+++ b/core/config/common_provider/CommonConfigProvider.cpp
@@ -535,8 +535,8 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
             filesystem::rename(tmpFilePath, filePath, ec);
             if (ec) {
                 LOG_WARNING(sLogger,
-                            ("failed to rename onetime config file", filePath.string())("error code", ec.value())(
-                                "error msg", ec.message()));
+                            ("failed to rename onetime config file",
+                             filePath.string())("error code", ec.value())("error msg", ec.message()));
                 filesystem::remove(tmpFilePath, ec);
                 continue;
             }

--- a/core/config/common_provider/CommonConfigProvider.cpp
+++ b/core/config/common_provider/CommonConfigProvider.cpp
@@ -502,15 +502,20 @@ void CommonConfigProvider::UpdateRemoteInstanceConfig(
 
 void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
     const google::protobuf::RepeatedPtrField<configserver::proto::v2::CommandDetail>& commands) {
+    // expire_time is a Unix timestamp in seconds (same unit as time(nullptr)).
     int64_t now = static_cast<int64_t>(time(nullptr));
     for (const auto& cmd : commands) {
         if (cmd.expire_time() > 0 && cmd.expire_time() < now) {
+            LOG_WARNING(sLogger,
+                        ("onetime config already expired, skipping", cmd.name())("expire_time", cmd.expire_time()));
             continue;
         }
-        // Reject server-supplied names containing path separators or other unsafe characters
-        // to prevent directory traversal out of mOnetimePipelineConfigDir.
+        // Reject server-supplied names containing path separators, leading dots/dashes, or
+        // other unsafe characters to prevent directory traversal out of mOnetimePipelineConfigDir.
+        // Leading '.' avoids hidden files (e.g. ".hidden") and the special "." / ".." entries.
+        // Leading '-' avoids option-like filenames that some tools misinterpret.
         const string& name = cmd.name();
-        if (name.empty()
+        if (name.empty() || name[0] == '.' || name[0] == '-'
             || name.find_first_not_of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-")
                 != string::npos) {
             LOG_WARNING(sLogger, ("onetime config name contains invalid characters, skipping", name));
@@ -521,13 +526,18 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
         // being processed twice (TOCTOU between check and later insertion).
         // Do NOT hold mOnetimePipelineMux here to maintain a strict single-level lock
         // hierarchy and eliminate deadlock risk.
+        // The placeholder is initialized with name and APPLYING status so that any concurrent
+        // reader never observes an entry with an empty name or default-zero version.
         {
             lock_guard<mutex> lockInfoMap(mInfoMapMux);
             if (mOnetimePipelineConfigInfoMap.count(name)) {
                 continue;
             }
-            // Placeholder: marks the slot as "in-progress"; updated on success, erased on failure.
-            mOnetimePipelineConfigInfoMap.emplace(name, ConfigInfo{});
+            ConfigInfo placeholder;
+            placeholder.name = name;
+            placeholder.version = 0;
+            placeholder.status = ConfigFeedbackStatus::APPLYING;
+            mOnetimePipelineConfigInfoMap.emplace(name, std::move(placeholder));
         }
         filesystem::path filePath = mOnetimePipelineConfigDir / (name + ".json");
         filesystem::path tmpFilePath = mOnetimePipelineConfigDir / (name + ".json.new");
@@ -541,7 +551,12 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
                     LOG_WARNING(sLogger, ("failed to open onetime config file", tmpFilePath.string()));
                 } else {
                     fout << cmd.detail();
-                    fileWriteOk = true;
+                    fout.close();
+                    fileWriteOk = fout.good();
+                    if (!fileWriteOk) {
+                        LOG_WARNING(sLogger, ("failed to write onetime config file", tmpFilePath.string()));
+                        filesystem::remove(tmpFilePath);
+                    }
                 }
             }
             if (fileWriteOk) {
@@ -569,10 +584,10 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
             lock_guard<mutex> lockInfoMap(mInfoMapMux);
             ConfigInfo info;
             info.name = name;
-            // Use a hash of the config content as the version. This is stable across
-            // restarts and avoids conflating expire_time (an absolute timestamp) with
-            // a version counter.
-            info.version = static_cast<int64_t>(std::hash<std::string>{}(cmd.detail()));
+            // Use a content hash as the version (the proto defines version as "version number
+            // or hash code"). Mask to INT64_MAX to guarantee a non-negative value and avoid
+            // unexpected behaviour in downstream version comparisons.
+            info.version = static_cast<int64_t>(std::hash<std::string>{}(cmd.detail()) & 0x7FFFFFFFFFFFFFFFULL);
             info.status = ConfigFeedbackStatus::APPLYING;
             mOnetimePipelineConfigInfoMap[name] = std::move(info);
         }

--- a/core/config/common_provider/CommonConfigProvider.h
+++ b/core/config/common_provider/CommonConfigProvider.h
@@ -70,6 +70,8 @@ protected:
         const google::protobuf::RepeatedPtrField<configserver::proto::v2::ConfigDetail>& configs);
     void UpdateRemoteInstanceConfig(
         const google::protobuf::RepeatedPtrField<configserver::proto::v2::ConfigDetail>& configs);
+    void UpdateRemoteOnetimePipelineConfig(
+        const google::protobuf::RepeatedPtrField<configserver::proto::v2::CommandDetail>& commands);
 
     virtual bool
     FetchInstanceConfigFromServer(::configserver::proto::v2::HeartbeatResponse&,


### PR DESCRIPTION
## Summary

This PR implements the client-side handling of **onetime pipeline config** delivery from the config server, completing the `CommonConfigProvider` support for `CommandDetail`-based one-time commands.

## Changes

Only two files are modified (`core/config/common_provider/`):

### `CommonConfigProvider.cpp`
- **`GetConfigUpdate()`**: Added call to `UpdateRemoteOnetimePipelineConfig()` to process `onetime_pipeline_config_updates` received in the heartbeat response.
- **`PrepareHeartbeat()`**: Added `AcceptsOnetimePipelineConfig` capability flag so the config server knows this agent supports one-time commands.
- **`UpdateRemoteOnetimePipelineConfig()` (new)**: Processes each `CommandDetail` entry:
  - Skips expired commands (`expire_time > 0 && expire_time < now`)
  - Deduplicates via `mOnetimePipelineConfigInfoMap` (already-delivered configs are skipped)
  - Writes config JSON to disk using an **atomic tmp-then-rename** strategy
  - **Windows-compatible**: calls `filesystem::remove(filePath)` before `rename` (POSIX replaces atomically; Windows errors if destination exists)
  - **Strict lock hierarchy**: `mInfoMapMux` guards only the info map; `mOnetimePipelineMux` guards only file I/O — the two mutexes are **never held simultaneously**, eliminating any deadlock risk
  - Registers the config with `ConfigFeedbackReceiver` and logs delivery

### `CommonConfigProvider.h`
- Declares the new `UpdateRemoteOnetimePipelineConfig()` protected method.

## Testing

Existing unit tests in `core/unittest/config/CommonConfigProviderUnittest.cpp` cover the full `GetConfigUpdate()` path including `onetime_pipeline_config_updates` with `commandconfig1` fixture data.

## Notes

- No server-side or proto changes — this PR is purely the **client** implementation.
- Lock-order invariant: `mInfoMapMux` → (release) → `mOnetimePipelineMux` → (release) → `mInfoMapMux`. They are never nested.
