### PR TITLE
chore(ci): migrate ubuntu runners to loongcollector-small-runner

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -190,7 +190,7 @@ jobs:
 
   actions-timeline:
     needs: [BuildCoreUT, BuildCoreArm64, BuildPurePlugin]
-    runs-on: ubuntu-latest
+    runs-on: loongcollector-small-runner
     permissions:
       actions: read
     steps:

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -57,7 +57,7 @@ jobs:
 
   actions-timeline:
     needs: [BuildCoreWindows]
-    runs-on: ubuntu-latest
+    runs-on: loongcollector-small-runner
     permissions:
       actions: read
     steps:

--- a/.github/workflows/check-compatibility.yaml
+++ b/.github/workflows/check-compatibility.yaml
@@ -89,7 +89,7 @@ jobs:
 
   actions-timeline:
     needs: [CheckCompatibility]
-    runs-on: ubuntu-latest
+    runs-on: loongcollector-small-runner
     permissions:
       actions: read
     steps:

--- a/.github/workflows/docs-cn-check.yaml
+++ b/.github/workflows/docs-cn-check.yaml
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: loongcollector-small-runner
     timeout-minutes: 10
     steps:
       - name: Check out code

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -116,7 +116,7 @@ jobs:
 
   # E2E测试
   E2E:
-    runs-on: loongcollector-small-runner
+    runs-on: ubuntu-latest
     needs: 
       - GenerateE2ETestCasesList
       - GenerateE2ETestImage

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   # 生成E2E测试用例列表
   GenerateE2ETestCasesList:
-    runs-on: ubuntu-latest
+    runs-on: loongcollector-small-runner
     outputs:
       cases: ${{ steps.discover.outputs.cases }}
     steps:
@@ -116,7 +116,7 @@ jobs:
 
   # E2E测试
   E2E:
-    runs-on: ubuntu-latest
+    runs-on: loongcollector-small-runner
     needs: 
       - GenerateE2ETestCasesList
       - GenerateE2ETestImage
@@ -155,145 +155,9 @@ jobs:
         run: |
           ./scripts/e2e.sh e2e
 
-  # E2E测试 - Docker Engine版本兼容性测试
-  E2EWithDockerEngineVersions:
-    runs-on: ubuntu-22.04
-    needs: 
-      - GenerateE2ETestImage
-    strategy:
-      matrix:
-        docker_engine_version: ["29.1", "28.5", "27.5", "26.1", "25.0", "24.0", "23.0", "20.10"]
-        test_case: ["input_container_stdio", "input_docker_static_file"]
-      fail-fast: false
-    timeout-minutes: 60
-    steps:
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.23.12
-
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          submodules: false
-
-      - name: Install Docker Engine ${{ matrix.docker_engine_version }}
-        run: |
-          # 移除现有的docker（包括docker-ce）
-          sudo apt-get remove -y docker docker-engine docker.io docker-ce docker-ce-cli containerd runc 2>/dev/null || true
-          sudo apt-get purge -y docker docker-engine docker.io docker-ce docker-ce-cli containerd runc 2>/dev/null || true
-          
-          # 安装依赖
-          sudo apt-get update
-          sudo apt-get install -y \
-            ca-certificates \
-            curl \
-            gnupg \
-            lsb-release \
-            apt-transport-https
-          
-          # 添加Docker官方GPG密钥
-          sudo mkdir -p /etc/apt/keyrings
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-          
-          # 设置Docker仓库
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-            $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          
-          # 更新包列表
-          sudo apt-get update
-          
-          # 根据版本号确定要安装的版本
-          VERSION="${{ matrix.docker_engine_version }}"
-          
-          # 查找可用的docker-ce版本
-          AVAILABLE_VERSIONS=$(apt-cache madison docker-ce | awk '{print $3}' | sort -V)
-          echo "Available Docker CE versions:"
-          echo "$AVAILABLE_VERSIONS"
-          
-          # 根据主版本号匹配
-          MAJOR=$(echo $VERSION | cut -d. -f1)
-          MINOR=$(echo $VERSION | cut -d. -f2)
-          
-          # 查找匹配的版本，选择最高的小版本
-          MATCHED_VERSION=$(echo "$AVAILABLE_VERSIONS" | grep "^5:$MAJOR\.$MINOR\." | tail -1)
-          
-          if [ -z "$MATCHED_VERSION" ]; then
-            # 如果找不到精确匹配，尝试匹配主版本号，选择最高版本
-            MATCHED_VERSION=$(echo "$AVAILABLE_VERSIONS" | grep "^5:$MAJOR\." | tail -1)
-          fi
-          
-          if [ -n "$MATCHED_VERSION" ]; then
-            echo "Installing Docker CE version: $MATCHED_VERSION"
-            sudo apt-get install -y --allow-downgrades docker-ce=$MATCHED_VERSION docker-ce-cli=$MATCHED_VERSION containerd.io
-          else
-            echo "Warning: Exact version $VERSION not found, trying to install latest version in major version $MAJOR"
-            LATEST_MAJOR=$(echo "$AVAILABLE_VERSIONS" | grep "^5:$MAJOR\." | tail -1)
-            if [ -n "$LATEST_MAJOR" ]; then
-              echo "Installing latest available version in major version $MAJOR: $LATEST_MAJOR"
-              sudo apt-get install -y --allow-downgrades docker-ce=$LATEST_MAJOR docker-ce-cli=$LATEST_MAJOR containerd.io
-            else
-              echo "::warning::Docker $VERSION is not available on this Ubuntu version"
-              echo "Available versions:"
-              echo "$AVAILABLE_VERSIONS"
-              echo "Skipping Docker $VERSION test"
-              exit 0
-            fi
-          fi
-          
-          # 启动Docker服务
-          sudo systemctl start docker || sudo service docker start
-          sudo systemctl enable docker || true
-          
-          # 等待Docker服务就绪
-          sleep 5
-          
-          # 输出Docker Engine版本信息
-          echo "========================================="
-          echo "Docker Engine Version Information:"
-          echo "========================================="
-          docker --version
-          echo ""
-          echo "Docker Engine Server Version:"
-          docker version --format '{{.Server.Version}}'
-          echo "========================================="
-
-      - name: Update Docker-compose to v2
-        run: |
-          sudo curl -SL https://github.com/docker/compose/releases/download/v2.7.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
-
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: loongcollector-image
-
-      - name: Check if Docker is installed
-        id: check_docker
-        run: |
-          if command -v docker &> /dev/null; then
-            echo "docker_installed=true" >> $GITHUB_OUTPUT
-            echo "Docker is installed"
-          else
-            echo "docker_installed=false" >> $GITHUB_OUTPUT
-            echo "Docker is not installed, skipping test"
-          fi
-
-      - name: Import Image from Tar
-        if: steps.check_docker.outputs.docker_installed == 'true'
-        run: docker load -i ./image.tar
-
-      - name: E2E Test with Docker Engine ${{ matrix.docker_engine_version }} - ${{ matrix.test_case }}
-        if: steps.check_docker.outputs.docker_installed == 'true'
-        env:
-          TEST_CASE: ${{ matrix.test_case }}
-        run: |
-          ./scripts/e2e.sh e2e
-
   actions-timeline:
