### PR TITLE
feat(common_provider): implement onetime pipeline config delivery

### DIFF
--- a/core/collection_pipeline/CollectionPipelineManager.cpp
+++ b/core/collection_pipeline/CollectionPipelineManager.cpp
@@ -58,18 +58,25 @@ void CollectionPipelineManager::UpdatePipelines(CollectionConfigDiff& diff) {
     // other threads only read mPipelineNameEntityMap, so we don't need to lock read here
     for (const auto& name : diff.mRemoved) {
         auto iter = mPipelineNameEntityMap.find(name);
+        bool isOnetime = iter->second->IsOnetime();
         iter->second->Stop(true);
         iter->second->RemoveProcessQueue();
         {
             unique_lock<shared_mutex> lock(mPipelineNameEntityMapMutex);
             mPipelineNameEntityMap.erase(name);
         }
-        ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(name,
-                                                                                     ConfigFeedbackStatus::DELETED);
+        if (isOnetime) {
+            ConfigFeedbackReceiver::GetInstance().FeedbackOnetimePipelineConfigStatus(name,
+                                                                                      ConfigFeedbackStatus::DELETED);
+        } else {
+            ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(name,
+                                                                                         ConfigFeedbackStatus::DELETED);
+        }
     }
     for (auto& config : diff.mModified) {
         // Save config name and collect input types before BuildPipeline moves config
         const string configName = config.mName;
+        const bool isOnetimeConfig = config.IsOnetime();
         std::set<std::string> newInputTypes;
         for (const auto& input : config.mInputs) {
             newInputTypes.insert((*input)["Type"].asString());
@@ -87,8 +94,13 @@ void CollectionPipelineManager::UpdatePipelines(CollectionConfigDiff& diff) {
                 config.mProject,
                 config.mName,
                 config.mLogstore);
-            ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(config.mName,
-                                                                                         ConfigFeedbackStatus::FAILED);
+            if (isOnetimeConfig) {
+                ConfigFeedbackReceiver::GetInstance().FeedbackOnetimePipelineConfigStatus(configName,
+                                                                                          ConfigFeedbackStatus::FAILED);
+            } else {
+                ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(configName,
+                                                                                             ConfigFeedbackStatus::FAILED);
+            }
             continue;
         }
         LOG_INFO(sLogger,
@@ -121,24 +133,35 @@ void CollectionPipelineManager::UpdatePipelines(CollectionConfigDiff& diff) {
             mPipelineNameEntityMap[configName] = p;
         }
         p->Start();
-        ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(configName,
-                                                                                     ConfigFeedbackStatus::APPLIED);
+        if (p->IsOnetime()) {
+            ConfigFeedbackReceiver::GetInstance().FeedbackOnetimePipelineConfigStatus(configName,
+                                                                                      ConfigFeedbackStatus::APPLIED);
+        } else {
+            ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(configName,
+                                                                                         ConfigFeedbackStatus::APPLIED);
+        }
     }
     for (auto& config : diff.mAdded) {
         const string configName = config.mName;
+        const bool isOnetimeConfig = config.IsOnetime();
         auto p = BuildPipeline(std::move(config));
         if (!p) {
             LOG_WARNING(sLogger,
-                        ("failed to build pipeline for new config", "skip current object")("config", config.mName));
+                        ("failed to build pipeline for new config", "skip current object")("config", configName));
             AlarmManager::GetInstance()->SendAlarmError(
                 CATEGORY_CONFIG_ALARM,
-                "failed to build pipeline for new config: skip current object, config: " + config.mName,
-                config.mRegion,
-                config.mProject,
-                config.mName,
-                config.mLogstore);
-            ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(config.mName,
-                                                                                         ConfigFeedbackStatus::FAILED);
+                "failed to build pipeline for new config: skip current object, config: " + configName,
+                "",
+                "",
+                configName,
+                "");
+            if (isOnetimeConfig) {
+                ConfigFeedbackReceiver::GetInstance().FeedbackOnetimePipelineConfigStatus(configName,
+                                                                                          ConfigFeedbackStatus::FAILED);
+            } else {
+                ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(configName,
+                                                                                             ConfigFeedbackStatus::FAILED);
+            }
             continue;
         }
         LOG_INFO(sLogger,
@@ -148,8 +171,13 @@ void CollectionPipelineManager::UpdatePipelines(CollectionConfigDiff& diff) {
             mPipelineNameEntityMap[configName] = p;
         }
         p->Start();
-        ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(configName,
-                                                                                     ConfigFeedbackStatus::APPLIED);
+        if (p->IsOnetime()) {
+            ConfigFeedbackReceiver::GetInstance().FeedbackOnetimePipelineConfigStatus(configName,
+                                                                                      ConfigFeedbackStatus::APPLIED);
+        } else {
+            ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(configName,
+                                                                                         ConfigFeedbackStatus::APPLIED);
+        }
     }
 
     // 在Flusher改造完成前，先不执行如下步骤，不会造成太大影响

--- a/core/config/common_provider/CommonConfigProvider.cpp
+++ b/core/config/common_provider/CommonConfigProvider.cpp
@@ -517,17 +517,22 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
         // Leading '.' avoids hidden files (e.g. ".hidden") and the special "." / ".." entries.
         // Leading '-' avoids option-like filenames that some tools misinterpret.
         const string& name = cmd.name();
+        // Truncate name in log messages to a fixed length to prevent log flooding
+        // from a misbehaving or hostile server sending oversized/non-printable names.
+        static constexpr size_t kMaxLoggedNameLen = 64;
         if (name.empty()) {
-            LOG_WARNING(sLogger, ("onetime config name is empty, skipping", name));
+            LOG_WARNING(sLogger, ("onetime config name is empty, skipping", ""));
             continue;
         }
         if (name[0] == '.' || name[0] == '-') {
-            LOG_WARNING(sLogger, ("onetime config name has invalid leading character, skipping", name));
+            LOG_DEBUG(sLogger, ("onetime config name has invalid leading character, skipping",
+                                name.substr(0, kMaxLoggedNameLen)));
             continue;
         }
         if (name.find_first_not_of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-")
             != string::npos) {
-            LOG_WARNING(sLogger, ("onetime config name contains disallowed characters, skipping", name));
+            LOG_DEBUG(sLogger, ("onetime config name contains disallowed characters, skipping",
+                                name.substr(0, kMaxLoggedNameLen)));
             continue;
         }
         // Reserve a slot under mInfoMapMux to make the existence-check and reservation
@@ -592,7 +597,8 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
                     LOG_WARNING(sLogger,
                                 ("failed to rename onetime config file",
                                  filePath.string())("error code", ec.value())("error msg", ec.message()));
-                    filesystem::remove(tmpFilePath, ec);
+                    error_code removeEc;
+                    filesystem::remove(tmpFilePath, removeEc);
                     fileWriteOk = false;
                 }
             }
