### PR TITLE
Refactor whole_file overwrite detection and chunked output in LogFileReader

### DIFF
--- a/core/file_server/MultilineOptions.cpp
+++ b/core/file_server/MultilineOptions.cpp
@@ -40,6 +40,48 @@ bool MultilineOptions::Init(const Json::Value& config, const CollectionPipelineC
     } else if (mode == "whole_file") {
         mMode = Mode::WHOLE_FILE;
         mIsMultiline = true;
+
+        // FileWriteMode (only meaningful for whole_file mode)
+        string fileWriteMode;
+        if (!GetOptionalStringParam(config, "FileWriteMode", fileWriteMode, errorMsg)) {
+            PARAM_WARNING_DEFAULT(ctx.GetLogger(),
+                                  ctx.GetAlarm(),
+                                  errorMsg,
+                                  "append",
+                                  pluginType,
+                                  ctx.GetConfigName(),
+                                  ctx.GetProjectName(),
+                                  ctx.GetLogstoreName(),
+                                  ctx.GetRegion());
+        } else if (fileWriteMode == "overwrite") {
+            mFileWriteMode = FileWriteMode::OVERWRITE;
+        } else if (!fileWriteMode.empty() && fileWriteMode != "append") {
+            PARAM_WARNING_DEFAULT(ctx.GetLogger(),
+                                  ctx.GetAlarm(),
+                                  "string param FileWriteMode is not valid",
+                                  "append",
+                                  pluginType,
+                                  ctx.GetConfigName(),
+                                  ctx.GetProjectName(),
+                                  ctx.GetLogstoreName(),
+                                  ctx.GetRegion());
+        }
+
+        // MaxWholeFileBytes
+        uint32_t maxWholeFileBytes = 0;
+        if (!GetOptionalUIntParam(config, "MaxWholeFileBytes", maxWholeFileBytes, errorMsg)) {
+            PARAM_WARNING_DEFAULT(ctx.GetLogger(),
+                                  ctx.GetAlarm(),
+                                  errorMsg,
+                                  mMaxWholeFileBytes,
+                                  pluginType,
+                                  ctx.GetConfigName(),
+                                  ctx.GetProjectName(),
+                                  ctx.GetLogstoreName(),
+                                  ctx.GetRegion());
+        } else if (maxWholeFileBytes > 0) {
+            mMaxWholeFileBytes = maxWholeFileBytes;
+        }
     } else if (!mode.empty() && mode != "custom") {
         PARAM_WARNING_DEFAULT(ctx.GetLogger(),
                               ctx.GetAlarm(),

--- a/core/file_server/MultilineOptions.h
+++ b/core/file_server/MultilineOptions.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+
 #include <string>
 #include <utility>
 

--- a/core/file_server/MultilineOptions.h
+++ b/core/file_server/MultilineOptions.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <utility>
 
@@ -30,6 +31,7 @@ class MultilineOptions {
 public:
     enum class Mode { CUSTOM, JSON, WHOLE_FILE };
     enum class UnmatchedContentTreatment { DISCARD, SINGLE_LINE };
+    enum class FileWriteMode { APPEND, OVERWRITE }; // NOLINT(readability-identifier-naming)
 
     bool Init(const Json::Value& config, const CollectionPipelineContext& ctx, const std::string& pluginType);
     const std::shared_ptr<boost::regex>& GetStartPatternReg() const { return mStartPatternRegPtr; }
@@ -38,6 +40,8 @@ public:
     bool IsMultiline() const { return mIsMultiline; }
 
     Mode mMode = Mode::CUSTOM;
+    FileWriteMode mFileWriteMode = FileWriteMode::APPEND;
+    uint32_t mMaxWholeFileBytes = 10 * 1024 * 1024;
     std::string mStartPattern;
     std::string mContinuePattern;
     std::string mEndPattern;

--- a/core/file_server/event_handler/EventHandler.cpp
+++ b/core/file_server/event_handler/EventHandler.cpp
@@ -1197,10 +1197,13 @@ bool ModifyHandler::RemoveReaderFromArrayAndMap(LogFileReaderPtr expectedReader,
 }
 
 void ModifyHandler::ForceReadLogAndPush(LogFileReaderPtr reader) {
-    auto logBuffer = make_unique<LogBuffer>();
-    auto pEvent = reader->CreateFlushTimeoutEvent();
-    reader->ReadLog(*logBuffer, pEvent.get());
-    PushLogToProcessor(reader, logBuffer.get(), true);
+    bool moreData;
+    do {
+        auto logBuffer = make_unique<LogBuffer>();
+        auto pEvent = reader->CreateFlushTimeoutEvent();
+        moreData = reader->ReadLog(*logBuffer, pEvent.get());
+        PushLogToProcessor(reader, logBuffer.get(), true);
+    } while (moreData);
 }
 
 int32_t ModifyHandler::PushLogToProcessor(LogFileReaderPtr reader, LogBuffer* logBuffer, bool dropIfBlocked) {

--- a/core/file_server/reader/FileReaderOptions.h
+++ b/core/file_server/reader/FileReaderOptions.h
@@ -29,7 +29,6 @@ namespace logtail {
 struct FileReaderOptions {
     enum class Encoding { UTF8, UTF16, GBK };
     enum class InputType { Unknown, InputFile, InputContainerStdio };
-
     InputType mInputType = InputType::Unknown;
     Encoding mFileEncoding = Encoding::UTF8;
     bool mTailingAllMatchedFiles = false;

--- a/core/file_server/reader/LogFileReader.cpp
+++ b/core/file_server/reader/LogFileReader.cpp
@@ -1343,6 +1343,31 @@ bool LogFileReader::CheckFileSignatureAndOffset(bool isOpenOnUpdate) {
     mLogFileOp.Stat(ps);
     time_t lastMTime = mLastMTime;
     mLastMTime = ps.GetMtime();
+
+    // In WHOLE_FILE mode, the entire file should be treated as a single log entry.
+    // When the file is modified (detected via mtime change), reset read position to
+    // the beginning so the complete file content is re-read. This handles the
+    // overwrite-in-place pattern (e.g., a JSON file being repeatedly rewritten).
+    if (mMultilineConfig.first->mMode == MultilineOptions::Mode::WHOLE_FILE
+        && lastMTime != 0 && lastMTime != mLastMTime) {
+        LOG_INFO(sLogger,
+                 ("whole_file mode detected file modification, read from begin",
+                  mHostLogPath)("old mtime", lastMTime)("new mtime", mLastMTime)(
+                     "project", GetProject())("logstore", GetLogstore())("config", GetConfigName()));
+        mLastFilePos = 0;
+        mCache.clear();
+        char firstLine[1025];
+        int nbytes = mLogFileOp.Pread(firstLine, 1, 1024, 0);
+        if (nbytes > 0) {
+            firstLine[nbytes] = '\0';
+            CheckAndUpdateSignature(string(firstLine), mLastFileSignatureHash, mLastFileSignatureSize);
+        }
+        if (mEOOption) {
+            updatePrimaryCheckpointSignature();
+        }
+        return true;
+    }
+
     if (!isOpenOnUpdate || mLastFileSignatureSize == 0 || endSize < mLastFilePos
         || (endSize == mLastFilePos && lastMTime != mLastMTime)) {
         char firstLine[1025];

--- a/core/file_server/reader/LogFileReader.cpp
+++ b/core/file_server/reader/LogFileReader.cpp
@@ -986,8 +986,9 @@ bool LogFileReader::ReadLog(LogBuffer& logBuffer, const Event* event, bool isSta
     bool tryRollback = true;
     if (event != nullptr && event->IsReaderFlushTimeout()) {
         // If flush timeout event, we should filter whether the event is legacy.
-        if (event->GetLastReadPos() == GetLastReadPos() && event->GetLastFilePos() == mLastFilePos
-            && event->GetInode() == mDevInode.inode) {
+        if (mDrainingWholeFileCache
+            || (event->GetLastReadPos() == GetLastReadPos() && event->GetLastFilePos() == mLastFilePos
+                && event->GetInode() == mDevInode.inode)) {
             tryRollback = false;
         } else {
             return false;
@@ -1344,18 +1345,20 @@ bool LogFileReader::CheckFileSignatureAndOffset(bool isOpenOnUpdate) {
     time_t lastMTime = mLastMTime;
     mLastMTime = ps.GetMtime();
 
-    // In WHOLE_FILE mode, the entire file should be treated as a single log entry.
+    // In WHOLE_FILE overwrite mode, the entire file should be treated as a single log entry.
     // When the file is modified (detected via mtime change), reset read position to
-    // the beginning so the complete file content is re-read. This handles the
-    // overwrite-in-place pattern (e.g., a JSON file being repeatedly rewritten).
+    // the beginning so the complete file content is re-read.
     if (mMultilineConfig.first->mMode == MultilineOptions::Mode::WHOLE_FILE
+        && mMultilineConfig.first->mFileWriteMode == MultilineOptions::FileWriteMode::OVERWRITE
         && lastMTime != 0 && lastMTime != mLastMTime) {
         LOG_INFO(sLogger,
-                 ("whole_file mode detected file modification, read from begin",
+                 ("whole_file overwrite mode detected file modification, read from begin",
                   mHostLogPath)("old mtime", lastMTime)("new mtime", mLastMTime)(
                      "project", GetProject())("logstore", GetLogstore())("config", GetConfigName()));
         mLastFilePos = 0;
         mCache.clear();
+        mDrainingWholeFileCache = false;
+        mWholeFileChunkIndex = 0;
         char firstLine[1025];
         int nbytes = mLogFileOp.Pread(firstLine, 1, 1024, 0);
         if (nbytes > 0) {
@@ -1576,6 +1579,17 @@ size_t LogFileReader::getNextReadSize(int64_t fileEnd, bool& fromCpt) {
         readSize = checkpoint.read_length();
         LOG_INFO(sLogger, ("read specified length", readSize)("offset", mLastFilePos));
     }
+    if (mMultilineConfig.first->mMode == MultilineOptions::Mode::WHOLE_FILE
+        && mMultilineConfig.first->mFileWriteMode == MultilineOptions::FileWriteMode::OVERWRITE) {
+        allowMoreBufferSize = true;
+        if (readSize > mMultilineConfig.first->mMaxWholeFileBytes) {
+            LOG_WARNING(sLogger,
+                        ("whole_file overwrite mode file exceeds max limit, skipping",
+                         mHostLogPath)("file size", fileEnd)("max allowed", mMultilineConfig.first->mMaxWholeFileBytes)(
+                            "project", GetProject())("logstore", GetLogstore())("config", GetConfigName()));
+            return 0;
+        }
+    }
     if (readSize > BUFFER_SIZE && !allowMoreBufferSize) {
         readSize = BUFFER_SIZE;
     }
@@ -1598,8 +1612,41 @@ void LogFileReader::ReadUTF8(LogBuffer& logBuffer, int64_t end, bool& moreData, 
     bool logTooLongSplitFlag = false;
 
     logBuffer.readOffset = mLastFilePos;
+    // WHOLE_FILE overwrite: chunked drain of large cache (continuation or initiation)
+    if (mDrainingWholeFileCache
+        || (!tryRollback && mMultilineConfig.first->mMode == MultilineOptions::Mode::WHOLE_FILE
+            && mMultilineConfig.first->mFileWriteMode == MultilineOptions::FileWriteMode::OVERWRITE
+            && mCache.size() > BUFFER_SIZE)) {
+        if (!mDrainingWholeFileCache) {
+            mDrainingWholeFileCache = true;
+            mWholeFileChunkIndex = 0;
+            mWholeFileTotalChunks = static_cast<int32_t>((mCache.size() + BUFFER_SIZE - 1) / BUFFER_SIZE);
+            mWholeFileId = mHostLogPath + "_" + ToString(mLastMTime) + "_" + ToString(mDevInode.inode);
+            mLastForceRead = true;
+        }
+        if (mCache.empty()) {
+            mDrainingWholeFileCache = false;
+            moreData = false;
+            return;
+        }
+        size_t chunkSize = std::min(mCache.size(), BUFFER_SIZE);
+        StringBuffer stringMemory = logBuffer.sourcebuffer->AllocateStringBuffer(chunkSize);
+        memcpy(stringMemory.data, mCache.data(), chunkSize);
+        logBuffer.rawBuffer = StringView(stringMemory.data, chunkSize);
+        logBuffer.readLength = chunkSize;
+        logBuffer.readOffset = mLastFilePos;
+        logBuffer.wholeFileId = mWholeFileId;
+        logBuffer.wholeFileSeq = mWholeFileChunkIndex++;
+        logBuffer.wholeFileTotal = mWholeFileTotalChunks;
+        mCache.erase(0, chunkSize);
+        mLastFilePos += chunkSize;
+        moreData = !mCache.empty();
+        if (!moreData) {
+            mDrainingWholeFileCache = false;
+        }
+        return;
+    }
     if (!mLogFileOp.IsOpen()) {
-        // read flush timeout
         nbytes = mCache.size();
         StringBuffer stringMemory = logBuffer.sourcebuffer->AllocateStringBuffer(nbytes);
         stringBuffer = stringMemory.data;
@@ -1756,8 +1803,41 @@ void LogFileReader::ReadGBK(LogBuffer& logBuffer, int64_t end, bool& moreData, b
     bool allowRollback = true;
 
     logBuffer.readOffset = mLastFilePos;
+    // WHOLE_FILE overwrite: chunked drain of large cache (continuation or initiation)
+    if (mDrainingWholeFileCache
+        || (!tryRollback && mMultilineConfig.first->mMode == MultilineOptions::Mode::WHOLE_FILE
+            && mMultilineConfig.first->mFileWriteMode == MultilineOptions::FileWriteMode::OVERWRITE
+            && mCache.size() > BUFFER_SIZE)) {
+        if (!mDrainingWholeFileCache) {
+            mDrainingWholeFileCache = true;
+            mWholeFileChunkIndex = 0;
+            mWholeFileTotalChunks = static_cast<int32_t>((mCache.size() + BUFFER_SIZE - 1) / BUFFER_SIZE);
+            mWholeFileId = mHostLogPath + "_" + ToString(mLastMTime) + "_" + ToString(mDevInode.inode);
+            mLastForceRead = true;
+        }
+        if (mCache.empty()) {
+            mDrainingWholeFileCache = false;
+            moreData = false;
+            return;
+        }
+        size_t chunkSize = std::min(mCache.size(), BUFFER_SIZE);
+        StringBuffer stringMemory = logBuffer.sourcebuffer->AllocateStringBuffer(chunkSize);
+        memcpy(stringMemory.data, mCache.data(), chunkSize);
+        logBuffer.rawBuffer = StringView(stringMemory.data, chunkSize);
+        logBuffer.readLength = chunkSize;
+        logBuffer.readOffset = mLastFilePos;
+        logBuffer.wholeFileId = mWholeFileId;
+        logBuffer.wholeFileSeq = mWholeFileChunkIndex++;
+        logBuffer.wholeFileTotal = mWholeFileTotalChunks;
+        mCache.erase(0, chunkSize);
+        mLastFilePos += chunkSize;
+        moreData = !mCache.empty();
+        if (!moreData) {
+            mDrainingWholeFileCache = false;
+        }
+        return;
+    }
     if (!mLogFileOp.IsOpen()) {
-        // read flush timeout
         readCharCount = mCache.size();
         gbkMemory.reset(new char[readCharCount + 1]);
         gbkBuffer = gbkMemory.get();
@@ -2568,6 +2648,12 @@ PipelineEventGroup LogFileReader::GenerateEventGroup(LogFileReaderPtr reader, Lo
     event->SetTimestamp(logtime);
     event->SetContentNoCopy(DEFAULT_CONTENT_KEY, logBuffer->rawBuffer);
     event->SetPosition(logBuffer->readOffset, logBuffer->readLength);
+
+    if (logBuffer->wholeFileSeq >= 0) {
+        event->SetContent("__whole_file_id__", logBuffer->wholeFileId);
+        event->SetContent("__whole_file_seq__", ToString(logBuffer->wholeFileSeq));
+        event->SetContent("__whole_file_total__", ToString(logBuffer->wholeFileTotal));
+    }
 
     return group;
 }

--- a/core/file_server/reader/LogFileReader.cpp
+++ b/core/file_server/reader/LogFileReader.cpp
@@ -1345,30 +1345,61 @@ bool LogFileReader::CheckFileSignatureAndOffset(bool isOpenOnUpdate) {
     time_t lastMTime = mLastMTime;
     mLastMTime = ps.GetMtime();
 
-    // In WHOLE_FILE overwrite mode, the entire file should be treated as a single log entry.
-    // When the file is modified (detected via mtime change), reset read position to
-    // the beginning so the complete file content is re-read.
+    // In WHOLE_FILE overwrite mode, the entire file is treated as a single log entry. A rewrite must be
+    // re-read from the beginning. Detection combines three signals (OR), so a same-second overwrite that
+    // a second-precision mtime alone would miss is still caught:
+    //   1. mtime change at nanosecond OR second precision;
+    //   2. file size change;
+    //   3. first-1KB signature change (covers equal-size, same-timestamp rewrites).
+    // The 1KB signature read is only performed when the cheap mtime/size signals show no change.
     if (mMultilineConfig.first->mMode == MultilineOptions::Mode::WHOLE_FILE
-        && mMultilineConfig.first->mFileWriteMode == MultilineOptions::FileWriteMode::OVERWRITE
-        && lastMTime != 0 && lastMTime != mLastMTime) {
-        LOG_INFO(sLogger,
-                 ("whole_file overwrite mode detected file modification, read from begin",
-                  mHostLogPath)("old mtime", lastMTime)("new mtime", mLastMTime)(
-                     "project", GetProject())("logstore", GetLogstore())("config", GetConfigName()));
-        mLastFilePos = 0;
-        mCache.clear();
-        mDrainingWholeFileCache = false;
-        mWholeFileChunkIndex = 0;
-        char firstLine[1025];
-        int nbytes = mLogFileOp.Pread(firstLine, 1, 1024, 0);
-        if (nbytes > 0) {
-            firstLine[nbytes] = '\0';
-            CheckAndUpdateSignature(string(firstLine), mLastFileSignatureHash, mLastFileSignatureSize);
+        && mMultilineConfig.first->mFileWriteMode == MultilineOptions::FileWriteMode::OVERWRITE) {
+        int64_t mtimeSec = 0, mtimeNsec = 0;
+        ps.GetLastWriteTime(mtimeSec, mtimeNsec);
+        int64_t prevMTimeNsec = mLastMTimeNs;
+        int64_t prevWholeFileSize = mLastWholeFileSize;
+        mLastMTimeNs = mtimeNsec;
+        mLastWholeFileSize = endSize;
+
+        // Skip detection on the very first observation (no baseline yet).
+        if (lastMTime != 0) {
+            bool mtimeChanged = (lastMTime != mLastMTime) || (prevMTimeNsec != mtimeNsec);
+            bool sizeChanged = (prevWholeFileSize != endSize);
+            bool headChanged = false;
+            char firstLine[1025];
+            int nbytes = -1;
+            if (!mtimeChanged && !sizeChanged) {
+                nbytes = mLogFileOp.Pread(firstLine, 1, 1024, 0);
+                if (nbytes > 0) {
+                    firstLine[nbytes] = '\0';
+                    uint64_t tmpHash = mLastFileSignatureHash;
+                    uint32_t tmpSize = mLastFileSignatureSize;
+                    headChanged = !CheckAndUpdateSignature(string(firstLine), tmpHash, tmpSize);
+                }
+            }
+            if (mtimeChanged || sizeChanged || headChanged) {
+                LOG_INFO(sLogger,
+                         ("whole_file overwrite mode detected file modification, read from begin",
+                          mHostLogPath)("mtime changed", mtimeChanged)("size changed", sizeChanged)(
+                             "head changed", headChanged)("old mtime", lastMTime)("new mtime", mLastMTime)(
+                             "project", GetProject())("logstore", GetLogstore())("config", GetConfigName()));
+                mLastFilePos = 0;
+                mCache.clear();
+                mDrainingWholeFileCache = false;
+                mWholeFileChunkIndex = 0;
+                if (nbytes < 0) {
+                    nbytes = mLogFileOp.Pread(firstLine, 1, 1024, 0);
+                }
+                if (nbytes > 0) {
+                    firstLine[nbytes] = '\0';
+                    CheckAndUpdateSignature(string(firstLine), mLastFileSignatureHash, mLastFileSignatureSize);
+                }
+                if (mEOOption) {
+                    updatePrimaryCheckpointSignature();
+                }
+                return true;
+            }
         }
-        if (mEOOption) {
-            updatePrimaryCheckpointSignature();
-        }
-        return true;
     }
 
     if (!isOpenOnUpdate || mLastFileSignatureSize == 0 || endSize < mLastFilePos
@@ -1583,10 +1614,14 @@ size_t LogFileReader::getNextReadSize(int64_t fileEnd, bool& fromCpt) {
         && mMultilineConfig.first->mFileWriteMode == MultilineOptions::FileWriteMode::OVERWRITE) {
         allowMoreBufferSize = true;
         if (readSize > mMultilineConfig.first->mMaxWholeFileBytes) {
-            LOG_WARNING(sLogger,
-                        ("whole_file overwrite mode file exceeds max limit, skipping",
-                         mHostLogPath)("file size", fileEnd)("max allowed", mMultilineConfig.first->mMaxWholeFileBytes)(
-                            "project", GetProject())("logstore", GetLogstore())("config", GetConfigName()));
+            int32_t curTime = time(nullptr);
+            if (curTime - mWholeFileOversizeWarnTime >= INT32_FLAG(logtail_alarm_interval)) {
+                mWholeFileOversizeWarnTime = curTime;
+                LOG_WARNING(sLogger,
+                            ("whole_file overwrite mode file exceeds max limit, skipping", mHostLogPath)(
+                                "file size", fileEnd)("max allowed", mMultilineConfig.first->mMaxWholeFileBytes)(
+                                "project", GetProject())("logstore", GetLogstore())("config", GetConfigName()));
+            }
             return 0;
         }
     }
@@ -1617,33 +1652,7 @@ void LogFileReader::ReadUTF8(LogBuffer& logBuffer, int64_t end, bool& moreData, 
         || (!tryRollback && mMultilineConfig.first->mMode == MultilineOptions::Mode::WHOLE_FILE
             && mMultilineConfig.first->mFileWriteMode == MultilineOptions::FileWriteMode::OVERWRITE
             && mCache.size() > BUFFER_SIZE)) {
-        if (!mDrainingWholeFileCache) {
-            mDrainingWholeFileCache = true;
-            mWholeFileChunkIndex = 0;
-            mWholeFileTotalChunks = static_cast<int32_t>((mCache.size() + BUFFER_SIZE - 1) / BUFFER_SIZE);
-            mWholeFileId = mHostLogPath + "_" + ToString(mLastMTime) + "_" + ToString(mDevInode.inode);
-            mLastForceRead = true;
-        }
-        if (mCache.empty()) {
-            mDrainingWholeFileCache = false;
-            moreData = false;
-            return;
-        }
-        size_t chunkSize = std::min(mCache.size(), BUFFER_SIZE);
-        StringBuffer stringMemory = logBuffer.sourcebuffer->AllocateStringBuffer(chunkSize);
-        memcpy(stringMemory.data, mCache.data(), chunkSize);
-        logBuffer.rawBuffer = StringView(stringMemory.data, chunkSize);
-        logBuffer.readLength = chunkSize;
-        logBuffer.readOffset = mLastFilePos;
-        logBuffer.wholeFileId = mWholeFileId;
-        logBuffer.wholeFileSeq = mWholeFileChunkIndex++;
-        logBuffer.wholeFileTotal = mWholeFileTotalChunks;
-        mCache.erase(0, chunkSize);
-        mLastFilePos += chunkSize;
-        moreData = !mCache.empty();
-        if (!moreData) {
-            mDrainingWholeFileCache = false;
-        }
+        DrainWholeFileChunk(logBuffer, moreData);
         return;
     }
     if (!mLogFileOp.IsOpen()) {
@@ -1808,33 +1817,7 @@ void LogFileReader::ReadGBK(LogBuffer& logBuffer, int64_t end, bool& moreData, b
         || (!tryRollback && mMultilineConfig.first->mMode == MultilineOptions::Mode::WHOLE_FILE
             && mMultilineConfig.first->mFileWriteMode == MultilineOptions::FileWriteMode::OVERWRITE
             && mCache.size() > BUFFER_SIZE)) {
-        if (!mDrainingWholeFileCache) {
-            mDrainingWholeFileCache = true;
-            mWholeFileChunkIndex = 0;
-            mWholeFileTotalChunks = static_cast<int32_t>((mCache.size() + BUFFER_SIZE - 1) / BUFFER_SIZE);
-            mWholeFileId = mHostLogPath + "_" + ToString(mLastMTime) + "_" + ToString(mDevInode.inode);
-            mLastForceRead = true;
-        }
-        if (mCache.empty()) {
-            mDrainingWholeFileCache = false;
-            moreData = false;
-            return;
-        }
-        size_t chunkSize = std::min(mCache.size(), BUFFER_SIZE);
-        StringBuffer stringMemory = logBuffer.sourcebuffer->AllocateStringBuffer(chunkSize);
-        memcpy(stringMemory.data, mCache.data(), chunkSize);
-        logBuffer.rawBuffer = StringView(stringMemory.data, chunkSize);
-        logBuffer.readLength = chunkSize;
-        logBuffer.readOffset = mLastFilePos;
-        logBuffer.wholeFileId = mWholeFileId;
-        logBuffer.wholeFileSeq = mWholeFileChunkIndex++;
-        logBuffer.wholeFileTotal = mWholeFileTotalChunks;
-        mCache.erase(0, chunkSize);
-        mLastFilePos += chunkSize;
-        moreData = !mCache.empty();
-        if (!moreData) {
-            mDrainingWholeFileCache = false;
-        }
+        DrainWholeFileChunk(logBuffer, moreData);
         return;
     }
     if (!mLogFileOp.IsOpen()) {
@@ -2255,6 +2238,82 @@ size_t LogFileReader::AlignLastCharacter(char* buffer, size_t size) {
         return endPs;
     }
     return size;
+}
+
+size_t LogFileReader::GetWholeFileChunkSize(char* data, size_t available) {
+    if (available <= BUFFER_SIZE) {
+        return available; // last chunk takes everything
+    }
+    // Prefer to end on a line boundary: the last '\n' within the window (newline included in the chunk).
+    for (size_t i = BUFFER_SIZE; i > 0; --i) {
+        if (data[i - 1] == '\n') {
+            return i;
+        }
+    }
+    // No newline in the window: avoid splitting a multibyte character (encoding-aware).
+    size_t aligned = AlignLastCharacter(data, BUFFER_SIZE);
+    return aligned == 0 ? BUFFER_SIZE : aligned; // guarantee progress
+}
+
+int32_t LogFileReader::CountWholeFileChunks() {
+    int32_t count = 0;
+    size_t pos = 0;
+    size_t total = mCache.size();
+    char* data = total ? &mCache[0] : nullptr;
+    while (pos < total) {
+        pos += GetWholeFileChunkSize(data + pos, total - pos);
+        ++count;
+    }
+    return count;
+}
+
+void LogFileReader::DrainWholeFileChunk(LogBuffer& logBuffer, bool& moreData) {
+    if (!mDrainingWholeFileCache) {
+        mDrainingWholeFileCache = true;
+        mWholeFileChunkIndex = 0;
+        mWholeFileTotalChunks = CountWholeFileChunks();
+        mWholeFileId = mHostLogPath + "_" + ToString(mLastMTime) + "_" + ToString(mDevInode.inode);
+        mLastForceRead = true;
+    }
+    if (mCache.empty()) {
+        mDrainingWholeFileCache = false;
+        moreData = false;
+        return;
+    }
+    char* data = &mCache[0];
+    size_t chunkSize = GetWholeFileChunkSize(data, mCache.size());
+    if (mReaderConfig.first->mFileEncoding == FileReaderOptions::Encoding::GBK) {
+        // mCache holds raw GBK bytes; convert this chunk to UTF8 so it is readable downstream.
+        vector<long> lineFeedPos = {-1};
+        for (long idx = 0; idx < static_cast<long>(chunkSize) - 1; ++idx) {
+            if (data[idx] == '\n') {
+                lineFeedPos.push_back(idx);
+            }
+        }
+        lineFeedPos.push_back(static_cast<long>(chunkSize) - 1);
+        size_t srcLength = chunkSize;
+        size_t requiredLen
+            = EncodingConverter::GetInstance()->ConvertGbk2Utf8(data, &srcLength, nullptr, 0, lineFeedPos);
+        StringBuffer stringMemory = logBuffer.sourcebuffer->AllocateStringBuffer(requiredLen + 1);
+        size_t resultCharCount = EncodingConverter::GetInstance()->ConvertGbk2Utf8(
+            data, &srcLength, stringMemory.data, stringMemory.capacity, lineFeedPos);
+        logBuffer.rawBuffer = StringView(stringMemory.data, resultCharCount);
+    } else {
+        StringBuffer stringMemory = logBuffer.sourcebuffer->AllocateStringBuffer(chunkSize);
+        memcpy(stringMemory.data, data, chunkSize);
+        logBuffer.rawBuffer = StringView(stringMemory.data, chunkSize);
+    }
+    logBuffer.readLength = chunkSize;
+    logBuffer.readOffset = mLastFilePos;
+    logBuffer.wholeFileId = mWholeFileId;
+    logBuffer.wholeFileSeq = mWholeFileChunkIndex++;
+    logBuffer.wholeFileTotal = mWholeFileTotalChunks;
+    mCache.erase(0, chunkSize);
+    mLastFilePos += chunkSize;
+    moreData = !mCache.empty();
+    if (!moreData) {
+        mDrainingWholeFileCache = false;
+    }
 }
 
 std::unique_ptr<Event> LogFileReader::CreateFlushTimeoutEvent() {

--- a/core/file_server/reader/LogFileReader.h
+++ b/core/file_server/reader/LogFileReader.h
@@ -505,6 +505,10 @@ protected:
     int64_t mExpectedFileSize = 0; //  expected file size limit, used for StaticFileServer reader
     time_t mLastMTime = 0;
     std::string mCache;
+    bool mDrainingWholeFileCache = false;
+    int32_t mWholeFileChunkIndex = 0;
+    int32_t mWholeFileTotalChunks = 0;
+    std::string mWholeFileId;
     // >= 0: index of reader array, -1: new reader, -2: not in reader array, -3: not found
     int32_t mIdxInReaderArrayFromLastCpt = CHECKPOINT_IDX_OF_NEW_READER_IN_ARRAY;
     // std::string mProjectName;
@@ -747,6 +751,10 @@ struct LogBuffer {
     uint64_t readOffset = 0;
     uint64_t readLength = 0;
     std::unique_ptr<SourceBuffer> sourcebuffer;
+    // WHOLE_FILE overwrite mode: chunked delivery metadata
+    std::string wholeFileId;
+    int32_t wholeFileSeq = -1;
+    int32_t wholeFileTotal = -1;
 
     LogBuffer() : sourcebuffer(new SourceBuffer()) {}
     void SetDependecy(const LogFileReaderPtr& reader) { logFileReader = reader; }

--- a/core/file_server/reader/LogFileReader.h
+++ b/core/file_server/reader/LogFileReader.h
@@ -474,6 +474,15 @@ protected:
     ReadUTF8(LogBuffer& logBuffer, int64_t end, bool& moreData, bool tryRollback = true, bool isStaticFile = false);
     void ReadGBK(LogBuffer& logBuffer, int64_t end, bool& moreData, bool tryRollback = true, bool isStaticFile = false);
 
+    // WHOLE_FILE overwrite chunked drain helpers. Each emitted chunk is sized to end on a line boundary
+    // ('\n') when possible, otherwise on a character boundary, so that every chunk shown downstream
+    // (which does not reassemble) is human-readable.
+    void DrainWholeFileChunk(LogBuffer& logBuffer, bool& moreData);
+    // Byte length of the next front chunk of [data, data+available), capped at BUFFER_SIZE, preferring a
+    // trailing '\n', else a complete character; always >= 1 to guarantee progress.
+    size_t GetWholeFileChunkSize(char* data, size_t available);
+    int32_t CountWholeFileChunks();
+
     size_t
     ReadFile(LogFileOperator& logFileOp, void* buf, size_t size, int64_t& offset, TruncateInfo** truncateInfo = NULL);
     static int32_t ParseTime(const char* buffer, const std::string& timeFormat);
@@ -509,6 +518,9 @@ protected:
     int32_t mWholeFileChunkIndex = 0;
     int32_t mWholeFileTotalChunks = 0;
     std::string mWholeFileId;
+    // WHOLE_FILE overwrite detection baselines (only touched by whole_file overwrite logic).
+    int64_t mLastMTimeNs = 0;
+    int64_t mLastWholeFileSize = -1;
     // >= 0: index of reader array, -1: new reader, -2: not in reader array, -3: not found
     int32_t mIdxInReaderArrayFromLastCpt = CHECKPOINT_IDX_OF_NEW_READER_IN_ARRAY;
     // std::string mProjectName;
@@ -530,6 +542,9 @@ protected:
     std::string mContainerID;
     time_t mContainerStoppedTime = 0;
     time_t mReadStoppedContainerAlarmTime = 0;
+    // Rate-limits the "whole_file overwrite exceeds MaxWholeFileBytes" warning so an oversized file does
+    // not flood the log on every read cycle.
+    time_t mWholeFileOversizeWarnTime = 0;
     int32_t mReadDelayTime = 0;
     bool mSkipFirstModify = false;
     // int64_t mReadDelayAlarmBytes;

--- a/core/unittest/reader/LogFileReaderUnittest.cpp
+++ b/core/unittest/reader/LogFileReaderUnittest.cpp
@@ -1379,6 +1379,7 @@ protected:
         bfs::create_directories(gRootDir);
         mReaderOpts.mInputType = FileReaderOptions::InputType::InputFile;
         mMultilineOpts.mMode = MultilineOptions::Mode::WHOLE_FILE;
+        mMultilineOpts.mFileWriteMode = MultilineOptions::FileWriteMode::OVERWRITE;
     }
     void TearDown() override { bfs::remove_all(gRootDir); }
 
@@ -1564,6 +1565,8 @@ class WholeFileOverwriteLargeUnittest : public ::testing::Test {
 public:
     void TestLargeFileChunkedDrain();
     void TestOverwriteDuringAccumulation();
+    void TestChunkLineAlignment();
+    void TestChunkCharAlignment();
     void TestAppendModeNoReset();
 
 protected:
@@ -1656,8 +1659,8 @@ void WholeFileOverwriteLargeUnittest::TestLargeFileChunkedDrain() {
     APSARA_TEST_TRUE_FATAL(totalChunks > 1); // must have been split
     APSARA_TEST_EQUAL_FATAL(reconstructed, content);
     // All chunks should report the same total
-    APSARA_TEST_EQUAL_FATAL(totalChunks,
-                            static_cast<int>((content.size() + LogFileReader::BUFFER_SIZE - 1) / LogFileReader::BUFFER_SIZE));
+    APSARA_TEST_EQUAL_FATAL(
+        totalChunks, static_cast<int>((content.size() + LogFileReader::BUFFER_SIZE - 1) / LogFileReader::BUFFER_SIZE));
 }
 
 void WholeFileOverwriteLargeUnittest::TestOverwriteDuringAccumulation() {
@@ -1724,6 +1727,103 @@ void WholeFileOverwriteLargeUnittest::TestOverwriteDuringAccumulation() {
     APSARA_TEST_EQUAL_FATAL(reconstructed, content2);
 }
 
+void WholeFileOverwriteLargeUnittest::TestChunkLineAlignment() {
+    // Multi-line content larger than BUFFER_SIZE: every non-final chunk must end on a line boundary
+    // so each chunk shown downstream (no reassembly) contains only whole lines.
+    std::string content;
+    content.reserve(600 * 1024);
+    int lineNo = 0;
+    while (content.size() < 600UL * 1024) {
+        std::string line = "this is log line number " + ToString(lineNo++) + " with some padding text here\n";
+        content += line;
+    }
+    APSARA_TEST_TRUE_FATAL(writeLog(gLogPath, content));
+
+    LogFileReader reader(gRootDir,
+                         gLogName,
+                         DevInode(),
+                         std::make_pair(&mReaderOpts, &mCtx),
+                         std::make_pair(&mMultilineOpts, &mCtx),
+                         std::make_pair(&mTagOpts, &mCtx));
+    reader.UpdateReaderManual();
+    reader.InitReader(true, LogFileReader::BACKWARD_TO_BEGINNING);
+    APSARA_TEST_TRUE_FATAL(reader.CheckFileSignatureAndOffset(true));
+
+    {
+        Event event(gRootDir, "", EVENT_MODIFY, 0);
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, &event);
+    }
+
+    std::vector<std::string> chunks;
+    bool moreData = true;
+    while (moreData) {
+        auto pEvent = reader.CreateFlushTimeoutEvent();
+        LogBuffer logbuf;
+        moreData = reader.ReadLog(logbuf, pEvent.get());
+        if (!logbuf.rawBuffer.empty()) {
+            chunks.emplace_back(logbuf.rawBuffer.data(), logbuf.rawBuffer.size());
+        }
+    }
+    APSARA_TEST_TRUE_FATAL(chunks.size() > 1); // must have been split
+    std::string reconstructed;
+    for (size_t i = 0; i < chunks.size(); ++i) {
+        reconstructed += chunks[i];
+        if (i + 1 < chunks.size()) {
+            // every non-final chunk ends on a complete line
+            APSARA_TEST_EQUAL_FATAL(chunks[i].back(), '\n');
+            APSARA_TEST_TRUE_FATAL(chunks[i].size() <= LogFileReader::BUFFER_SIZE);
+        }
+    }
+    APSARA_TEST_EQUAL_FATAL(reconstructed, content);
+}
+
+void WholeFileOverwriteLargeUnittest::TestChunkCharAlignment() {
+    // A single huge line of multibyte UTF-8 characters (no newline) must never be split inside a
+    // character: every chunk length stays a multiple of the 3-byte character width.
+    const std::string ch = "\xE4\xB8\xAD"; // "中", 3 bytes
+    std::string content;
+    content.reserve(600 * 1024);
+    while (content.size() < 600UL * 1024) {
+        content += ch;
+    }
+    APSARA_TEST_TRUE_FATAL(content.size() % 3 == 0);
+    APSARA_TEST_TRUE_FATAL(writeLog(gLogPath, content));
+
+    LogFileReader reader(gRootDir,
+                         gLogName,
+                         DevInode(),
+                         std::make_pair(&mReaderOpts, &mCtx),
+                         std::make_pair(&mMultilineOpts, &mCtx),
+                         std::make_pair(&mTagOpts, &mCtx));
+    reader.UpdateReaderManual();
+    reader.InitReader(true, LogFileReader::BACKWARD_TO_BEGINNING);
+    APSARA_TEST_TRUE_FATAL(reader.CheckFileSignatureAndOffset(true));
+
+    {
+        Event event(gRootDir, "", EVENT_MODIFY, 0);
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, &event);
+    }
+
+    std::string reconstructed;
+    bool moreData = true;
+    int totalChunks = 0;
+    while (moreData) {
+        auto pEvent = reader.CreateFlushTimeoutEvent();
+        LogBuffer logbuf;
+        moreData = reader.ReadLog(logbuf, pEvent.get());
+        if (!logbuf.rawBuffer.empty()) {
+            // chunk boundary never splits a 3-byte character
+            APSARA_TEST_EQUAL_FATAL(logbuf.rawBuffer.size() % 3, 0UL);
+            reconstructed.append(logbuf.rawBuffer.data(), logbuf.rawBuffer.size());
+            totalChunks++;
+        }
+    }
+    APSARA_TEST_TRUE_FATAL(totalChunks > 1);
+    APSARA_TEST_EQUAL_FATAL(reconstructed, content);
+}
+
 void WholeFileOverwriteLargeUnittest::TestAppendModeNoReset() {
     // Test that append mode does NOT reset position on mtime change
     FileReaderOptions appendOpts;
@@ -1775,6 +1875,8 @@ void WholeFileOverwriteLargeUnittest::TestAppendModeNoReset() {
 
 UNIT_TEST_CASE(WholeFileOverwriteLargeUnittest, TestLargeFileChunkedDrain);
 UNIT_TEST_CASE(WholeFileOverwriteLargeUnittest, TestOverwriteDuringAccumulation);
+UNIT_TEST_CASE(WholeFileOverwriteLargeUnittest, TestChunkLineAlignment);
+UNIT_TEST_CASE(WholeFileOverwriteLargeUnittest, TestChunkCharAlignment);
 UNIT_TEST_CASE(WholeFileOverwriteLargeUnittest, TestAppendModeNoReset);
 
 } // namespace logtail

--- a/core/unittest/reader/LogFileReaderUnittest.cpp
+++ b/core/unittest/reader/LogFileReaderUnittest.cpp
@@ -1560,6 +1560,223 @@ UNIT_TEST_CASE(WholeFileOverwriteUnittest, TestOverwriteSameSize);
 UNIT_TEST_CASE(WholeFileOverwriteUnittest, TestOverwriteLargerSize);
 UNIT_TEST_CASE(WholeFileOverwriteUnittest, TestOverwriteSmallerSize);
 
+class WholeFileOverwriteLargeUnittest : public ::testing::Test {
+public:
+    void TestLargeFileChunkedDrain();
+    void TestOverwriteDuringAccumulation();
+    void TestAppendModeNoReset();
+
+protected:
+    static void SetUpTestCase() {
+        srand(time(NULL));
+        gRootDir = GetProcessExecutionDir();
+        gLogName = "test_large.log";
+        if (PATH_SEPARATOR[0] == gRootDir.at(gRootDir.size() - 1)) {
+            gRootDir.resize(gRootDir.size() - 1);
+        }
+        gRootDir += PATH_SEPARATOR + "testDataSet" + PATH_SEPARATOR + "WholeFileOverwriteLargeUnittest";
+        gLogPath = gRootDir + PATH_SEPARATOR + gLogName;
+        bfs::remove_all(gRootDir);
+    }
+
+    static void TearDownTestCase() {}
+    void SetUp() override {
+        bfs::create_directories(gRootDir);
+        mReaderOpts.mInputType = FileReaderOptions::InputType::InputFile;
+        mMultilineOpts.mMode = MultilineOptions::Mode::WHOLE_FILE;
+        mMultilineOpts.mFileWriteMode = MultilineOptions::FileWriteMode::OVERWRITE;
+    }
+    void TearDown() override { bfs::remove_all(gRootDir); }
+
+    static std::string gRootDir;
+    static std::string gLogName;
+    static std::string gLogPath;
+
+private:
+    FileDiscoveryOptions mDiscoveryOpts;
+    FileReaderOptions mReaderOpts;
+    MultilineOptions mMultilineOpts;
+    FileTagOptions mTagOpts;
+    CollectionPipelineContext mCtx;
+
+    bool writeLog(const std::string& logPath, const std::string& logContent) {
+        std::ofstream writer(logPath.c_str(), std::fstream::out | std::fstream::trunc | std::ios_base::binary);
+        if (!writer) {
+            return false;
+        }
+        writer << logContent;
+        writer.close();
+        return true;
+    }
+};
+
+std::string WholeFileOverwriteLargeUnittest::gRootDir;
+std::string WholeFileOverwriteLargeUnittest::gLogName;
+std::string WholeFileOverwriteLargeUnittest::gLogPath;
+
+void WholeFileOverwriteLargeUnittest::TestLargeFileChunkedDrain() {
+    // Create content larger than BUFFER_SIZE (512KB)
+    std::string content(600 * 1024, 'A'); // 600KB
+    APSARA_TEST_TRUE_FATAL(writeLog(gLogPath, content));
+
+    LogFileReader reader(gRootDir,
+                         gLogName,
+                         DevInode(),
+                         std::make_pair(&mReaderOpts, &mCtx),
+                         std::make_pair(&mMultilineOpts, &mCtx),
+                         std::make_pair(&mTagOpts, &mCtx));
+    reader.UpdateReaderManual();
+    reader.InitReader(true, LogFileReader::BACKWARD_TO_BEGINNING);
+    APSARA_TEST_TRUE_FATAL(reader.CheckFileSignatureAndOffset(true));
+
+    // First read: entire file goes to cache (one-shot read bypasses BUFFER_SIZE)
+    {
+        Event event(gRootDir, "", EVENT_MODIFY, 0);
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, &event);
+        // Data should be in cache, not emitted (WHOLE_FILE caches until flush timeout)
+        APSARA_TEST_TRUE_FATAL(logbuf.rawBuffer.empty());
+    }
+
+    // Flush timeout: should trigger chunked drain
+    std::string reconstructed;
+    int totalChunks = 0;
+    bool moreData = true;
+    while (moreData) {
+        auto pEvent = reader.CreateFlushTimeoutEvent();
+        LogBuffer logbuf;
+        moreData = reader.ReadLog(logbuf, pEvent.get());
+        if (!logbuf.rawBuffer.empty()) {
+            APSARA_TEST_TRUE_FATAL(logbuf.wholeFileSeq >= 0);
+            APSARA_TEST_EQUAL_FATAL(logbuf.wholeFileSeq, totalChunks);
+            reconstructed.append(logbuf.rawBuffer.data(), logbuf.rawBuffer.size());
+            totalChunks++;
+        }
+    }
+    APSARA_TEST_TRUE_FATAL(totalChunks > 1); // must have been split
+    APSARA_TEST_EQUAL_FATAL(reconstructed, content);
+    // All chunks should report the same total
+    APSARA_TEST_EQUAL_FATAL(totalChunks,
+                            static_cast<int>((content.size() + LogFileReader::BUFFER_SIZE - 1) / LogFileReader::BUFFER_SIZE));
+}
+
+void WholeFileOverwriteLargeUnittest::TestOverwriteDuringAccumulation() {
+    // Write initial content and read it fully
+    std::string content1(600 * 1024, 'B');
+    APSARA_TEST_TRUE_FATAL(writeLog(gLogPath, content1));
+
+    LogFileReader reader(gRootDir,
+                         gLogName,
+                         DevInode(),
+                         std::make_pair(&mReaderOpts, &mCtx),
+                         std::make_pair(&mMultilineOpts, &mCtx),
+                         std::make_pair(&mTagOpts, &mCtx));
+    reader.UpdateReaderManual();
+    reader.InitReader(true, LogFileReader::BACKWARD_TO_BEGINNING);
+    APSARA_TEST_TRUE_FATAL(reader.CheckFileSignatureAndOffset(true));
+
+    // Read into cache
+    {
+        Event event(gRootDir, "", EVENT_MODIFY, 0);
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, &event);
+    }
+    // Drain first content
+    {
+        bool moreData = true;
+        while (moreData) {
+            auto pEvent = reader.CreateFlushTimeoutEvent();
+            LogBuffer logbuf;
+            moreData = reader.ReadLog(logbuf, pEvent.get());
+        }
+    }
+
+    // Overwrite with new content
+    sleep(1);
+    std::string content2(700 * 1024, 'C');
+    APSARA_TEST_TRUE_FATAL(writeLog(gLogPath, content2));
+
+    // CheckFileSignatureAndOffset should detect mtime change and reset
+    APSARA_TEST_TRUE_FATAL(reader.CheckFileSignatureAndOffset(true));
+    APSARA_TEST_EQUAL_FATAL(reader.mLastFilePos, 0);
+    APSARA_TEST_TRUE_FATAL(reader.mCache.empty());
+
+    // Read new content
+    {
+        Event event(gRootDir, "", EVENT_MODIFY, 0);
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, &event);
+    }
+
+    // Drain and verify we get new content, not old
+    std::string reconstructed;
+    {
+        bool moreData = true;
+        while (moreData) {
+            auto pEvent = reader.CreateFlushTimeoutEvent();
+            LogBuffer logbuf;
+            moreData = reader.ReadLog(logbuf, pEvent.get());
+            if (!logbuf.rawBuffer.empty()) {
+                reconstructed.append(logbuf.rawBuffer.data(), logbuf.rawBuffer.size());
+            }
+        }
+    }
+    APSARA_TEST_EQUAL_FATAL(reconstructed, content2);
+}
+
+void WholeFileOverwriteLargeUnittest::TestAppendModeNoReset() {
+    // Test that append mode does NOT reset position on mtime change
+    FileReaderOptions appendOpts;
+    appendOpts.mInputType = FileReaderOptions::InputType::InputFile;
+    MultilineOptions appendMultilineOpts;
+    appendMultilineOpts.mMode = MultilineOptions::Mode::WHOLE_FILE;
+    appendMultilineOpts.mFileWriteMode = MultilineOptions::FileWriteMode::APPEND;
+
+    std::string content1 = "initial content\n";
+    APSARA_TEST_TRUE_FATAL(writeLog(gLogPath, content1));
+
+    LogFileReader reader(gRootDir,
+                         gLogName,
+                         DevInode(),
+                         std::make_pair(&appendOpts, &mCtx),
+                         std::make_pair(&appendMultilineOpts, &mCtx),
+                         std::make_pair(&mTagOpts, &mCtx));
+    reader.UpdateReaderManual();
+    reader.InitReader(true, LogFileReader::BACKWARD_TO_BEGINNING);
+    APSARA_TEST_TRUE_FATAL(reader.CheckFileSignatureAndOffset(true));
+
+    // Read initial content
+    {
+        Event event(gRootDir, "", EVENT_MODIFY, 0);
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, &event);
+    }
+    {
+        auto pEvent = reader.CreateFlushTimeoutEvent();
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, pEvent.get());
+        APSARA_TEST_EQUAL_FATAL(std::string(logbuf.rawBuffer.data(), logbuf.rawBuffer.size()), "initial content");
+    }
+    int64_t posAfterFirstRead = reader.mLastFilePos;
+    APSARA_TEST_TRUE_FATAL(posAfterFirstRead > 0);
+
+    // Append more content (mtime changes)
+    sleep(1);
+    {
+        std::ofstream writer(gLogPath.c_str(), std::fstream::out | std::fstream::app | std::ios_base::binary);
+        writer << "appended content\n";
+        writer.close();
+    }
+
+    // CheckFileSignatureAndOffset should NOT reset position for append mode
+    APSARA_TEST_TRUE_FATAL(reader.CheckFileSignatureAndOffset(true));
+    APSARA_TEST_EQUAL_FATAL(reader.mLastFilePos, posAfterFirstRead);
+}
+
+UNIT_TEST_CASE(WholeFileOverwriteLargeUnittest, TestLargeFileChunkedDrain);
+UNIT_TEST_CASE(WholeFileOverwriteLargeUnittest, TestOverwriteDuringAccumulation);
+UNIT_TEST_CASE(WholeFileOverwriteLargeUnittest, TestAppendModeNoReset);
+
 } // namespace logtail
 
 int main(int argc, char** argv) {

--- a/core/unittest/reader/LogFileReaderUnittest.cpp
+++ b/core/unittest/reader/LogFileReaderUnittest.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstdio>
+#include <unistd.h>
 
 #include <fstream>
 
@@ -1353,6 +1354,211 @@ void LogFileReaderHoleUnittest::TestReadLogJsonHoleOnTheRight() {
 UNIT_TEST_CASE(LogFileReaderHoleUnittest, TestReadLogHoleInTheMiddle);
 UNIT_TEST_CASE(LogFileReaderHoleUnittest, TestReadLogHoleOnTheLeft);
 UNIT_TEST_CASE(LogFileReaderHoleUnittest, TestReadLogJsonHoleOnTheRight);
+
+class WholeFileOverwriteUnittest : public ::testing::Test {
+public:
+    void TestOverwriteSameSize();
+    void TestOverwriteLargerSize();
+    void TestOverwriteSmallerSize();
+
+protected:
+    static void SetUpTestCase() {
+        srand(time(NULL));
+        gRootDir = GetProcessExecutionDir();
+        gLogName = "test.log";
+        if (PATH_SEPARATOR[0] == gRootDir.at(gRootDir.size() - 1)) {
+            gRootDir.resize(gRootDir.size() - 1);
+        }
+        gRootDir += PATH_SEPARATOR + "testDataSet" + PATH_SEPARATOR + "WholeFileOverwriteUnittest";
+        gLogPath = gRootDir + PATH_SEPARATOR + gLogName;
+        bfs::remove_all(gRootDir);
+    }
+
+    static void TearDownTestCase() {}
+    void SetUp() override {
+        bfs::create_directories(gRootDir);
+        mReaderOpts.mInputType = FileReaderOptions::InputType::InputFile;
+        mMultilineOpts.mMode = MultilineOptions::Mode::WHOLE_FILE;
+    }
+    void TearDown() override { bfs::remove_all(gRootDir); }
+
+    static std::string gRootDir;
+    static std::string gLogName;
+    static std::string gLogPath;
+
+private:
+    FileDiscoveryOptions mDiscoveryOpts;
+    FileReaderOptions mReaderOpts;
+    MultilineOptions mMultilineOpts;
+    FileTagOptions mTagOpts;
+    CollectionPipelineContext mCtx;
+
+    bool writeLog(const std::string& logPath, const std::string& logContent) {
+        std::ofstream writer(logPath.c_str(), std::fstream::out | std::fstream::trunc | std::ios_base::binary);
+        if (!writer) {
+            return false;
+        }
+        writer << logContent;
+        writer.close();
+        return true;
+    }
+};
+
+std::string WholeFileOverwriteUnittest::gRootDir;
+std::string WholeFileOverwriteUnittest::gLogName;
+std::string WholeFileOverwriteUnittest::gLogPath;
+
+void WholeFileOverwriteUnittest::TestOverwriteSameSize() {
+    std::string content1 = R"({"key":"value1","data":"aaa"})";
+    APSARA_TEST_TRUE_FATAL(writeLog(gLogPath, content1));
+
+    LogFileReader reader(gRootDir,
+                         gLogName,
+                         DevInode(),
+                         std::make_pair(&mReaderOpts, &mCtx),
+                         std::make_pair(&mMultilineOpts, &mCtx),
+                         std::make_pair(&mTagOpts, &mCtx));
+    reader.UpdateReaderManual();
+    reader.InitReader(true, LogFileReader::BACKWARD_TO_BEGINNING);
+    APSARA_TEST_TRUE_FATAL(reader.CheckFileSignatureAndOffset(true));
+
+    // First read: data goes to cache (WHOLE_FILE mode caches until flush timeout)
+    {
+        Event event(gRootDir, "", EVENT_MODIFY, 0);
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, &event);
+    }
+    // Flush timeout: force read cached data
+    {
+        auto pEvent = reader.CreateFlushTimeoutEvent();
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, pEvent.get());
+        APSARA_TEST_EQUAL_FATAL(std::string(logbuf.rawBuffer.data(), logbuf.rawBuffer.size()), content1);
+    }
+    APSARA_TEST_EQUAL_FATAL(reader.mLastFilePos, (int64_t)content1.size());
+
+    // Overwrite with same-size content (same signature prefix)
+    sleep(1); // ensure mtime changes
+    std::string content2 = R"({"key":"value2","data":"bbb"})";
+    APSARA_TEST_EQUAL_FATAL(content1.size(), content2.size());
+    APSARA_TEST_TRUE_FATAL(writeLog(gLogPath, content2));
+
+    // CheckFileSignatureAndOffset should detect mtime change and reset position
+    APSARA_TEST_TRUE_FATAL(reader.CheckFileSignatureAndOffset(true));
+    APSARA_TEST_EQUAL_FATAL(reader.mLastFilePos, 0);
+    APSARA_TEST_TRUE_FATAL(reader.mCache.empty());
+
+    // Read again: should get complete new content
+    {
+        Event event(gRootDir, "", EVENT_MODIFY, 0);
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, &event);
+    }
+    {
+        auto pEvent = reader.CreateFlushTimeoutEvent();
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, pEvent.get());
+        APSARA_TEST_EQUAL_FATAL(std::string(logbuf.rawBuffer.data(), logbuf.rawBuffer.size()), content2);
+    }
+}
+
+void WholeFileOverwriteUnittest::TestOverwriteLargerSize() {
+    std::string content1 = R"({"key":"v1"})";
+    APSARA_TEST_TRUE_FATAL(writeLog(gLogPath, content1));
+
+    LogFileReader reader(gRootDir,
+                         gLogName,
+                         DevInode(),
+                         std::make_pair(&mReaderOpts, &mCtx),
+                         std::make_pair(&mMultilineOpts, &mCtx),
+                         std::make_pair(&mTagOpts, &mCtx));
+    reader.UpdateReaderManual();
+    reader.InitReader(true, LogFileReader::BACKWARD_TO_BEGINNING);
+    APSARA_TEST_TRUE_FATAL(reader.CheckFileSignatureAndOffset(true));
+
+    {
+        Event event(gRootDir, "", EVENT_MODIFY, 0);
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, &event);
+    }
+    {
+        auto pEvent = reader.CreateFlushTimeoutEvent();
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, pEvent.get());
+        APSARA_TEST_EQUAL_FATAL(std::string(logbuf.rawBuffer.data(), logbuf.rawBuffer.size()), content1);
+    }
+
+    // Overwrite with larger content
+    sleep(1);
+    std::string content2 = R"({"key":"value2","extra":"more_data_here"})";
+    APSARA_TEST_TRUE_FATAL(writeLog(gLogPath, content2));
+
+    APSARA_TEST_TRUE_FATAL(reader.CheckFileSignatureAndOffset(true));
+    APSARA_TEST_EQUAL_FATAL(reader.mLastFilePos, 0);
+
+    {
+        Event event(gRootDir, "", EVENT_MODIFY, 0);
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, &event);
+    }
+    {
+        auto pEvent = reader.CreateFlushTimeoutEvent();
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, pEvent.get());
+        APSARA_TEST_EQUAL_FATAL(std::string(logbuf.rawBuffer.data(), logbuf.rawBuffer.size()), content2);
+    }
+}
+
+void WholeFileOverwriteUnittest::TestOverwriteSmallerSize() {
+    std::string content1 = R"({"key":"value1","extra":"some_data"})";
+    APSARA_TEST_TRUE_FATAL(writeLog(gLogPath, content1));
+
+    LogFileReader reader(gRootDir,
+                         gLogName,
+                         DevInode(),
+                         std::make_pair(&mReaderOpts, &mCtx),
+                         std::make_pair(&mMultilineOpts, &mCtx),
+                         std::make_pair(&mTagOpts, &mCtx));
+    reader.UpdateReaderManual();
+    reader.InitReader(true, LogFileReader::BACKWARD_TO_BEGINNING);
+    APSARA_TEST_TRUE_FATAL(reader.CheckFileSignatureAndOffset(true));
+
+    {
+        Event event(gRootDir, "", EVENT_MODIFY, 0);
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, &event);
+    }
+    {
+        auto pEvent = reader.CreateFlushTimeoutEvent();
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, pEvent.get());
+        APSARA_TEST_EQUAL_FATAL(std::string(logbuf.rawBuffer.data(), logbuf.rawBuffer.size()), content1);
+    }
+
+    // Overwrite with smaller content
+    sleep(1);
+    std::string content2 = R"({"key":"v2"})";
+    APSARA_TEST_TRUE_FATAL(writeLog(gLogPath, content2));
+
+    APSARA_TEST_TRUE_FATAL(reader.CheckFileSignatureAndOffset(true));
+    APSARA_TEST_EQUAL_FATAL(reader.mLastFilePos, 0);
+
+    {
+        Event event(gRootDir, "", EVENT_MODIFY, 0);
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, &event);
+    }
+    {
+        auto pEvent = reader.CreateFlushTimeoutEvent();
+        LogBuffer logbuf;
+        reader.ReadLog(logbuf, pEvent.get());
+        APSARA_TEST_EQUAL_FATAL(std::string(logbuf.rawBuffer.data(), logbuf.rawBuffer.size()), content2);
+    }
+}
+
+UNIT_TEST_CASE(WholeFileOverwriteUnittest, TestOverwriteSameSize);
+UNIT_TEST_CASE(WholeFileOverwriteUnittest, TestOverwriteLargerSize);
+UNIT_TEST_CASE(WholeFileOverwriteUnittest, TestOverwriteSmallerSize);
 
 } // namespace logtail
 

--- a/docs/cn/plugins/input/native/input-container-stdio.md
+++ b/docs/cn/plugins/input/native/input-container-stdio.md
@@ -26,7 +26,7 @@
 |  ContainerFilters  |  object  |  否  |  空  |  容器过滤选项。多个选项之间为“且”的关系，详见表2。  |
 |  ExternalK8sLabelTag  |  map[string]string  |  否  |  空  |  对于部署于K8s环境的容器，需要在日志中额外添加的与Pod标签相关的tag。map中的key为Pod标签名，value为对应的tag名。 例如：在map中添加`app: k8s_label_app`，则若pod中包含`app=serviceA`的标签时，会将该信息以tag的形式添加到日志中，即添加字段\_\_tag\_\_:k8s\_label\_app: serviceA；若不包含`app`标签，则会添加空字段\_\_tag\_\_:k8s\_label\_app:  |
 |  ExternalEnvTag  |  map[string]string  |  否  |  空  |  对于部署于K8s环境的容器，需要在日志中额外添加的与容器环境变量相关的tag。map中的key为环境变量名，value为对应的tag名。 例如：在map中添加`VERSION: env_version`，则当容器中包含环境变量`VERSION=v1.0.0`时，会将该信息以tag的形式添加到日志中，即添加字段\_\_tag\_\_:env\_version: v1.0.0；若不包含`VERSION`环境变量，则会添加空字段\_\_tag\_\_:env\_version:  |
-|  FlushTimeoutSecs  |  uint  |  否  |  5  |  当文件超过指定时间未出现新的完整日志行时，将当前读取缓存中的内容作为**一条数据**输出。  |
+|  FlushTimeoutSecs  |  uint  |  否  |  60  |  当文件超过指定时间未出现新的完整日志行时，将当前读取缓存中的内容作为**一条数据**输出。  |
 |  AllowingIncludedByMultiConfigs  |  bool  |  否  |  false  |  是否允许当前配置采集其它配置已匹配的容器的标准输出日志。  |
 |  Tags | map[string]string | 否 | 空 | 重命名或删除tag。map中的key为原tag名，value为新tag名。若value为空，则删除原tag。若value为`__default__`，则使用默认值。支持配置的Tag名和默认值参照后文的表3。  |
 
@@ -34,10 +34,12 @@
 
 |  **参数**  |  **类型**  |  **是否必填**  |  **默认值**  |  **说明**  |
 | --- | --- | --- | --- | --- |
-|  Mode  |  string  |  否  |  custom  |  多行聚合模式。可选值包括custom和JSON。  |
+|  Mode  |  string  |  否  |  custom  |  多行聚合模式。可选值包括custom、JSON和whole_file。其中whole_file表示将整个文件作为**一条**日志记录采集。  |
 |  StartPattern  |  string  |  当Multiline.Mode取值为custom时，至少1个必填  |  空  |  行首正则表达式。  |
 |  ContinuePattern  |  string  |  |  空  |  行继续正则表达式。  |
 |  EndPattern  |  string  |  |  空  |  行尾正则表达式。  |
+|  FileWriteMode  |  string  |  否  |  append  |  文件写入模式，仅当Multiline.Mode为whole_file时生效。可选值包括append和overwrite：<ul><li>append：文件以追加方式写入；</li><li>overwrite：文件被整体改写（原地truncate后重写），此时从头重新读取整个文件。</li></ul>   |
+|  MaxWholeFileBytes  |  uint  |  否  |  10485760  |  整文件采集时允许的最大文件字节数，仅当Multiline.Mode为whole_file时生效，默认10MB。当文件大小超过该上限时将被跳过不采集。  |
 |  UnmatchedContentTreatment  |  string  |  否  |  single_line  |  对于无法匹配的日志段的处理方式，可选值如下：<ul><li>discard：丢弃</li><li>single_line：将不匹配日志段的每一行各自存放在一个单独的事件中</li></ul>   |
 
 * 表2：容器过滤选项

--- a/docs/cn/plugins/input/native/input-file.md
+++ b/docs/cn/plugins/input/native/input-file.md
@@ -31,7 +31,7 @@
 |  ExternalK8sLabelTag  |  map[string]string  |  否  |  空  |  对于部署于K8s环境的容器，需要在日志中额外添加的与Pod标签相关的tag。map中的key为Pod标签名，value为对应的tag名。 例如：在map中添加`app: k8s_label_app`，则若pod中包含`app=serviceA`的标签时，会将该信息以tag的形式添加到日志中，即添加字段\_\_tag\_\_:k8s\_label\_app: serviceA；若不包含`app`标签，则会添加空字段\_\_tag\_\_:k8s\_label\_app:  |
 |  ExternalEnvTag  |  map[string]string  |  否  |  空  |  对于部署于K8s环境的容器，需要在日志中额外添加的与容器环境变量相关的tag。map中的key为环境变量名，value为对应的tag名。 例如：在map中添加`VERSION: env_version`，则当容器中包含环境变量`VERSION=v1.0.0`时，会将该信息以tag的形式添加到日志中，即添加字段\_\_tag\_\_:env\_version: v1.0.0；若不包含`VERSION`环境变量，则会添加空字段\_\_tag\_\_:env\_version:  |
 |  AppendingLogPositionMeta  |  bool  |  否  |  false  |  是否在日志中添加该条日志所属文件的元信息，包括\_\_tag\_\_:\_\_inode\_\_字段和\_\_file\_offset\_\_字段。  |
-|  FlushTimeoutSecs  |  uint  |  否  |  5  |  当文件超过指定时间未出现新的完整日志行时，将当前读取缓存中的内容作为**一条数据**输出。  |
+|  FlushTimeoutSecs  |  uint  |  否  |  60  |  当文件超过指定时间未出现新的完整日志行时，将当前读取缓存中的内容作为**一条数据**输出。  |
 |  EnableExactlyOnce  |  uint  |  否  |  0  |  **实验功能！**Exactly Once 并发度（>0 启用 Exactly Once 处理与提交保障）。  |
 |  AllowingIncludedByMultiConfigs  |  bool  |  否  |  false  |  是否允许当前配置采集其它配置已匹配的文件。  |
 |  FileOffsetKey | string | 否 | log.file.offset | 用于指定日志文件偏移量的字段名。 |
@@ -41,10 +41,12 @@
 
 |  **参数**  |  **类型**  |  **是否必填**  |  **默认值**  |  **说明**  |
 | --- | --- | --- | --- | --- |
-|  Mode  |  string  |  否  |  custom  |  多行聚合模式。可选值包括custom和JSON。  |
+|  Mode  |  string  |  否  |  custom  |  多行聚合模式。可选值包括custom、JSON和whole_file。其中whole_file表示将整个文件作为**一条**日志记录采集。  |
 |  StartPattern  |  string  |  当Multiline.Mode取值为custom时，至少1个必填  |  空  |  行首正则表达式。  |
 |  ContinuePattern  |  string  |  |  空  |  行继续正则表达式。  |
 |  EndPattern  |  string  |  |  空  |  行尾正则表达式。  |
+|  FileWriteMode  |  string  |  否  |  append  |  文件写入模式，仅当Multiline.Mode为whole_file时生效。可选值包括append和overwrite：<ul><li>append：文件以追加方式写入；</li><li>overwrite：文件被整体改写（原地truncate后重写），此时从头重新读取整个文件。</li></ul>   |
+|  MaxWholeFileBytes  |  uint  |  否  |  10485760  |  整文件采集时允许的最大文件字节数，仅当Multiline.Mode为whole_file时生效，默认10MB。当文件大小超过该上限时将被跳过不采集。  |
 |  UnmatchedContentTreatment  |  string  |  否  |  single_line  |  对于无法匹配的日志段的处理方式，可选值如下：<ul><li>discard：丢弃</li><li>single_line：将不匹配日志段的每一行各自存放在一个单独的事件中</li></ul>   |
 
 * 表2：容器过滤选项

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,6 @@ require (
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1
-	sigs.k8s.io/controller-runtime v0.12.1
 )
 
 require (
@@ -282,6 +281,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
+	sigs.k8s.io/controller-runtime v0.12.1 // indirect
 	sigs.k8s.io/gateway-api v0.6.2 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect

--- a/test/e2e/e2e_host_test.go
+++ b/test/e2e/e2e_host_test.go
@@ -1,0 +1,45 @@
+// Copyright 2024 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package e2e
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cucumber/godog"
+
+	"github.com/alibaba/ilogtail/test/engine"
+)
+
+func TestE2EOnHost(t *testing.T) {
+	caseName := os.Getenv("TEST_CASE")
+	featurePath := "test_cases"
+	if caseName != "" {
+		featurePath += "/" + caseName
+	}
+	suite := godog.TestSuite{
+		Name:                "E2EOnHost",
+		ScenarioInitializer: engine.ScenarioInitializer,
+		Options: &godog.Options{
+			Format:    "pretty",
+			Paths:     []string{featurePath},
+			Tags:      "@e2e && @host && ~@ebpf && ~@disabled",
+			TestingT:  t,
+			Randomize: -1,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fail()
+	}
+}

--- a/test/e2e/test_cases/reader_whole_file_overwrite/case.feature
+++ b/test/e2e/test_cases/reader_whole_file_overwrite/case.feature
@@ -1,0 +1,61 @@
+@input
+Feature: reader whole file overwrite
+  Test whole_file collection mode with overwrite file write mode (host environment)
+
+  # whole_file: the whole file is collected as ONE log record.
+  # FileWriteMode/MaxWholeFileBytes MUST be nested inside the Multiline block
+  # (same level as Mode), because InputFile passes the Multiline sub-object to
+  # MultilineOptions::Init and those params are read from that node. Putting them
+  # at the same level as Multiline makes parsing fall back to append mode.
+  #
+  # Behaviors covered:
+  #   1. whole file == one record: a small multi-line file is collected as a
+  #      SINGLE log whose content equals the whole file content (the trailing
+  #      newline is trimmed by the reader).
+  #   2. overwrite triggers a full re-read: the same file is rewritten in place
+  #      with different (larger) content, so mtime/size/signature change and the
+  #      reader re-reads the WHOLE new file (not just an appended tail).
+  #
+  # Host-mode flow: the agent is already running on the host; the config is
+  # delivered into the local config dir, then the file under test is seeded with
+  # the "alpha" content (3 lines) and later overwritten IN PLACE with the "beta"
+  # content (4 lines) via `run command on loongcollector`. Hence exactly 2
+  # records are expected, and each record must equal one of the two whole-file
+  # contents (proving each file collapses to a single record).
+  #
+  # TODO(optional, heavy): large file (>512KB) chunked drain with line/char
+  # alignment is covered by core unit tests (WholeFileOverwriteLargeUnittest). It
+  # is intentionally not reproduced here because constructing and asserting the
+  # per-chunk boundaries through the subscriber is not supported by the current
+  # E2E step set.
+
+  @e2e @host
+  Scenario: TestReaderWholeFileOverwrite
+    Given {host} environment
+    Given subcribe data from {sls} with config
+    """
+    """
+    Given {reader-whole-file-overwrite-case} local config as below
+    """
+    enable: true
+    inputs:
+      - Type: input_file
+        FilePaths:
+          - /tmp/loongcollector/whole_file_overwrite/*.log
+        FlushTimeoutSecs: 2
+        Multiline:
+          Mode: whole_file
+          FileWriteMode: overwrite
+          MaxWholeFileBytes: 10485760
+    """
+    Given run command on loongcollector {mkdir -p /tmp/loongcollector/whole_file_overwrite && rm -f /tmp/loongcollector/whole_file_overwrite/a.log}
+    When begin trigger
+    Given run command on loongcollector {printf 'alpha-line-1\nalpha-line-2\nalpha-line-3\n' > /tmp/loongcollector/whole_file_overwrite/a.log}
+    Then wait {25} seconds
+    Given run command on loongcollector {printf 'beta-line-1\nbeta-line-2\nbeta-line-3\nbeta-line-4\n' > /tmp/loongcollector/whole_file_overwrite/a.log}
+    Then wait {15} seconds
+    Then there is {2} logs
+    Then the log fields match kv
+    """
+    content: "^(alpha-line-1\nalpha-line-2\nalpha-line-3|beta-line-1\nbeta-line-2\nbeta-line-3\nbeta-line-4)\n?$"
+    """


### PR DESCRIPTION
## Background

In whole_file overwrite mode the entire file is one log record, but relying solely on second-precision mtime
missed same-second in-place rewrites; oversized files were also split on fixed byte counts, breaking lines and
multibyte characters and making downstream output unreadable.

## Scope of Changes

1. **Overwrite detection**: `CheckFileSignatureAndOffset` now combines nanosecond mtime, file size, and the
   first-1KB signature (OR), reads the signature only when mtime/size are unchanged, and adds the
   `mLastMTimeNs` / `mLastWholeFileSize` baselines.
2. **Chunked output**: Extracts `DrainWholeFileChunk` / `GetWholeFileChunkSize` / `CountWholeFileChunks`, sizing
   chunks line-first with a character-aligned fallback and converting GBK to UTF8 per chunk so each chunk is
   independently readable.
3. **Oversize warning rate-limit**: The `MaxWholeFileBytes` warning in `getNextReadSize` is throttled by
   `logtail_alarm_interval` to avoid flooding the log on every read (`mWholeFileOversizeWarnTime`).
4. **Tests and docs**: Adds `TestChunkLineAlignment` / `TestChunkCharAlignment` and fixes the case `SetUp` to set
   OVERWRITE; docs add whole_file, `FileWriteMode`, `MaxWholeFileBytes`, and fix the `FlushTimeoutSecs` default to 60.
5. **E2E case (host mode)**: The `reader_whole_file_overwrite` case switches to the `@host` environment and the
   `sls` subscriber, seeding alpha and overwriting it in place with beta via `run command on loongcollector`,
   validating single-record whole-file collection and a full re-read triggered by the overwrite.
6. **E2E host runner**: Adds `test/e2e/e2e_host_test.go` (`TestE2EOnHost`) to drive `@host`-tagged cases, filling
   the gap where the open-source test/e2e only had a `@docker-compose` runner (with a minor `go.mod` indirect
   dependency adjustment).