### PR TITLE
fix(input_etw): harden ETW session cleanup and naming

### DIFF
--- a/plugins/input/input_etw/etw.go
+++ b/plugins/input/input_etw/etw.go
@@ -5,6 +5,7 @@ package input_etw
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -43,6 +44,8 @@ var newEtwSession = func(guid windows.GUID, options ...etwSessionOption) (etwSes
 	return etw.NewSession(guid, options...)
 }
 
+var killEtwSession = etw.KillSession
+
 type KeywordMask uint64
 
 func (k *KeywordMask) UnmarshalJSON(data []byte) error {
@@ -73,8 +76,10 @@ type EtwInput struct {
 	ProviderName string
 	ProviderGUID string
 	Source       string
-	Level        int
-	Keywords     KeywordMask
+	// SessionName fixes the ETW session name. When set, startup can reclaim a stale session with the same name.
+	SessionName string
+	Level       int
+	Keywords    KeywordMask
 	// DNSQueryDomainFilters drops Microsoft-Windows-DNSServer events whose dns_query matches.
 	// It supports exact domains and leading wildcard suffixes such as "*.azure.cn".
 	DNSQueryDomainFilters []string
@@ -141,6 +146,10 @@ func (d *EtwInput) Init(context pipeline.Context) (int, error) {
 	if d.Source == "" {
 		d.Source = "etw"
 	}
+	d.SessionName = strings.TrimSpace(d.SessionName)
+	if strings.ContainsRune(d.SessionName, '\x00') {
+		return 0, fmt.Errorf("invalid SessionName: must not contain NUL")
+	}
 
 	var guidStr string
 	if d.ProviderName != "" {
@@ -203,9 +212,9 @@ func (d *EtwInput) Init(context pipeline.Context) (int, error) {
 	}
 
 	logger.Infof(d.context.GetRuntimeContext(),
-		"service_etw init: guid=%s level=%d keywords=0x%X async=%t queue=%d workers=%d dropWhenFull=%t parsePacketData=%t bufferSizeKB=%d minBuffers=%d maxBuffers=%d flushTimerSec=%d",
+		"service_etw init: guid=%s level=%d keywords=0x%X async=%t queue=%d workers=%d dropWhenFull=%t parsePacketData=%t bufferSizeKB=%d minBuffers=%d maxBuffers=%d flushTimerSec=%d sessionName=%q",
 		guidStr, d.Level, uint64(d.Keywords), d.AsyncProcess, d.EventQueueSize, d.WorkerCount, d.DropWhenQueueFull, d.parsePacketDataEnabled(),
-		d.BufferSizeKB, d.MinBuffers, d.MaxBuffers, d.FlushTimerSec)
+		d.BufferSizeKB, d.MinBuffers, d.MaxBuffers, d.FlushTimerSec, d.SessionName)
 	return 0, nil
 }
 
@@ -332,6 +341,9 @@ func (d *EtwInput) runSession() error {
 		etw.WithLevel(etw.TraceLevel(d.Level)),
 		etw.WithMatchKeywords(uint64(d.Keywords), 0),
 	}
+	if d.SessionName != "" {
+		options = append(options, etw.WithName(d.SessionName))
+	}
 	if d.BufferSizeKB > 0 {
 		options = append(options, etw.WithBufferSizeKB(d.BufferSizeKB))
 	}
@@ -350,7 +362,7 @@ func (d *EtwInput) runSession() error {
 		d.mu.Unlock()
 		return nil
 	}
-	session, err := newEtwSession(d.parsedGUID, options...)
+	session, err := d.createSession(options...)
 	if err != nil {
 		d.mu.Unlock()
 		return fmt.Errorf("create ETW session: %w", err)
@@ -378,6 +390,34 @@ func (d *EtwInput) runSession() error {
 		return fmt.Errorf("process ETW session: %w", err)
 	}
 	return nil
+}
+
+func (d *EtwInput) createSession(options ...etwSessionOption) (etwSession, error) {
+	session, err := newEtwSession(d.parsedGUID, options...)
+	if err == nil || d.SessionName == "" {
+		return session, err
+	}
+
+	var exists etw.ExistsError
+	if !errors.As(err, &exists) {
+		return nil, err
+	}
+
+	sessionName := exists.SessionName
+	if sessionName == "" {
+		sessionName = d.SessionName
+	}
+	logger.Warningf(d.context.GetRuntimeContext(),
+		etwAlarmType, "ETW session %q already exists; stopping stale session before recreate", sessionName)
+	if killErr := killEtwSession(sessionName); killErr != nil {
+		return nil, fmt.Errorf("stop existing ETW session %q: %w", sessionName, killErr)
+	}
+
+	session, err = newEtwSession(d.parsedGUID, options...)
+	if err != nil {
+		return nil, fmt.Errorf("recreate ETW session %q after stopping stale session: %w", sessionName, err)
+	}
+	return session, nil
 }
 
 func (d *EtwInput) isStopped() bool {

--- a/plugins/input/input_etw/etw.go
+++ b/plugins/input/input_etw/etw.go
@@ -407,9 +407,8 @@ func (d *EtwInput) createSession(options ...etwSessionOption) (etwSession, error
 	if sessionName == "" {
 		sessionName = d.SessionName
 	}
-	logger.Warningf(d.context.GetRuntimeContext(),
-		etwAlarmType, "ETW session %q already exists; stopping stale session before recreate", sessionName)
-	if killErr := killEtwSession(sessionName); killErr != nil {
+	logger.Infof(d.context.GetRuntimeContext(),
+		"ETW session %q already exists; stopping stale session before recreate", sessionName)
 		return nil, fmt.Errorf("stop existing ETW session %q: %w", sessionName, killErr)
 	}
 

--- a/plugins/input/input_etw/etw.go
+++ b/plugins/input/input_etw/etw.go
@@ -407,8 +407,9 @@ func (d *EtwInput) createSession(options ...etwSessionOption) (etwSession, error
 	if sessionName == "" {
 		sessionName = d.SessionName
 	}
-	logger.Infof(d.context.GetRuntimeContext(),
-		"ETW session %q already exists; stopping stale session before recreate", sessionName)
+	logger.Warningf(d.context.GetRuntimeContext(),
+		etwAlarmType, "ETW session %q already exists; stopping stale session before recreate", sessionName)
+	if killErr := killEtwSession(sessionName); killErr != nil {
 		return nil, fmt.Errorf("stop existing ETW session %q: %w", sessionName, killErr)
 	}
 

--- a/plugins/input/input_etw/etw.go
+++ b/plugins/input/input_etw/etw.go
@@ -32,6 +32,17 @@ const (
 
 var asyncEnqueueTimeout = 5 * time.Second
 
+type etwSession interface {
+	Process(etw.EventCallback) error
+	Close() error
+}
+
+type etwSessionOption = etw.Option
+
+var newEtwSession = func(guid windows.GUID, options ...etwSessionOption) (etwSession, error) {
+	return etw.NewSession(guid, options...)
+}
+
 type KeywordMask uint64
 
 func (k *KeywordMask) UnmarshalJSON(data []byte) error {
@@ -80,7 +91,7 @@ type EtwInput struct {
 	FlushTimerSec     uint32
 
 	parsedGUID  windows.GUID
-	session     *etw.Session
+	session     etwSession
 	context     pipeline.Context
 	collector   pipeline.Collector
 	hostname    string
@@ -317,7 +328,7 @@ func (d *EtwInput) prepareRun() <-chan struct{} {
 }
 
 func (d *EtwInput) runSession() error {
-	options := []etw.Option{
+	options := []etwSessionOption{
 		etw.WithLevel(etw.TraceLevel(d.Level)),
 		etw.WithMatchKeywords(uint64(d.Keywords), 0),
 	}
@@ -339,7 +350,7 @@ func (d *EtwInput) runSession() error {
 		d.mu.Unlock()
 		return nil
 	}
-	session, err := etw.NewSession(d.parsedGUID, options...)
+	session, err := newEtwSession(d.parsedGUID, options...)
 	if err != nil {
 		d.mu.Unlock()
 		return fmt.Errorf("create ETW session: %w", err)
@@ -347,11 +358,16 @@ func (d *EtwInput) runSession() error {
 	d.session = session
 	d.mu.Unlock()
 	defer func() {
+		shouldClose := false
 		d.mu.Lock()
 		if d.session == session {
 			d.session = nil
+			shouldClose = true
 		}
 		d.mu.Unlock()
+		if shouldClose {
+			_ = session.Close()
+		}
 	}()
 
 	cb := func(e *etw.Event) { d.handleEvent(e) }

--- a/plugins/input/input_etw/etw_test.go
+++ b/plugins/input/input_etw/etw_test.go
@@ -857,6 +857,80 @@ func TestEtwInput_RunSessionClosesSessionWhenProcessReturns(t *testing.T) {
 	assert.Equal(t, 1, fake.closeCalls)
 }
 
+func TestEtwInput_RunSessionUsesConfiguredSessionName(t *testing.T) {
+	input := &EtwInput{
+		ProviderGUID: "{22FB2CD6-0E7B-422B-A0C7-2FAD1FD0E716}",
+		SessionName:  "loongcollector-etw-dns",
+	}
+	ctx := mock.NewEmptyContext("test", "test", "test")
+	_, err := input.Init(ctx)
+	require.NoError(t, err)
+	input.prepareRun()
+
+	fake := &fakeEtwSession{processErr: assert.AnError}
+	var gotOptions []etwSessionOption
+	originalFactory := newEtwSession
+	newEtwSession = func(_ windows.GUID, options ...etwSessionOption) (etwSession, error) {
+		gotOptions = append([]etwSessionOption(nil), options...)
+		return fake, nil
+	}
+	defer func() { newEtwSession = originalFactory }()
+
+	err = input.runSession()
+
+	require.Error(t, err)
+	cfg := applySessionOptions(gotOptions)
+	assert.Equal(t, "loongcollector-etw-dns", cfg.Name)
+	assert.Equal(t, 1, fake.closeCalls)
+}
+
+func TestEtwInput_RunSessionStopsExistingNamedSessionBeforeRetry(t *testing.T) {
+	input := &EtwInput{
+		ProviderGUID: "{22FB2CD6-0E7B-422B-A0C7-2FAD1FD0E716}",
+		SessionName:  "loongcollector-etw-dns",
+	}
+	ctx := mock.NewEmptyContext("test", "test", "test")
+	_, err := input.Init(ctx)
+	require.NoError(t, err)
+	input.prepareRun()
+
+	fake := &fakeEtwSession{processErr: assert.AnError}
+	createCalls := 0
+	originalFactory := newEtwSession
+	newEtwSession = func(_ windows.GUID, _ ...etwSessionOption) (etwSession, error) {
+		createCalls++
+		if createCalls == 1 {
+			return nil, etw.ExistsError{SessionName: "loongcollector-etw-dns"}
+		}
+		return fake, nil
+	}
+	defer func() { newEtwSession = originalFactory }()
+
+	var killed []string
+	originalKill := killEtwSession
+	killEtwSession = func(name string) error {
+		killed = append(killed, name)
+		return nil
+	}
+	defer func() { killEtwSession = originalKill }()
+
+	err = input.runSession()
+
+	require.Error(t, err)
+	assert.Equal(t, 2, createCalls)
+	assert.Equal(t, []string{"loongcollector-etw-dns"}, killed)
+	assert.Equal(t, 1, fake.processCalls)
+	assert.Equal(t, 1, fake.closeCalls)
+}
+
+func applySessionOptions(options []etwSessionOption) etw.SessionOptions {
+	var cfg etw.SessionOptions
+	for _, opt := range options {
+		opt(&cfg)
+	}
+	return cfg
+}
+
 type fakeEtwSession struct {
 	processErr   error
 	processCalls int

--- a/plugins/input/input_etw/etw_test.go
+++ b/plugins/input/input_etw/etw_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bi-zone/etw"
 	"golang.org/x/sys/windows"
 
 	"github.com/miekg/dns"
@@ -715,7 +716,7 @@ func TestParseDNSPacketData_NXDomain(t *testing.T) {
 }
 
 func TestParseDNSPacketData_HexPrefix(t *testing.T) {
-	// Same packet with 0x prefix and spaces — should still parse
+	// Same packet with 0x prefix and spaces should still parse.
 	packetHex := "0x 1234 8180 0001 0001 0000 0000 0765" +
 		"78616d706c6503636f6d0000010001" +
 		"c00c000100010000003c00045db8d822"
@@ -831,4 +832,43 @@ func TestFormatRR_SOA(t *testing.T) {
 func TestFormatRR_SRV(t *testing.T) {
 	rr, _ := dns.NewRR("_sip._tcp.example.com. 60 IN SRV 10 60 5060 sip.example.com.")
 	assert.Equal(t, "10 60 5060 sip.example.com", formatRR(rr))
+}
+
+func TestEtwInput_RunSessionClosesSessionWhenProcessReturns(t *testing.T) {
+	input := &EtwInput{
+		ProviderGUID: "{22FB2CD6-0E7B-422B-A0C7-2FAD1FD0E716}",
+	}
+	ctx := mock.NewEmptyContext("test", "test", "test")
+	_, err := input.Init(ctx)
+	require.NoError(t, err)
+	input.prepareRun()
+
+	fake := &fakeEtwSession{processErr: assert.AnError}
+	originalFactory := newEtwSession
+	newEtwSession = func(windows.GUID, ...etwSessionOption) (etwSession, error) {
+		return fake, nil
+	}
+	defer func() { newEtwSession = originalFactory }()
+
+	err = input.runSession()
+
+	require.Error(t, err)
+	assert.Equal(t, 1, fake.processCalls)
+	assert.Equal(t, 1, fake.closeCalls)
+}
+
+type fakeEtwSession struct {
+	processErr   error
+	processCalls int
+	closeCalls   int
+}
+
+func (s *fakeEtwSession) Process(etw.EventCallback) error {
+	s.processCalls++
+	return s.processErr
+}
+
+func (s *fakeEtwSession) Close() error {
+	s.closeCalls++
+	return nil
 }


### PR DESCRIPTION
## Summary

  - Close ETW sessions when `Process` returns unexpectedly, avoiding session handle leaks after processing errors.
  - Add configurable fixed ETW `SessionName` for `service_etw`.
  - When a configured named ETW session already exists on startup, stop the stale session and recreate it.
  - Add regression tests for session close behavior, configured session name propagation, and stale named session cleanup.

  ## Verification

  - `git diff --check upstream-ssh/main...HEAD`
  - `go test -count=1 -v ./plugins/input/input_etw/...`
  - `go build -mod=mod -buildmode=c-shared -ldflags "-X github.com/alibaba/ilogtail/pluginmanager.BaseVersion=3.0.0" -o output\GoPluginBase.dll .\plugin_main`