@@ -606,7 +612,7 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
         // Compute the FNV-1a content hash outside the lock to keep the critical section short.
         // Use FNV-1a 64-bit: deterministic across processes, restarts, platforms, and
         // standard-library versions, making the version stable for downstream comparisons.
-        // Mask to INT63_MAX to guarantee a non-negative int64_t value.
+        // Mask to INT64_MAX to guarantee a non-negative int64_t value.
         uint64_t fnvHash = 14695981039346656037ULL; // FNV-1a 64-bit offset basis
         for (unsigned char c : cmd.detail()) {
             fnvHash ^= static_cast<uint64_t>(c);

--- a/core/config/common_provider/CommonConfigProvider.cpp
+++ b/core/config/common_provider/CommonConfigProvider.cpp
@@ -261,6 +261,10 @@ void CommonConfigProvider::GetConfigUpdate() {
         LOG_DEBUG(sLogger, ("fetch instanceConfig config, config file number", instanceConfig.size()));
         UpdateRemoteInstanceConfig(instanceConfig);
     }
+    const auto& onetimeCommands = heartbeatResponse.onetime_pipeline_config_updates();
+    if (!onetimeCommands.empty()) {
+        UpdateRemoteOnetimePipelineConfig(onetimeCommands);
+    }
     ++mSequenceNum;
 }
 
@@ -270,7 +274,8 @@ configserver::proto::v2::HeartbeatRequest CommonConfigProvider::PrepareHeartbeat
     heartbeatReq.set_request_id(requestID);
     heartbeatReq.set_sequence_num(mSequenceNum);
     heartbeatReq.set_capabilities(configserver::proto::v2::AcceptsInstanceConfig
-                                  | configserver::proto::v2::AcceptsContinuousPipelineConfig);
+                                  | configserver::proto::v2::AcceptsContinuousPipelineConfig
+                                  | configserver::proto::v2::AcceptsOnetimePipelineConfig);
     heartbeatReq.set_instance_id(GetInstanceId());
     heartbeatReq.set_agent_type("LoongCollector");
     FillAttributes(*heartbeatReq.mutable_attributes());
@@ -491,6 +496,119 @@ void CommonConfigProvider::UpdateRemoteInstanceConfig(
             }
             ConfigFeedbackReceiver::GetInstance().RegisterInstanceConfig(config.name(), this);
         }
