### PR TITLE
docs(code-review): add minimal reuse hints to skill and codebase-map

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -377,7 +377,8 @@ snapshot 在增量决策中的职责（必须遵守）：
 
 ### Sub-agent D: 复用合规与文档一致性
 
-- 是否重复实现了已有公共能力（优先复用 `core/common` 与现有工具函数）。
+- 是否重复实现了已有公共能力（优先复用 `core/common` 与现有工具函数）；先对照 `/.cursor/rules/project-knowledge/codebase-map.md` §2 检索，map 缺项则评审后补充。
+- 新增多套同构 map/LRU 时，质疑能否合并为单一状态 entry（勿仅复述作者拆分）。
 - 注释与代码行为是否一致，TODO/FIXME 是否引入新技术债。
 - 插件配置或 `GetXxxParam` 改动是否同步更新 `docs/` 对应文档。
 - 重点覆盖评估标准：可维护性、兼容性与文档测试。

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -378,7 +378,7 @@ snapshot 在增量决策中的职责（必须遵守）：
 ### Sub-agent D: 复用合规与文档一致性
 
 - 是否重复实现了已有公共能力（优先复用 `core/common` 与现有工具函数）；先对照 `/.cursor/rules/project-knowledge/codebase-map.md` §2 检索，map 缺项则评审后补充。
-- 新增多套同构 map/LRU 时，质疑能否合并为单一状态 entry（勿仅复述作者拆分）。
+- 质疑多套同构 map/LRU 能否合并为单一状态 entry，说明合并与否的理由。
 - 注释与代码行为是否一致，TODO/FIXME 是否引入新技术债。
 - 插件配置或 `GetXxxParam` 改动是否同步更新 `docs/` 对应文档。
 - 重点覆盖评估标准：可维护性、兼容性与文档测试。

--- a/.cursor/rules/project-knowledge/codebase-map.md
+++ b/.cursor/rules/project-knowledge/codebase-map.md
@@ -20,6 +20,7 @@
 
 ## 2) Public Capability Entrances（优先复用，避免重复造轮子）
 
+- LRU cache: `core/common/LRUCache.h` (`lru11::Cache`，参考 `core/metadata/K8sMetadata.h`)
 - String and parse utils:
   - `core/common/StringTools.h`
     - 常用能力：`StringViewSplitter`（零拷贝切分）、`Trim`（统一裁剪语义）、`StringTo`（返回值判错的数值转换）
@@ -32,6 +33,10 @@
 - Alarm and metrics:
   - `core/monitor/*`
   - `core/monitor/metric_constants/*`
+
+## 2b) GenAI 数据层级（AgentSight / `gen_ai.*`）
+
+`session.id` → `turn.id` → `step.id`：delta 基线通常挂在 session；`step` 在同一 turn 内递增，turn 切换时归零。
 
 ## 3) Lifecycle & Resource Invariants（评审时必须核对）
 

--- a/.cursor/skills/code-review/SKILL.md
+++ b/.cursor/skills/code-review/SKILL.md
@@ -377,7 +377,8 @@ snapshot 在增量决策中的职责（必须遵守）：
 
 ### Sub-agent D: 复用合规与文档一致性
 
-- 是否重复实现了已有公共能力（优先复用 `core/common` 与现有工具函数）。
+- 是否重复实现了已有公共能力（优先复用 `core/common` 与现有工具函数）；先对照 `/.cursor/rules/project-knowledge/codebase-map.md` §2 检索，map 缺项则评审后补充。
+- 新增多套同构 map/LRU 时，质疑能否合并为单一状态 entry（勿仅复述作者拆分）。
 - 注释与代码行为是否一致，TODO/FIXME 是否引入新技术债。
 - 插件配置或 `GetXxxParam` 改动是否同步更新 `docs/` 对应文档。
 - 重点覆盖评估标准：可维护性、兼容性与文档测试。

--- a/.cursor/skills/code-review/SKILL.md
+++ b/.cursor/skills/code-review/SKILL.md
@@ -378,7 +378,7 @@ snapshot 在增量决策中的职责（必须遵守）：
 ### Sub-agent D: 复用合规与文档一致性
 
 - 是否重复实现了已有公共能力（优先复用 `core/common` 与现有工具函数）；先对照 `/.cursor/rules/project-knowledge/codebase-map.md` §2 检索，map 缺项则评审后补充。
-- 新增多套同构 map/LRU 时，质疑能否合并为单一状态 entry（勿仅复述作者拆分）。
+- 质疑多套同构 map/LRU 能否合并为单一状态 entry，说明合并与否的理由。
 - 注释与代码行为是否一致，TODO/FIXME 是否引入新技术债。
 - 插件配置或 `GetXxxParam` 改动是否同步更新 `docs/` 对应文档。
 - 重点覆盖评估标准：可维护性、兼容性与文档测试。


### PR DESCRIPTION
## Summary

- Add `LRUCache.h` and GenAI session/turn/step hierarchy to `codebase-map.md` so reviewers can mechanically find common reuse points.
- Extend code-review Sub-agent D with two lightweight checks: consult codebase-map §2 before flagging duplicate implementations, and question whether multiple parallel maps/LRUs can merge into a single state entry.

Motivated by PR #2579 review retrospective: hand-rolled LRU and dual-LRU splits were missed because reuse guidance was implicit rather than mapped.

## Test plan

- [x] Skill markdown renders correctly (no structural changes beyond two bullet additions)
- [x] `.cursor` and `.claude` code-review skills stay in sync
- [x] No runtime or build impact (docs-only)


Made with [Cursor](https://cursor.com)