### PR TITLE
[1928-b1] feat(pipeline): add PassThroughEvents helper (#2598)

### DIFF
--- a/pkg/pipeline/events.go
+++ b/pkg/pipeline/events.go
@@ -23,7 +23,10 @@ import (
 //   - Plugins that only handle a subset of event kinds MUST NOT silently drop the rest.
 //   - Log-only processors MUST pass Metric and Span events through unchanged.
 //   - Prefer CollectGroupEvents or ProcessLogEventsOnly to satisfy the contract.
-//   - When matched events are transformed or filtered, use RecombineEvents to preserve order.
+//   - When matched events are transformed 1:1 (one processed event per matched event),
+//     use RecombineEvents to preserve original order. RecombineEvents does NOT support
+//     filtering/dropping matched events; for that, use PartitionEvents and rebuild the
+//     output slice manually.
 type EventKindSet struct {
 	Log    bool
 	Metric bool
@@ -70,11 +73,25 @@ func PassThroughEvents(events []models.PipelineEvent, handledKinds EventKindSet)
 	return passThrough
 }
 
-// RecombineEvents merges processed matched events back into original positions.
-// processedMatched must contain one entry per matched event in original order.
+// RecombineEvents merges processed matched events back into their original positions,
+// preserving the order and identity of pass-through (unhandled) events.
+//
+// Contract: processedMatched MUST contain exactly one entry per matched event, in original
+// order (strict 1:1 transformation). RecombineEvents is NOT a filtering primitive and cannot
+// represent dropped events; callers that filter must rebuild the slice via PartitionEvents.
+//
+// If original is empty, it is returned as-is (including an empty-but-non-nil slice) so the
+// caller's slice identity and emptiness are preserved rather than collapsed to nil.
+//
+// Defensive fallback when the 1:1 precondition is violated (indicates a caller bug, never
+// panics):
+//   - If processedMatched is shorter than the matched count, the surplus matched positions
+//     keep their original events.
+//   - If processedMatched is longer than the matched count, the extra trailing entries are
+//     ignored.
 func RecombineEvents(original []models.PipelineEvent, handledKinds EventKindSet, processedMatched []models.PipelineEvent) []models.PipelineEvent {
 	if len(original) == 0 {
-		return nil
+		return original
 	}
 	result := make([]models.PipelineEvent, len(original))
 	matchedIdx := 0

--- a/pkg/pipeline/events.go
+++ b/pkg/pipeline/events.go
@@ -1,0 +1,125 @@
+// Copyright 2026 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"github.com/alibaba/ilogtail/pkg/models"
+)
+
+// Event pass-through contract for v2 Processor/Flusher plugins:
+//
+//   - Plugins that only handle a subset of event kinds MUST NOT silently drop the rest.
+//   - Log-only processors MUST pass Metric and Span events through unchanged.
+//   - Prefer CollectGroupEvents or ProcessLogEventsOnly to satisfy the contract.
+//   - When matched events are transformed or filtered, use RecombineEvents to preserve order.
+type EventKindSet struct {
+	Log    bool
+	Metric bool
+	Span   bool
+}
+
+// LogOnlyEventKinds is the supported-kind set for text-parsing style processors.
+var LogOnlyEventKinds = EventKindSet{Log: true}
+
+// AllPipelineEventKinds covers Log, Metric, and Span pipeline events.
+var AllPipelineEventKinds = EventKindSet{Log: true, Metric: true, Span: true}
+
+// Supports reports whether this set handles the given event type.
+// Unknown kinds (e.g. EventTypeByteArray) are not supported and should pass through.
+func (s EventKindSet) Supports(eventType models.EventType) bool {
+	switch eventType {
+	case models.EventTypeLogging:
+		return s.Log
+	case models.EventTypeMetric:
+		return s.Metric
+	case models.EventTypeSpan:
+		return s.Span
+	default:
+		return false
+	}
+}
+
+// PartitionEvents splits events into matched (supported) and pass-through (unsupported) slices.
+// Order within each slice follows the original order.
+func PartitionEvents(events []models.PipelineEvent, supported EventKindSet) (matched, passThrough []models.PipelineEvent) {
+	for _, event := range events {
+		if supported.Supports(event.GetType()) {
+			matched = append(matched, event)
+		} else {
+			passThrough = append(passThrough, event)
+		}
+	}
+	return matched, passThrough
+}
+
+// PassThroughEvents returns events whose kinds are not handled by handledKinds.
+func PassThroughEvents(events []models.PipelineEvent, handledKinds EventKindSet) []models.PipelineEvent {
+	_, passThrough := PartitionEvents(events, handledKinds)
+	return passThrough
+}
+
+// RecombineEvents merges processed matched events back into original positions.
+// processedMatched must contain one entry per matched event in original order.
+func RecombineEvents(original []models.PipelineEvent, handledKinds EventKindSet, processedMatched []models.PipelineEvent) []models.PipelineEvent {
+	if len(original) == 0 {
+		return nil
+	}
+	result := make([]models.PipelineEvent, len(original))
+	matchedIdx := 0
+	for i, event := range original {
+		if handledKinds.Supports(event.GetType()) {
+			if matchedIdx < len(processedMatched) {
+				result[i] = processedMatched[matchedIdx]
+				matchedIdx++
+			} else {
+				result[i] = event
+			}
+			continue
+		}
+		result[i] = event
+	}
+	return result
+}
+
+// ApplyToSupportedEvents invokes fn on each event whose kind is in supported.
+// Unsupported events are left untouched (implicit pass-through when the slice is collected as-is).
+func ApplyToSupportedEvents(events []models.PipelineEvent, supported EventKindSet, fn func(models.PipelineEvent)) {
+	for _, event := range events {
+		if supported.Supports(event.GetType()) {
+			fn(event)
+		}
+	}
+}
+
+// CollectGroupEvents emits all events in the group without filtering.
+func CollectGroupEvents(ctx PipelineContext, in *models.PipelineGroupEvents) {
+	if in == nil || len(in.Events) == 0 {
+		return
+	}
+	ctx.Collector().Collect(in.Group, in.Events...)
+}
+
+// ProcessLogEventsOnly runs processLog on Log events and collects all events (Metric/Span pass through).
+func ProcessLogEventsOnly(in *models.PipelineGroupEvents, ctx PipelineContext, processLog func(*models.Log)) {
+	if in == nil {
+		return
+	}
+	for _, event := range in.Events {
+		if event.GetType() == models.EventTypeLogging {
+			processLog(event.(*models.Log))
+		}
+	}
+	CollectGroupEvents(ctx, in)
+}

--- a/pkg/pipeline/events_test.go
+++ b/pkg/pipeline/events_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/alibaba/ilogtail/pkg/models"
+)
+
+func TestEventKindSet_Supports(t *testing.T) {
+	assert.True(t, LogOnlyEventKinds.Supports(models.EventTypeLogging))
+	assert.False(t, LogOnlyEventKinds.Supports(models.EventTypeMetric))
+	assert.False(t, LogOnlyEventKinds.Supports(models.EventTypeSpan))
+	assert.False(t, LogOnlyEventKinds.Supports(models.EventTypeByteArray))
+
+	assert.True(t, AllPipelineEventKinds.Supports(models.EventTypeLogging))
+	assert.True(t, AllPipelineEventKinds.Supports(models.EventTypeMetric))
+	assert.True(t, AllPipelineEventKinds.Supports(models.EventTypeSpan))
+}
+
+func TestPartitionEvents_LogMetricSpan(t *testing.T) {
+	log := models.NewLog("", []byte("log"), "info", "", "", models.NewTags(), 1)
+	metric := models.NewSingleValueMetric("m", models.MetricTypeGauge, models.NewTags(), 2, 1.0)
+	span := models.NewSpan("op", "trace", "span", models.SpanKindServer, 3, 4, models.NewTags(), nil, nil)
+	events := []models.PipelineEvent{metric, log, span}
+
+	matched, passThrough := PartitionEvents(events, LogOnlyEventKinds)
+	require.Len(t, matched, 1)
+	require.Len(t, passThrough, 2)
+	assert.Equal(t, models.EventTypeLogging, matched[0].GetType())
+	assert.Equal(t, models.EventTypeMetric, passThrough[0].GetType())
+	assert.Equal(t, models.EventTypeSpan, passThrough[1].GetType())
+}
+
+func TestPassThroughEvents_PreservesMetricAndSpan(t *testing.T) {
+	log := models.NewLog("", []byte("log"), "info", "", "", models.NewTags(), 1)
+	metric := models.NewSingleValueMetric("m", models.MetricTypeGauge, models.NewTags(), 2, 1.0)
+	span := models.NewSpan("op", "trace", "span", models.SpanKindServer, 3, 4, models.NewTags(), nil, nil)
+	events := []models.PipelineEvent{log, metric, span}
+
+	passThrough := PassThroughEvents(events, LogOnlyEventKinds)
+	require.Len(t, passThrough, 2)
+	assert.Equal(t, models.EventTypeMetric, passThrough[0].GetType())
+	assert.Equal(t, models.EventTypeSpan, passThrough[1].GetType())
+}
+
+func TestRecombineEvents_PreservesOrder(t *testing.T) {
+	log1 := models.NewLog("", []byte("a"), "info", "", "", models.NewTags(), 1)
+	log2 := models.NewLog("", []byte("b"), "info", "", "", models.NewTags(), 2)
+	metric := models.NewSingleValueMetric("m", models.MetricTypeGauge, models.NewTags(), 3, 1.0)
+	span := models.NewSpan("op", "trace", "span", models.SpanKindServer, 4, 5, models.NewTags(), nil, nil)
+	original := []models.PipelineEvent{metric, log1, span, log2}
+
+	processedLog1 := models.NewLog("", []byte("A"), "info", "", "", models.NewTags(), 1)
+	processedLog2 := models.NewLog("", []byte("B"), "info", "", "", models.NewTags(), 2)
+	recombined := RecombineEvents(original, LogOnlyEventKinds, []models.PipelineEvent{processedLog1, processedLog2})
+
+	require.Len(t, recombined, 4)
+	assert.Equal(t, models.EventTypeMetric, recombined[0].GetType())
+	assert.Equal(t, "A", string(recombined[1].(*models.Log).GetBody()))
+	assert.Equal(t, models.EventTypeSpan, recombined[2].GetType())
+	assert.Equal(t, "B", string(recombined[3].(*models.Log).GetBody()))
+}
+
+func TestApplyToSupportedEvents_OnlyTouchesLogs(t *testing.T) {
+	log := models.NewLog("", []byte("before"), "info", "", "", models.NewTags(), 1)
+	metric := models.NewSingleValueMetric("m", models.MetricTypeGauge, models.NewTags(), 2, 1.0)
+	events := []models.PipelineEvent{metric, log}
+
+	ApplyToSupportedEvents(events, LogOnlyEventKinds, func(event models.PipelineEvent) {
+		event.(*models.Log).SetBody([]byte("after"))
+	})
+
+	assert.Equal(t, "after", string(log.GetBody()))
+	assert.Equal(t, 1.0, metric.GetValue().GetSingleValue())
+}

--- a/pkg/pipeline/events_test.go
+++ b/pkg/pipeline/events_test.go
@@ -78,6 +78,47 @@ func TestRecombineEvents_PreservesOrder(t *testing.T) {
 	assert.Equal(t, "B", string(recombined[3].(*models.Log).GetBody()))
 }
 
+func TestRecombineEvents_EmptyOriginal(t *testing.T) {
+	var nilOriginal []models.PipelineEvent
+	assert.Nil(t, RecombineEvents(nilOriginal, LogOnlyEventKinds, nil))
+
+	emptyOriginal := []models.PipelineEvent{}
+	result := RecombineEvents(emptyOriginal, LogOnlyEventKinds, nil)
+	require.NotNil(t, result)
+	assert.Len(t, result, 0)
+}
+
+func TestRecombineEvents_FewerProcessedThanMatched(t *testing.T) {
+	log1 := models.NewLog("", []byte("a"), "info", "", "", models.NewTags(), 1)
+	log2 := models.NewLog("", []byte("b"), "info", "", "", models.NewTags(), 2)
+	metric := models.NewSingleValueMetric("m", models.MetricTypeGauge, models.NewTags(), 3, 1.0)
+	original := []models.PipelineEvent{metric, log1, log2}
+
+	processedLog1 := models.NewLog("", []byte("A"), "info", "", "", models.NewTags(), 1)
+	recombined := RecombineEvents(original, LogOnlyEventKinds, []models.PipelineEvent{processedLog1})
+
+	require.Len(t, recombined, 3)
+	assert.Equal(t, models.EventTypeMetric, recombined[0].GetType())
+	assert.Equal(t, "A", string(recombined[1].(*models.Log).GetBody()))
+	// Surplus matched position keeps its original event when processedMatched is short.
+	assert.Equal(t, "b", string(recombined[2].(*models.Log).GetBody()))
+}
+
+func TestRecombineEvents_MoreProcessedThanMatched(t *testing.T) {
+	log1 := models.NewLog("", []byte("a"), "info", "", "", models.NewTags(), 1)
+	metric := models.NewSingleValueMetric("m", models.MetricTypeGauge, models.NewTags(), 2, 1.0)
+	original := []models.PipelineEvent{metric, log1}
+
+	processedLog1 := models.NewLog("", []byte("A"), "info", "", "", models.NewTags(), 1)
+	extraLog := models.NewLog("", []byte("X"), "info", "", "", models.NewTags(), 3)
+	recombined := RecombineEvents(original, LogOnlyEventKinds, []models.PipelineEvent{processedLog1, extraLog})
+
+	require.Len(t, recombined, 2)
+	assert.Equal(t, models.EventTypeMetric, recombined[0].GetType())
+	// Extra trailing processed entries are ignored.
+	assert.Equal(t, "A", string(recombined[1].(*models.Log).GetBody()))
+}
+
 func TestApplyToSupportedEvents_OnlyTouchesLogs(t *testing.T) {
 	log := models.NewLog("", []byte("before"), "info", "", "", models.NewTags(), 1)
 	metric := models.NewSingleValueMetric("m", models.MetricTypeGauge, models.NewTags(), 2, 1.0)


### PR DESCRIPTION
Closes #2598

## 对应步骤
[Discussion #1928](https://github.com/alibaba/loongcollector/discussions/1928) · **主线 B · 步骤 B1** · [Epic #2595](https://github.com/alibaba/loongcollector/issues/2595)

## 背景与上下文

Discussion #1928 定义了采集配置 Pipeline 的四条演进线（A→B→C + 支线 D）。**主线 B** 的目标是让 v2 Processor/Flusher 对 `PipelineGroupEvents` 中的 Log / Metric / Span **要么按语义处理，要么显式透传**，为后续废弃 LogGroup（主线 C）做准备。

当前约 50+ Processor 仍只实现 `ProcessLogs`，v2 `Process` 路径缺少统一约定，批量迁移（B4）时容易**静默丢弃 Metric/Span**。B1 是 B 线的**基础设施**：先沉淀透传契约与 helper，再驱动 B2 矩阵盘点与 B3/B4 插件迁移。

## 对整体目标的价值

| 演进线 | B1 贡献 |
|--------|---------|
| **B** | 为所有 log-only Processor 提供标准透传 API，降低 B4 迁移成本与丢事件风险 |
| **C** | v2 全事件模型是 C5 默认 `StructureType: v2` 的前置条件；B1 确保迁移过程不丢 Metric/Span |
| **A / D** | 无直接依赖；本 PR 不改 C++ Input 或自监控 |

## 改动

- 新增 `pkg/pipeline/events.go`：定义 `EventKindSet` 与 v2 **事件透传契约**（文档注释）
- 提供 helper：
  - `PartitionEvents` / `PassThroughEvents` — 按事件类型拆分 handled vs pass-through
  - `RecombineEvents` — 处理后保持原始顺序
  - `ProcessLogEventsOnly` / `CollectGroupEvents` — log-only Processor 标准收尾
- 新增 `pkg/pipeline/events_test.go`：5 个单测，覆盖 Log/Metric/Span 透传与顺序保持

**行为变更**：无。纯新增 API，现有插件不受影响。

## Test plan

- [x] `cd pkg && go test ./pipeline/... -count=1` — PASS（5 cases）
- [x] 自检：Critical 0 / Suggestion 0（见 PR 评论）

## 影响面 / 回滚

- **影响面**：仅 `pkg/pipeline` 新增文件；B3/B4 后续 PR 将引用这些 helper
- **回滚**：revert 本 PR；无配置或运行时行为变化
- **约束遵守**：未改默认 `StructureType`；未动 `plugins/` / `core/`

## 合并顺序

无 stacked 依赖，可与阶段 1 其它 PR（A1/A2/B2）并行合并。