+    }
+}
+
+void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
+    const google::protobuf::RepeatedPtrField<configserver::proto::v2::CommandDetail>& commands) {
+    // expire_time is a Unix timestamp in seconds (same unit as time(nullptr)).
+    int64_t now = static_cast<int64_t>(time(nullptr));
+    for (const auto& cmd : commands) {
+        if (cmd.expire_time() > 0 && cmd.expire_time() <= now) {
+            LOG_WARNING(sLogger,
+                        ("onetime config already expired, skipping", cmd.name())("expire_time", cmd.expire_time()));
+            continue;
+        }
+        // Reject server-supplied names containing path separators, leading dots/dashes, or
+        // other unsafe characters to prevent directory traversal out of mOnetimePipelineConfigDir.
+        // Leading '.' avoids hidden files (e.g. ".hidden") and the special "." / ".." entries.
+        // Leading '-' avoids option-like filenames that some tools misinterpret.
+        const string& name = cmd.name();
+        if (name.empty()) {
+            LOG_WARNING(sLogger, ("onetime config name is empty, skipping", name));
+            continue;
+        }
+        if (name[0] == '.' || name[0] == '-') {
+            LOG_WARNING(sLogger, ("onetime config name has invalid leading character, skipping", name));
+            continue;
+        }
+        if (name.find_first_not_of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-")
+            != string::npos) {
+            LOG_WARNING(sLogger, ("onetime config name contains disallowed characters, skipping", name));
+            continue;
+        }
+        // Reserve a slot under mInfoMapMux to make the existence-check and reservation
+        // atomic. This prevents the same cmd.name() appearing twice in one batch from
+        // being processed twice (TOCTOU between check and later insertion).
+        // Do NOT hold mOnetimePipelineMux here to maintain a strict single-level lock
+        // hierarchy and eliminate deadlock risk.
+        // The placeholder is initialized with name and APPLYING status so that any concurrent
+        // reader can distinguish an in-progress entry (version=0, status=APPLYING) from an
+        // unrelated default-constructed ConfigInfo.
+        {
+            lock_guard<mutex> lockInfoMap(mInfoMapMux);
+            if (mOnetimePipelineConfigInfoMap.count(name)) {
+                LOG_DEBUG(sLogger, ("onetime config already delivered, skipping", name));
+                continue;
+            }
+            ConfigInfo placeholder;
+            placeholder.name = name;
+            placeholder.version = 0;
+            placeholder.status = ConfigFeedbackStatus::APPLYING;
+            mOnetimePipelineConfigInfoMap.emplace(name, std::move(placeholder));
+        }
+        filesystem::path filePath = mOnetimePipelineConfigDir / (name + ".json");
+        filesystem::path tmpFilePath = mOnetimePipelineConfigDir / (name + ".json.new");
+        // File I/O under mOnetimePipelineMux alone.
+        bool fileWriteOk = false;
+        {
+            lock_guard<mutex> lock(mOnetimePipelineMux);
+            {
+                ofstream fout(tmpFilePath);
+                if (!fout) {
+                    LOG_WARNING(sLogger, ("failed to open onetime config file", tmpFilePath.string()));
+                } else {
+                    fout << cmd.detail();
+                    fout.close();
+                    fileWriteOk = fout.good();
+                    if (!fileWriteOk) {
+                        LOG_WARNING(sLogger, ("failed to write onetime config file", tmpFilePath.string()));
+                        filesystem::remove(tmpFilePath);
+                    }
+                }
+            }
+            if (fileWriteOk) {
+                error_code ec;
+                // On POSIX, filesystem::rename atomically replaces the destination; only
+                // remove first on Windows where rename fails if the destination exists.
+#ifdef _WIN32
+                filesystem::remove(filePath, ec);
+#endif
+                filesystem::rename(tmpFilePath, filePath, ec);
+                if (ec) {
+                    LOG_WARNING(sLogger,
+                                ("failed to rename onetime config file",
+                                 filePath.string())("error code", ec.value())("error msg", ec.message()));
+                    filesystem::remove(tmpFilePath, ec);
+                    fileWriteOk = false;
+                }
+            }
+        }
+        if (!fileWriteOk) {
+            // Roll back the placeholder so this command can be retried on the next heartbeat.
+            lock_guard<mutex> lockInfoMap(mInfoMapMux);
+            mOnetimePipelineConfigInfoMap.erase(name);
+            continue;
+        }
+        // Compute the FNV-1a content hash outside the lock to keep the critical section short.
+        // Use FNV-1a 64-bit: deterministic across processes, restarts, platforms, and
+        // standard-library versions, making the version stable for downstream comparisons.
+        // Mask to INT63_MAX to guarantee a non-negative int64_t value.
+        uint64_t fnvHash = 14695981039346656037ULL; // FNV-1a 64-bit offset basis
+        for (unsigned char c : cmd.detail()) {
+            fnvHash ^= static_cast<uint64_t>(c);
+            fnvHash *= 1099511628211ULL; // FNV-1a 64-bit prime
+        }
+        {
+            lock_guard<mutex> lockInfoMap(mInfoMapMux);
+            ConfigInfo info;
+            info.name = name;
+            info.version = static_cast<int64_t>(fnvHash & 0x7FFFFFFFFFFFFFFFULL);
+            info.status = ConfigFeedbackStatus::APPLYING;
+            mOnetimePipelineConfigInfoMap[name] = std::move(info);
+        }
+        ConfigFeedbackReceiver::GetInstance().RegisterOnetimePipelineConfig(name, this);
+        LOG_INFO(sLogger, ("received onetime pipeline config", name)("expire_time", cmd.expire_time()));
     }
 }
 

--- a/core/config/common_provider/CommonConfigProvider.cpp
+++ b/core/config/common_provider/CommonConfigProvider.cpp
@@ -206,7 +206,8 @@ void CommonConfigProvider::LoadConfigFile() {
         string content((istreambuf_iterator<char>(fin)), istreambuf_iterator<char>());
         fin.close();
         ConfigInfo info;
-        info.name = p.stem().string();
+        string fname = p.filename().string();
+        info.name = fname.substr(0, fname.size() - 5); // strip trailing ".json" (5 chars)
         info.version = ComputeOnetimeConfigVersion(content);
         info.status = ConfigFeedbackStatus::APPLIED;
         {
@@ -564,7 +565,8 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
             return;
         }
     }
-    // expire_time is a Unix timestamp in seconds (same unit as time(nullptr)).
+    // expire_time is a Unix timestamp in seconds; the config server populates it using
+    // time.Now().Unix() (see config_server/internal/server/agent/handler.go).
     int64_t now = static_cast<int64_t>(time(nullptr));
     for (const auto& cmd : commands) {
         if (cmd.expire_time() > 0 && cmd.expire_time() <= now) {
@@ -683,11 +685,12 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
             continue;
         }
         // Compute the FNV-1a content hash outside the lock to keep the critical section short.
+        int64_t version = ComputeOnetimeConfigVersion(cmd.detail());
         {
             // The placeholder already has name and APPLYING status; only update version.
             // In-place update avoids field-divergence if ConfigInfo gains new fields later.
             lock_guard<mutex> lockInfoMap(mInfoMapMux);
-            mOnetimePipelineConfigInfoMap[name].version = ComputeOnetimeConfigVersion(cmd.detail());
+            mOnetimePipelineConfigInfoMap[name].version = version;
         }
         ConfigFeedbackReceiver::GetInstance().RegisterOnetimePipelineConfig(name, this);
         LOG_INFO(sLogger, ("received onetime pipeline config", name)("expire_time", cmd.expire_time()));

--- a/core/config/common_provider/CommonConfigProvider.cpp
+++ b/core/config/common_provider/CommonConfigProvider.cpp
@@ -15,6 +15,7 @@
 #include "CommonConfigProvider.h"
 
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <random>
 
@@ -169,6 +170,47 @@ void CommonConfigProvider::LoadConfigFile() {
             ConfigFeedbackReceiver::GetInstance().RegisterInstanceConfig(info.name, this);
         }
     }
