### PR TITLE
Recognize riscv64 in build and release scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,12 @@ PLATFORMS := linux darwin windows
 
 ifeq ($(shell uname -m),x86_64)
     ARCH := amd64
-else
+else ifneq (,$(filter $(shell uname -m),aarch64 arm64))
     ARCH := arm64
+else ifneq (,$(filter $(shell uname -m),riscv64 riscv64gc))
+    ARCH := riscv64
+else
+    ARCH := sw64
 endif
 
 ifndef DOCKER_BUILD_USE_BUILDKIT

--- a/docker/Dockerfile_edge_linux
+++ b/docker/Dockerfile_edge_linux
@@ -88,6 +88,7 @@ RUN set -eux; \
     case "${TARGETARCH}" in \
         amd64) LIB_DIR="/usr/lib/x86_64-linux-gnu" ;; \
         arm64) LIB_DIR="/usr/lib/aarch64-linux-gnu" ;; \
+        riscv64) LIB_DIR="/usr/lib/riscv64-linux-gnu" ;; \
         *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
     mkdir -p "${LIB_DIR}"; \

--- a/docker/Dockerfile_release
+++ b/docker/Dockerfile_release
@@ -54,6 +54,7 @@ RUN set -eux; \
     case "${TARGETARCH}" in \
         amd64) LIB_DIR="/usr/lib/x86_64-linux-gnu" ;; \
         arm64) LIB_DIR="/usr/lib/aarch64-linux-gnu" ;; \
+        riscv64) LIB_DIR="/usr/lib/riscv64-linux-gnu" ;; \
         *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
     mkdir -p "${LIB_DIR}"; \

--- a/scripts/build_edge_linux.sh
+++ b/scripts/build_edge_linux.sh
@@ -6,6 +6,8 @@ function arch() {
     echo amd64
   elif uname -m | grep -E "aarch64|arm64" &>/dev/null; then
     echo arm64
+  elif uname -m | grep -E "riscv64|riscv64gc" &>/dev/null; then
+    echo riscv64
   else
     echo sw64
   fi

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -22,6 +22,8 @@ function arch() {
     echo amd64
   elif uname -m | grep -E "aarch64|arm64" &>/dev/null; then
     echo arm64
+  elif uname -m | grep -E "riscv64|riscv64gc" &>/dev/null; then
+    echo riscv64
   else
     echo sw64
   fi

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -22,6 +22,8 @@ function arch() {
     echo amd64
   elif uname -m | grep -E "aarch64|arm64" &>/dev/null; then
     echo arm64
+  elif uname -m | grep -E "riscv64|riscv64gc" &>/dev/null; then
+    echo riscv64
   else
     echo sw64
   fi


### PR DESCRIPTION
## Why

`loongcollector` already has architecture-gated fast paths that fall back conservatively outside x86-specific SIMD code, but the build and release scripts still mis-handle `riscv64`.

The current problems are in the packaging and container entry path rather than the core data path:

- `Makefile` treats every non-`x86_64` Linux host as `arm64`;
- `scripts/build_edge_linux.sh`, `scripts/dist.sh`, and `scripts/docker_build.sh` treat unknown architectures as `sw64`;
- `docker/Dockerfile_edge_linux` and `docker/Dockerfile_release` only map `amd64` and `arm64` library directories, so `TARGETARCH=riscv64` falls into the unsupported branch immediately.

This patch makes the baseline `riscv64` packaging path explicit without changing existing x86_64 or arm64 behavior.

## What changed

- Updated `Makefile`:
  - detect `riscv64` / `riscv64gc` explicitly;
  - stop collapsing every non-`x86_64` Linux host to `arm64`.
- Updated `scripts/build_edge_linux.sh`, `scripts/dist.sh`, and `scripts/docker_build.sh`:
  - make the `arch()` helper return `riscv64` for `uname -m` values `riscv64` / `riscv64gc`;
  - preserve the existing `amd64`, `arm64`, and `sw64` behavior.
- Updated `docker/Dockerfile_edge_linux` and `docker/Dockerfile_release`:
  - accept `TARGETARCH=riscv64`;
  - map it to `/usr/lib/riscv64-linux-gnu`.

## Verification

- Verified the relevant source-level fallback boundaries:
  - `ProcessorParseJsonNative.cpp` only enables `simdjson` under `__INCLUDE_SSE4_2__` and otherwise falls back to `rapidjson`;
  - `picohttpparser.cpp` only enables SSE4.2 parsing helpers under `__SSE4_2__`;
  - the patch therefore stays focused on architecture detection and packaging instead of touching existing parsing fast paths.
- Verified the patched architecture detection in a fresh `ubuntu:24.04` Docker environment with a mocked `uname -m=riscv64`:
  - `make -pn -f /src/Makefile` reports `ARCH := riscv64`;
  - `scripts/build_edge_linux.sh` reports `riscv64`;
  - `scripts/dist.sh` reports `riscv64`;
  - `scripts/docker_build.sh` reports `riscv64`.
- Verified the packaging/release-script path by actually executing the patched scripts in a fresh `ubuntu:24.04` Docker verification copy with `uname -m=riscv64` and `uname -s=Linux`:
  - `scripts/dist.sh output dist loongcollector-0.0.1` produces `dist/loongcollector-0.0.1.linux-riscv64.tar.gz`;
  - `scripts/docker_build.sh production generated_files 0.0.1 example/repo false false` emits a real `docker build` command with `--build-arg TARGETPLATFORM=linux/riscv64` and `--build-arg HOST_OS=Linux`.
- Verified the patched Dockerfile mappings:
  - `docker/Dockerfile_edge_linux` now contains `riscv64) LIB_DIR="/usr/lib/riscv64-linux-gnu"`;
  - `docker/Dockerfile_release` now contains `riscv64) LIB_DIR="/usr/lib/riscv64-linux-gnu"`.

## Notes

- This is a conservative portability patch. It does not add RVV or any RISC-V-specific optimized backend.
- The current patch improves the baseline `riscv64` build/dist/release-script path and the Ubuntu-based release/edge image mapping.
- It does not yet extend the existing release workflow matrix or the CentOS-based `Dockerfile_production` path.