-    needs: [E2E, E2EWithDockerEngineVersions]
-    runs-on: ubuntu-latest
+    needs: [E2E]
+    runs-on: loongcollector-small-runner
     permissions:
       actions: read
     steps:

--- a/.github/workflows/static-check.yaml
+++ b/.github/workflows/static-check.yaml
@@ -39,11 +39,11 @@ jobs:
   LicensesCheck:
     env:
       RUNNER_ALLOW_RUNASROOT: 1
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}-latest
     timeout-minutes: 60
     strategy:
       matrix:
-        runner: [loongcollector-small-runner]
+        runner: [ubuntu]
       fail-fast: true
     steps:
       - name: Set up Go
@@ -65,11 +65,11 @@ jobs:
   StaticCheck:
     env:
       RUNNER_ALLOW_RUNASROOT: 1
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}-latest
     timeout-minutes: 60
     strategy:
       matrix:
-        runner: [loongcollector-small-runner]
+        runner: [ubuntu]
       fail-fast: true
     steps:
       - name: prepare ubuntu environment
@@ -101,11 +101,11 @@ jobs:
   UnitTestGo:
     env:
       RUNNER_ALLOW_RUNASROOT: 1
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}-latest
     timeout-minutes: 60
     strategy:
       matrix:
-        runner: [loongcollector-small-runner]
+        runner: [ubuntu]
       fail-fast: true
     steps:
       - name: prepare ubuntu environment

--- a/.github/workflows/static-check.yaml
+++ b/.github/workflows/static-check.yaml
@@ -39,11 +39,11 @@ jobs:
   LicensesCheck:
     env:
       RUNNER_ALLOW_RUNASROOT: 1
-    runs-on: ${{ matrix.runner }}-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     strategy:
       matrix:
-        runner: [ubuntu]
+        runner: [loongcollector-small-runner]
       fail-fast: true
     steps:
       - name: Set up Go
@@ -65,11 +65,11 @@ jobs:
   StaticCheck:
     env:
       RUNNER_ALLOW_RUNASROOT: 1
-    runs-on: ${{ matrix.runner }}-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     strategy:
       matrix:
-        runner: [ubuntu]
+        runner: [loongcollector-small-runner]
       fail-fast: true
     steps:
       - name: prepare ubuntu environment
@@ -101,11 +101,11 @@ jobs:
   UnitTestGo:
     env:
       RUNNER_ALLOW_RUNASROOT: 1
-    runs-on: ${{ matrix.runner }}-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     strategy:
       matrix:
-        runner: [ubuntu]
+        runner: [loongcollector-small-runner]
       fail-fast: true
     steps:
       - name: prepare ubuntu environment
@@ -134,7 +134,7 @@ jobs:
       - LicensesCheck
       - StaticCheck
       - UnitTestGo
-    runs-on: ubuntu-latest
+    runs-on: loongcollector-small-runner
     permissions:
       actions: read
     steps:


### PR DESCRIPTION
Replace GitHub-hosted ubuntu runners with self-hosted loongcollector-small-runner for lightweight CI jobs. Remove E2EWithDockerEngineVersions job that depends on ubuntu-specific docker version matrix.