+    // Rebuild mOnetimePipelineConfigInfoMap from disk on startup to prevent re-delivery of
+    // already-applied onetime configs across process restarts.
+    // The directory may not exist yet (created lazily on first delivery), so ignore the error.
+    for (auto const& entry : filesystem::directory_iterator(mOnetimePipelineConfigDir, ec)) {
+        const filesystem::path& p = entry.path();
+        // Clean up any orphaned tmp files left by a crashed previous run.
+        if (p.extension() == ".new") {
+            filesystem::remove(p, ec);
+            continue;
+        }
+        if (p.extension() != ".json") {
+            continue;
+        }
+        // Compute version as FNV-1a hash of file content — consistent with the hash
+        // computed during write — so the server receives a stable, non-zero version.
+        ifstream fin(p, ios::binary);
+        if (!fin) {
+            continue;
+        }
+        string content((istreambuf_iterator<char>(fin)), istreambuf_iterator<char>());
+        fin.close();
+        uint64_t fnvHash = 14695981039346656037ULL;
+        for (unsigned char c : content) {
+            fnvHash ^= static_cast<uint64_t>(c);
+            fnvHash *= 1099511628211ULL;
+        }
+        ConfigInfo info;
+        info.name = p.stem().string();
+        info.version = static_cast<int64_t>(fnvHash & 0x7FFFFFFFFFFFFFFFULL);
+        info.status = ConfigFeedbackStatus::APPLIED;
+        {
+            lock_guard<mutex> lockInfoMap(mInfoMapMux);
+            mOnetimePipelineConfigInfoMap[info.name] = info;
+        }
+        ConfigFeedbackReceiver::GetInstance().RegisterOnetimePipelineConfig(info.name, this);
+    }
+    // NOTE: cleanup of delivered onetime config files and map entries is not performed here.
+    // The expire_time field in the server command is a delivery deadline (skip stale commands),
+    // not a config lifetime.  When a delivered onetime config should be removed, the server is
+    // expected to drive deletion via a future protocol extension (analogous to version=-1 for
+    // continuous configs).
 }
 
 void CommonConfigProvider::CheckUpdateThread() {
@@ -501,6 +543,18 @@ void CommonConfigProvider::UpdateRemoteInstanceConfig(
 
 void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
     const google::protobuf::RepeatedPtrField<configserver::proto::v2::CommandDetail>& commands) {
+    // Ensure the target directory exists before any file I/O.
+    // This follows the same pattern as UpdateRemotePipelineConfig / UpdateRemoteInstanceConfig.
+    {
+        error_code ec;
+        filesystem::create_directories(mOnetimePipelineConfigDir, ec);
+        if (ec) {
+            LOG_ERROR(sLogger,
+                      ("failed to create onetime config dir, skipping batch",
+                       mOnetimePipelineConfigDir.string())("error code", ec.value())("error msg", ec.message()));
+            return;
+        }
+    }
     // expire_time is a Unix timestamp in seconds (same unit as time(nullptr)).
     int64_t now = static_cast<int64_t>(time(nullptr));
     for (const auto& cmd : commands) {
@@ -525,14 +579,16 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
             continue;
         }
         if (name[0] == '.' || name[0] == '-') {
-            LOG_DEBUG(sLogger, ("onetime config name has invalid leading character, skipping",
-                                name.substr(0, kMaxLoggedNameLen)));
+            LOG_WARNING(sLogger,
+                        ("onetime config name has invalid leading character, skipping",
+                         name.substr(0, kMaxLoggedNameLen)));
             continue;
         }
         if (name.find_first_not_of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-")
             != string::npos) {
-            LOG_DEBUG(sLogger, ("onetime config name contains disallowed characters, skipping",
-                                name.substr(0, kMaxLoggedNameLen)));
+            LOG_WARNING(sLogger,
+                        ("onetime config name contains disallowed characters, skipping",
+                         name.substr(0, kMaxLoggedNameLen)));
             continue;
         }
         // Reserve a slot under mInfoMapMux to make the existence-check and reservation
@@ -541,13 +597,20 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
         // Do NOT hold mOnetimePipelineMux here to maintain a strict single-level lock
         // hierarchy and eliminate deadlock risk.
         // The placeholder is initialized with name and APPLYING status so that any concurrent
-        // reader can distinguish an in-progress entry (version=0, status=APPLYING) from an
-        // unrelated default-constructed ConfigInfo.
+        // reader (e.g. PrepareHeartbeat) can distinguish an in-progress entry
+        // (version=0, status=APPLYING) from a successfully delivered entry
+        // (version=<fnv_hash>, status=APPLIED/APPLYING-after-feedback).
+        // All readers that iterate mOnetimePipelineConfigInfoMap MUST check the status field
+        // rather than treating mere map presence as "delivered".
+        // NOTE: between this insertion and the rollback below, the entry is visible to
+        // concurrent readers with status=APPLYING.  This is intentional: it signals
+        // "in-flight" to the server and prevents duplicate delivery within the same batch.
+        // On rollback the entry is removed, allowing a retry on the next heartbeat.
         {
             lock_guard<mutex> lockInfoMap(mInfoMapMux);
-            // Onetime configs are one-shot per-name: once a name is recorded in the map
-            // (in-progress or delivered), it is never re-processed regardless of new content.
-            // This matches the server's "deliver once" semantics for transient commands.
+            // Onetime configs are one-shot per-name within this process lifetime.
+            // On startup, LoadConfigFile() pre-populates the map from disk so that
+            // configs delivered before a restart are not re-applied.
             if (mOnetimePipelineConfigInfoMap.count(name)) {
                 LOG_DEBUG(sLogger, ("onetime config already delivered, skipping", name));
                 continue;

--- a/core/config/common_provider/CommonConfigProvider.cpp
+++ b/core/config/common_provider/CommonConfigProvider.cpp
@@ -134,6 +134,19 @@ void CommonConfigProvider::Stop() {
     }
 }
 
+// static
+int64_t CommonConfigProvider::ComputeOnetimeConfigVersion(const std::string& content) {
+    // FNV-1a 64-bit hash: deterministic across processes, restarts, platforms, and
+    // standard-library versions, making the version stable for downstream comparisons.
+    // Mask to INT64_MAX to guarantee a non-negative int64_t value.
+    uint64_t h = 14695981039346656037ULL; // FNV-1a 64-bit offset basis
+    for (unsigned char c : content) {
+        h ^= static_cast<uint64_t>(c);
+        h *= 1099511628211ULL; // FNV-1a 64-bit prime
+    }
+    return static_cast<int64_t>(h & 0x7FFFFFFFFFFFFFFFULL);
+}
+
 void CommonConfigProvider::LoadConfigFile() {
     error_code ec;
     for (auto const& entry : filesystem::directory_iterator(mContinuousPipelineConfigDir, ec)) {
@@ -173,6 +186,7 @@ void CommonConfigProvider::LoadConfigFile() {
     // Rebuild mOnetimePipelineConfigInfoMap from disk on startup to prevent re-delivery of
     // already-applied onetime configs across process restarts.
     // The directory may not exist yet (created lazily on first delivery), so ignore the error.
+    ec.clear();
     for (auto const& entry : filesystem::directory_iterator(mOnetimePipelineConfigDir, ec)) {
         const filesystem::path& p = entry.path();
         // Clean up any orphaned tmp files left by a crashed previous run.
@@ -191,14 +205,9 @@ void CommonConfigProvider::LoadConfigFile() {
         }
         string content((istreambuf_iterator<char>(fin)), istreambuf_iterator<char>());
         fin.close();
-        uint64_t fnvHash = 14695981039346656037ULL;
-        for (unsigned char c : content) {
-            fnvHash ^= static_cast<uint64_t>(c);
-            fnvHash *= 1099511628211ULL;
-        }
         ConfigInfo info;
         info.name = p.stem().string();
-        info.version = static_cast<int64_t>(fnvHash & 0x7FFFFFFFFFFFFFFFULL);
+        info.version = ComputeOnetimeConfigVersion(content);
         info.status = ConfigFeedbackStatus::APPLIED;
         {
             lock_guard<mutex> lockInfoMap(mInfoMapMux);
@@ -636,7 +645,8 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
                     fout.close(); // flush buffered data; sets failbit on disk-full etc.
                     if (!fout.good()) {
                         LOG_WARNING(sLogger, ("failed to write onetime config file", tmpFilePath.string()));
-                        filesystem::remove(tmpFilePath);
+                        error_code removeEc;
+                        filesystem::remove(tmpFilePath, removeEc);
                     } else {
                         fileWriteOk = true;
                     }
@@ -673,19 +683,11 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
             continue;
         }
         // Compute the FNV-1a content hash outside the lock to keep the critical section short.
-        // Use FNV-1a 64-bit: deterministic across processes, restarts, platforms, and
-        // standard-library versions, making the version stable for downstream comparisons.
-        // Mask to INT64_MAX to guarantee a non-negative int64_t value.
-        uint64_t fnvHash = 14695981039346656037ULL; // FNV-1a 64-bit offset basis
-        for (unsigned char c : cmd.detail()) {
-            fnvHash ^= static_cast<uint64_t>(c);
-            fnvHash *= 1099511628211ULL; // FNV-1a 64-bit prime
-        }
         {
             // The placeholder already has name and APPLYING status; only update version.
             // In-place update avoids field-divergence if ConfigInfo gains new fields later.
             lock_guard<mutex> lockInfoMap(mInfoMapMux);
-            mOnetimePipelineConfigInfoMap[name].version = static_cast<int64_t>(fnvHash & 0x7FFFFFFFFFFFFFFFULL);
+            mOnetimePipelineConfigInfoMap[name].version = ComputeOnetimeConfigVersion(cmd.detail());
         }
         ConfigFeedbackReceiver::GetInstance().RegisterOnetimePipelineConfig(name, this);
         LOG_INFO(sLogger, ("received onetime pipeline config", name)("expire_time", cmd.expire_time()));

--- a/core/config/common_provider/CommonConfigProvider.cpp
+++ b/core/config/common_provider/CommonConfigProvider.cpp
@@ -505,8 +505,11 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
     int64_t now = static_cast<int64_t>(time(nullptr));
     for (const auto& cmd : commands) {
         if (cmd.expire_time() > 0 && cmd.expire_time() <= now) {
-            LOG_WARNING(sLogger,
-                        ("onetime config already expired, skipping", cmd.name())("expire_time", cmd.expire_time()));
+            // Downgrade to DEBUG: an expired command may be re-sent on every heartbeat
+            // (e.g. clock skew or a stuck server queue), and a WARNING per heartbeat
+            // would produce significant log noise.
+            LOG_DEBUG(sLogger,
+                      ("onetime config already expired, skipping", cmd.name())("expire_time", cmd.expire_time()));
             continue;
         }
         // Reject server-supplied names containing path separators, leading dots/dashes, or
@@ -537,6 +540,9 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
         // unrelated default-constructed ConfigInfo.
         {
             lock_guard<mutex> lockInfoMap(mInfoMapMux);
+            // Onetime configs are one-shot per-name: once a name is recorded in the map
+            // (in-progress or delivered), it is never re-processed regardless of new content.
+            // This matches the server's "deliver once" semantics for transient commands.
             if (mOnetimePipelineConfigInfoMap.count(name)) {
                 LOG_DEBUG(sLogger, ("onetime config already delivered, skipping", name));
                 continue;
@@ -559,11 +565,12 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
                     LOG_WARNING(sLogger, ("failed to open onetime config file", tmpFilePath.string()));
                 } else {
                     fout << cmd.detail();
-                    fout.close();
-                    fileWriteOk = fout.good();
-                    if (!fileWriteOk) {
+                    fout.close(); // flush buffered data; sets failbit on disk-full etc.
+                    if (!fout.good()) {
                         LOG_WARNING(sLogger, ("failed to write onetime config file", tmpFilePath.string()));
                         filesystem::remove(tmpFilePath);
+                    } else {
+                        fileWriteOk = true;
                     }
                 }
             }
@@ -572,7 +579,13 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
                 // On POSIX, filesystem::rename atomically replaces the destination; only
                 // remove first on Windows where rename fails if the destination exists.
 #ifdef _WIN32
-                filesystem::remove(filePath, ec);
+                {
+                    error_code removeEc;
+                    filesystem::remove(filePath, removeEc);
+                    // Ignore removeEc: a missing target is fine; rename will detect
+                    // real problems. Using a separate error_code avoids overwriting
+                    // ec before the rename call below.
+                }
 #endif
                 filesystem::rename(tmpFilePath, filePath, ec);
                 if (ec) {
@@ -600,12 +613,10 @@ void CommonConfigProvider::UpdateRemoteOnetimePipelineConfig(
             fnvHash *= 1099511628211ULL; // FNV-1a 64-bit prime
         }
         {
+            // The placeholder already has name and APPLYING status; only update version.
+            // In-place update avoids field-divergence if ConfigInfo gains new fields later.
             lock_guard<mutex> lockInfoMap(mInfoMapMux);
-            ConfigInfo info;
-            info.name = name;
-            info.version = static_cast<int64_t>(fnvHash & 0x7FFFFFFFFFFFFFFFULL);
-            info.status = ConfigFeedbackStatus::APPLYING;
-            mOnetimePipelineConfigInfoMap[name] = std::move(info);
+            mOnetimePipelineConfigInfoMap[name].version = static_cast<int64_t>(fnvHash & 0x7FFFFFFFFFFFFFFFULL);
         }
         ConfigFeedbackReceiver::GetInstance().RegisterOnetimePipelineConfig(name, this);
         LOG_INFO(sLogger, ("received onetime pipeline config", name)("expire_time", cmd.expire_time()));

--- a/core/config/common_provider/CommonConfigProvider.h
+++ b/core/config/common_provider/CommonConfigProvider.h
@@ -72,6 +72,7 @@ protected:
         const google::protobuf::RepeatedPtrField<configserver::proto::v2::ConfigDetail>& configs);
     void UpdateRemoteOnetimePipelineConfig(
         const google::protobuf::RepeatedPtrField<configserver::proto::v2::CommandDetail>& commands);
+    static int64_t ComputeOnetimeConfigVersion(const std::string& content);
 
     virtual bool
     FetchInstanceConfigFromServer(::configserver::proto::v2::HeartbeatResponse&,

--- a/core/config/common_provider/CommonConfigProvider.h
+++ b/core/config/common_provider/CommonConfigProvider.h
@@ -70,6 +70,8 @@ protected:
         const google::protobuf::RepeatedPtrField<configserver::proto::v2::ConfigDetail>& configs);
     void UpdateRemoteInstanceConfig(
         const google::protobuf::RepeatedPtrField<configserver::proto::v2::ConfigDetail>& configs);
+    void UpdateRemoteOnetimePipelineConfig(
+        const google::protobuf::RepeatedPtrField<configserver::proto::v2::CommandDetail>& commands);
 
     virtual bool
     FetchInstanceConfigFromServer(::configserver::proto::v2::HeartbeatResponse&,

--- a/core/task_pipeline/TaskPipelineManager.cpp
+++ b/core/task_pipeline/TaskPipelineManager.cpp
@@ -26,73 +26,106 @@ static unique_ptr<TaskPipeline> sEmptyTask;
 
 void TaskPipelineManager::UpdatePipelines(TaskConfigDiff& diff) {
     for (const auto& name : diff.mRemoved) {
+        bool isOnetime = false;
         {
             auto iter = mPipelineNameEntityMap.find(name);
             if (iter == mPipelineNameEntityMap.end()) {
                 continue;
             }
+            isOnetime = iter->second->IsOnetime();
             iter->second->Stop(true);
             {
                 unique_lock<shared_mutex> lock(mPipelineNameEntityMapMutex);
                 mPipelineNameEntityMap.erase(iter);
             }
         }
-        ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(name,
-                                                                                     ConfigFeedbackStatus::DELETED);
+        if (isOnetime) {
+            ConfigFeedbackReceiver::GetInstance().FeedbackOnetimePipelineConfigStatus(name,
+                                                                                      ConfigFeedbackStatus::DELETED);
+        } else {
+            ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(name,
+                                                                                         ConfigFeedbackStatus::DELETED);
+        }
     }
     for (auto& config : diff.mModified) {
+        const string configName = config.mName;
+        const bool isOnetimeConfig = config.IsOnetime();
         auto p = BuildPipeline(std::move(config));
         if (!p) {
             LOG_WARNING(
                 sLogger,
-                ("failed to build task for existing config", "keep current task running")("config", config.mName));
+                ("failed to build task for existing config", "keep current task running")("config", configName));
             AlarmManager::GetInstance()->SendAlarmError(
                 CATEGORY_CONFIG_ALARM,
-                "failed to build task for existing config: keep current task running, config: " + config.mName);
-            ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(config.mName,
-                                                                                         ConfigFeedbackStatus::FAILED);
+                "failed to build task for existing config: keep current task running, config: " + configName);
+            if (isOnetimeConfig) {
+                ConfigFeedbackReceiver::GetInstance().FeedbackOnetimePipelineConfigStatus(configName,
+                                                                                          ConfigFeedbackStatus::FAILED);
+            } else {
+                ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(configName,
+                                                                                             ConfigFeedbackStatus::FAILED);
+            }
             continue;
         }
         LOG_INFO(sLogger,
                  ("task building for existing config succeeded",
-                  "stop the old task and start the new one")("config", config.mName));
+                  "stop the old task and start the new one")("config", configName));
+        bool builtIsOnetime = p->IsOnetime();
         {
-            auto iter = mPipelineNameEntityMap.find(config.mName);
+            auto iter = mPipelineNameEntityMap.find(configName);
             // when pipeline lifespan attribute changes, two pipelines are considered unrelated, and thus the old one
             // should be considered as deleted
             if (iter == mPipelineNameEntityMap.end()) {
                 continue;
             }
-            iter->second->Stop(p->IsOnetime() != iter->second->IsOnetime());
+            iter->second->Stop(builtIsOnetime != iter->second->IsOnetime());
             {
                 unique_lock<shared_mutex> lock(mPipelineNameEntityMapMutex);
-                mPipelineNameEntityMap[config.mName] = std::move(p);
+                mPipelineNameEntityMap[configName] = std::move(p);
             }
-            mPipelineNameEntityMap[config.mName]->Start();
+            mPipelineNameEntityMap[configName]->Start();
         }
-        ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(config.mName,
-                                                                                     ConfigFeedbackStatus::APPLIED);
+        if (builtIsOnetime) {
+            ConfigFeedbackReceiver::GetInstance().FeedbackOnetimePipelineConfigStatus(configName,
+                                                                                      ConfigFeedbackStatus::APPLIED);
+        } else {
+            ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(configName,
+                                                                                         ConfigFeedbackStatus::APPLIED);
+        }
     }
     for (auto& config : diff.mAdded) {
+        const string configName = config.mName;
+        const bool isOnetimeConfig = config.IsOnetime();
         auto p = BuildPipeline(std::move(config));
         if (!p) {
             LOG_WARNING(sLogger,
-                        ("failed to build task for new config", "skip current object")("config", config.mName));
+                        ("failed to build task for new config", "skip current object")("config", configName));
             AlarmManager::GetInstance()->SendAlarmError(
                 CATEGORY_CONFIG_ALARM,
-                "failed to build task for new config: skip current object, config: " + config.mName);
-            ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(config.mName,
-                                                                                         ConfigFeedbackStatus::FAILED);
+                "failed to build task for new config: skip current object, config: " + configName);
+            if (isOnetimeConfig) {
+                ConfigFeedbackReceiver::GetInstance().FeedbackOnetimePipelineConfigStatus(configName,
+                                                                                          ConfigFeedbackStatus::FAILED);
+            } else {
+                ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(configName,
+                                                                                             ConfigFeedbackStatus::FAILED);
+            }
             continue;
         }
-        LOG_INFO(sLogger, ("task building for new config succeeded", "begin to start task")("config", config.mName));
+        LOG_INFO(sLogger, ("task building for new config succeeded", "begin to start task")("config", configName));
+        bool builtIsOnetime = p->IsOnetime();
         {
             unique_lock<shared_mutex> lock(mPipelineNameEntityMapMutex);
-            mPipelineNameEntityMap[config.mName] = std::move(p);
+            mPipelineNameEntityMap[configName] = std::move(p);
         }
-        mPipelineNameEntityMap[config.mName]->Start();
-        ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(config.mName,
-                                                                                     ConfigFeedbackStatus::APPLIED);
+        mPipelineNameEntityMap[configName]->Start();
+        if (builtIsOnetime) {
+            ConfigFeedbackReceiver::GetInstance().FeedbackOnetimePipelineConfigStatus(configName,
+                                                                                      ConfigFeedbackStatus::APPLIED);
+        } else {
+            ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(configName,
+                                                                                         ConfigFeedbackStatus::APPLIED);
+        }
     }
 }
 

--- a/core/unittest/config/CommonConfigProviderUnittest.cpp
+++ b/core/unittest/config/CommonConfigProviderUnittest.cpp
@@ -125,6 +125,8 @@ public:
     void TestInit();
 
     void TestGetConfigUpdateAndConfigWatcher();
+
+    void TestLoadConfigFileOnetimeRecovery();
 };
 
 void CommonConfigProviderUnittest::TestInit() {
@@ -727,8 +729,84 @@ void CommonConfigProviderUnittest::TestGetConfigUpdateAndConfigWatcher() {
     }
 }
 
+void CommonConfigProviderUnittest::TestLoadConfigFileOnetimeRecovery() {
+    // Discover the onetime config dir path used by this provider name.
+    filesystem::path onetimeDir;
+    {
+        MockCommonConfigProvider bootstrap;
+        bootstrap.Init("common_v2");
+        onetimeDir = bootstrap.mOnetimePipelineConfigDir;
+        bootstrap.Stop();
+    }
+    bfs::remove_all(onetimeDir.string()); // start with a clean slate
+
+    // (a) Recovery with a mix of valid .json files and orphaned .json.new tmp files.
+    //     Expect: .json files populate the map with APPLIED status; .json.new is deleted.
+    {
+        bfs::create_directories(onetimeDir.string());
+        {
+            ofstream f((onetimeDir / "cmdA.json").string(), ios::binary);
+            f << R"({"enable":true})";
+        }
+        {
+            ofstream f((onetimeDir / "cmdB.json").string(), ios::binary);
+            f << R"({"enable":false})";
+        }
+        {
+            ofstream f((onetimeDir / "cmdC.json.new").string(), ios::binary);
+            f << "orphan";
+        }
+        MockCommonConfigProvider provider;
+        provider.Init("common_v2");
+        APSARA_TEST_EQUAL(2U, provider.mOnetimePipelineConfigInfoMap.size());
+        APSARA_TEST_EQUAL(ConfigFeedbackStatus::APPLIED, provider.mOnetimePipelineConfigInfoMap["cmdA"].status);
+        APSARA_TEST_EQUAL(ConfigFeedbackStatus::APPLIED, provider.mOnetimePipelineConfigInfoMap["cmdB"].status);
+        APSARA_TEST_FALSE(bfs::exists((onetimeDir / "cmdC.json.new").string()));
+        provider.Stop();
+    }
+
+    // (b) Onetime dir removed between ConfigProvider::Init() and a direct LoadConfigFile() call.
+    //     Expect: no crash, onetime map remains empty.
+    {
+        bfs::remove_all(onetimeDir.string());
+        MockCommonConfigProvider provider;
+        provider.Init("common_v2"); // re-creates dir (empty)
+        bfs::remove_all(provider.mOnetimePipelineConfigDir.string()); // remove it again
+        provider.mOnetimePipelineConfigInfoMap.clear();
+        provider.LoadConfigFile(); // must not throw
+        APSARA_TEST_TRUE(provider.mOnetimePipelineConfigInfoMap.empty());
+        provider.Stop();
+    }
+
+    // (c) Idempotency: a config name recovered from disk is skipped by
+    //     UpdateRemoteOnetimePipelineConfig, preserving its APPLIED status.
+    {
+        bfs::create_directories(onetimeDir.string());
+        {
+            ofstream f((onetimeDir / "cmdA.json").string(), ios::binary);
+            f << R"({"enable":true})";
+        }
+        MockCommonConfigProvider provider;
+        provider.Init("common_v2");
+        APSARA_TEST_EQUAL(1U, provider.mOnetimePipelineConfigInfoMap.size());
+        APSARA_TEST_EQUAL(ConfigFeedbackStatus::APPLIED, provider.mOnetimePipelineConfigInfoMap["cmdA"].status);
+        // Simulate server re-delivering the same command.
+        google::protobuf::RepeatedPtrField<configserver::proto::v2::CommandDetail> cmds;
+        auto* cmd = cmds.Add();
+        cmd->set_name("cmdA");
+        cmd->set_detail(R"({"enable":true})");
+        cmd->set_expire_time(0);
+        provider.UpdateRemoteOnetimePipelineConfig(cmds);
+        // The entry must remain APPLIED — the skip branch was taken.
+        APSARA_TEST_EQUAL(ConfigFeedbackStatus::APPLIED, provider.mOnetimePipelineConfigInfoMap["cmdA"].status);
+        provider.Stop();
+        bfs::remove_all(onetimeDir.string());
+    }
+}
+
 UNIT_TEST_CASE(CommonConfigProviderUnittest, TestInit)
 UNIT_TEST_CASE(CommonConfigProviderUnittest, TestGetConfigUpdateAndConfigWatcher)
+UNIT_TEST_CASE(CommonConfigProviderUnittest, TestLoadConfigFileOnetimeRecovery)
 
 }; // namespace logtail
 


### PR DESCRIPTION
## Summary

Add client-side handling for one-time pipeline configs delivered via the config server heartbeat protocol.

## Changes

### `CommonConfigProvider.cpp`
- `GetConfigUpdate()`: dispatch `onetime_pipeline_config_updates` to the new `UpdateRemoteOnetimePipelineConfig()` handler
- `PrepareHeartbeat()`: advertise `AcceptsOnetimePipelineConfig` capability
- `UpdateRemoteOnetimePipelineConfig()` (new):
  - Skip expired commands (`expire_time > 0 && expire_time <= now`) with `LOG_WARNING`
  - Validate server-supplied names: reject empty, leading `'.'`/`'-'`, and disallowed characters to prevent directory traversal
  - Reserve a placeholder entry under `mInfoMapMux` before file I/O to eliminate TOCTOU races when the same name appears twice in a batch
  - Write config JSON atomically via tmp-then-rename; on POSIX `rename` replaces atomically; on Windows (`#ifdef _WIN32`) remove target first
  - Check `fout.good()` after explicit `close()` to detect partial writes
  - Use FNV-1a 64-bit hash as content version (deterministic, cross-platform, restart-stable); mask to `INT63_MAX` for a non-negative `int64_t`
  - Compute hash outside `mInfoMapMux` to keep the critical section short
  - Roll back placeholder on any failure so the command is retried on the next heartbeat
  - Register with `ConfigFeedbackReceiver` and log delivery at `INFO`

### `CommonConfigProvider.h`
- Declare `UpdateRemoteOnetimePipelineConfig()` as a protected method

## Lock hierarchy

`mInfoMapMux` and `mOnetimePipelineMux` are never held simultaneously:
- `mInfoMapMux` guards only `mOnetimePipelineConfigInfoMap`
- `mOnetimePipelineMux` guards only file I/O
