### PR TITLE
[1928-a1] feat(config): default-allow native input with Go plugins

### DIFF
--- a/core/config/CollectionConfig.cpp
+++ b/core/config/CollectionConfig.cpp
@@ -97,11 +97,11 @@ static void ReplaceEnvVarRef(Json::Value& value, bool& res) {
 }
 
 static const unordered_set<string>& GetNativeInputBlacklistWhenUsingGoPlugin() {
-    // A1: explicit blacklist of native inputs that cannot coexist with Go processors/flushers yet.
-    // All registered native inputs minus legacy whitelist:
+    // A1: explicit blacklist framework; populated to match pre-A1 legacy whitelist parity
+    // (does NOT expand Parse allow surface). Allowed native inputs:
     //   input_file, input_container_stdio, input_static_file_onetime,
     //   input_*_security, input_internal_metrics, input_internal_alarms.
-    // Remove one entry after B-line matrix/E2E proves runtime reachability.
+    // Remove one blacklist entry after B-line matrix/E2E proves end-to-end reachability.
     static const unordered_set<string> kBlacklist = {
         "input_agentsight",
         "input_cpu_profiling",

--- a/core/config/CollectionConfig.cpp
+++ b/core/config/CollectionConfig.cpp
@@ -95,6 +95,13 @@ static void ReplaceEnvVarRef(Json::Value& value, bool& res) {
     }
 }
 
+static bool IsNativeInputBlockedWhenUsingGoPlugin(const string& pluginType) {
+    // Step A1: switch to "default allow + blacklist" for native input coexistence with Go plugins.
+    // Add plugin types here if they are proven incompatible in later stages.
+    (void)pluginType;
+    return false;
+}
+
 bool CollectionConfig::Parse() {
     if (BOOL_FLAG(enable_env_ref_in_config)) {
         if (ReplaceEnvVar()) {
@@ -143,8 +150,7 @@ bool CollectionConfig::Parse() {
     // inputs, processors and flushers module must be parsed first and parsed by order, since aggregators and
     // extensions module parsing will rely on their results.
     bool hasFileInput = false;
-    bool hasSecurityInput = false;
-    bool hasSelfMonitorInput = false;
+    bool hasNativeInputBlockedWhenUsingGoPlugin = false;
     key = "inputs";
     itr = mDetail->find(key.c_str(), key.c_str() + key.size());
     if (!itr) {
@@ -268,11 +274,8 @@ bool CollectionConfig::Parse() {
             hasFileInput = true;
         }
 #endif
-        if (pluginType.find("_security") != string::npos) {
-            hasSecurityInput = true;
-        }
-        if (pluginType == "input_internal_metrics" || pluginType == "input_internal_alarms") {
-            hasSelfMonitorInput = true;
+        if (IsNativeInputBlockedWhenUsingGoPlugin(pluginType)) {
+            hasNativeInputBlockedWhenUsingGoPlugin = true;
         }
     }
     // TODO: remove these special restrictions
@@ -362,12 +365,11 @@ bool CollectionConfig::Parse() {
                 if (isCurrentPluginNative) {
                     if (PluginRegistry::GetInstance()->IsValidGoPlugin(pluginType)) {
                         // TODO: remove these special restrictions
-                        if (!hasFileInput && !hasSecurityInput && !hasSelfMonitorInput) {
+                        if (hasNativeInputBlockedWhenUsingGoPlugin) {
                             PARAM_ERROR_RETURN(sLogger,
                                                alarm,
-                                               "extended processor plugins coexist with native input plugins other "
-                                               "than input_file or input_container_stdio or input_*_security "
-                                               "or input_internal_*",
+                                               "extended processor plugins coexist with native input plugins in "
+                                               "blacklist",
                                                noModule,
                                                mName,
                                                mProject,
@@ -492,12 +494,10 @@ bool CollectionConfig::Parse() {
         const string pluginType = it->asString();
         if (PluginRegistry::GetInstance()->IsValidGoPlugin(pluginType)) {
             // TODO: remove these special restrictions
-            if (mHasNativeInput && !hasFileInput && !hasSecurityInput && !hasSelfMonitorInput) {
+            if (mHasNativeInput && hasNativeInputBlockedWhenUsingGoPlugin) {
                 PARAM_ERROR_RETURN(sLogger,
                                    alarm,
-                                   "extended flusher plugins coexist with native input plugins other than "
-                                   "input_file or input_container_stdio or input_*_security "
-                                   "or input_internal_*",
+                                   "extended flusher plugins coexist with native input plugins in blacklist",
                                    noModule,
                                    mName,
                                    mProject,

--- a/core/config/CollectionConfig.cpp
+++ b/core/config/CollectionConfig.cpp
@@ -95,11 +95,36 @@ static void ReplaceEnvVarRef(Json::Value& value, bool& res) {
     }
 }
 
-static bool IsNativeInputBlockedWhenUsingGoPlugin(const string& pluginType) {
-    // Step A1: switch to "default allow + blacklist" for native input coexistence with Go plugins.
-    // Add plugin types here if they are proven incompatible in later stages.
-    (void)pluginType;
+static bool IsNativeInputAllowedWithGoPlugin(const string& pluginType) {
+    // Legacy whitelist before A1: file / security / self-monitor native inputs may coexist with Go plugins.
+#ifndef APSARA_UNIT_TEST_MAIN
+    if (pluginType == "input_file" || pluginType == "input_container_stdio"
+        || pluginType == "input_static_file_onetime") {
+        return true;
+    }
+#else
+    if (pluginType.find("input_file") != string::npos || pluginType.find("input_container_stdio") != string::npos
+        || pluginType.find("input_static_file_onetime") != string::npos) {
+        return true;
+    }
+#endif
+    if (pluginType.find("_security") != string::npos) {
+        return true;
+    }
+    if (pluginType == "input_internal_metrics" || pluginType == "input_internal_alarms") {
+        return true;
+    }
     return false;
+}
+
+static bool IsNativeInputBlockedWhenUsingGoPlugin(const string& pluginType, bool isOnetime) {
+    // A1 framework: default-allow + blacklist. Populate blacklist with legacy non-whitelist native inputs
+    // so Parse behavior stays consistent until B-line matrix/E2E proves runtime reachability.
+    // Parse success != events reaching Go pipeline; silent discard alarm follow-up tracked on #2599 / #2606.
+    if (!PluginRegistry::GetInstance()->IsValidNativeInputPlugin(pluginType, isOnetime)) {
+        return false;
+    }
+    return !IsNativeInputAllowedWithGoPlugin(pluginType);
 }
 
 bool CollectionConfig::Parse() {
@@ -274,7 +299,7 @@ bool CollectionConfig::Parse() {
             hasFileInput = true;
         }
 #endif
-        if (IsNativeInputBlockedWhenUsingGoPlugin(pluginType)) {
+        if (IsNativeInputBlockedWhenUsingGoPlugin(pluginType, IsOnetime())) {
             hasNativeInputBlockedWhenUsingGoPlugin = true;
         }
     }

--- a/core/config/CollectionConfig.cpp
+++ b/core/config/CollectionConfig.cpp
@@ -15,6 +15,7 @@
 #include "config/CollectionConfig.h"
 
 #include <string>
+#include <unordered_set>
 
 #include "boost/regex.hpp"
 
@@ -95,36 +96,30 @@ static void ReplaceEnvVarRef(Json::Value& value, bool& res) {
     }
 }
 
-static bool IsNativeInputAllowedWithGoPlugin(const string& pluginType) {
-    // Legacy whitelist before A1: file / security / self-monitor native inputs may coexist with Go plugins.
-#ifndef APSARA_UNIT_TEST_MAIN
-    if (pluginType == "input_file" || pluginType == "input_container_stdio"
-        || pluginType == "input_static_file_onetime") {
-        return true;
-    }
-#else
-    if (pluginType.find("input_file") != string::npos || pluginType.find("input_container_stdio") != string::npos
-        || pluginType.find("input_static_file_onetime") != string::npos) {
-        return true;
-    }
-#endif
-    if (pluginType.find("_security") != string::npos) {
-        return true;
-    }
-    if (pluginType == "input_internal_metrics" || pluginType == "input_internal_alarms") {
-        return true;
-    }
-    return false;
+static const unordered_set<string>& GetNativeInputBlacklistWhenUsingGoPlugin() {
+    // A1: explicit blacklist of native inputs that cannot coexist with Go processors/flushers yet.
+    // All registered native inputs minus legacy whitelist:
+    //   input_file, input_container_stdio, input_static_file_onetime,
+    //   input_*_security, input_internal_metrics, input_internal_alarms.
+    // Remove one entry after B-line matrix/E2E proves runtime reachability.
+    static const unordered_set<string> kBlacklist = {
+        "input_agentsight",
+        "input_cpu_profiling",
+        "input_forward",
+        "input_host_meta",
+        "input_host_monitor",
+        "input_internal_config_container_info",
+        "input_network_observer",
+        "input_prometheus",
+    };
+    return kBlacklist;
 }
 
 static bool IsNativeInputBlockedWhenUsingGoPlugin(const string& pluginType, bool isOnetime) {
-    // A1 framework: default-allow + blacklist. Populate blacklist with legacy non-whitelist native inputs
-    // so Parse behavior stays consistent until B-line matrix/E2E proves runtime reachability.
-    // Parse success != events reaching Go pipeline; silent discard alarm follow-up tracked on #2599 / #2606.
     if (!PluginRegistry::GetInstance()->IsValidNativeInputPlugin(pluginType, isOnetime)) {
         return false;
     }
-    return !IsNativeInputAllowedWithGoPlugin(pluginType);
+    return GetNativeInputBlacklistWhenUsingGoPlugin().count(pluginType) > 0;
 }
 
 bool CollectionConfig::Parse() {

--- a/core/config/CollectionConfig.cpp
+++ b/core/config/CollectionConfig.cpp
@@ -115,10 +115,9 @@ static const unordered_set<string>& GetNativeInputBlacklistWhenUsingGoPlugin() {
     return kBlacklist;
 }
 
-static bool IsNativeInputBlockedWhenUsingGoPlugin(const string& pluginType, bool isOnetime) {
-    if (!PluginRegistry::GetInstance()->IsValidNativeInputPlugin(pluginType, isOnetime)) {
-        return false;
-    }
+static bool IsNativeInputBlockedWhenUsingGoPlugin(const string& pluginType, bool /* isOnetime */) {
+    // Blacklist is platform-agnostic: Linux-only native inputs are not registered on Windows,
+    // but configs referencing them must still be rejected when paired with Go plugins.
     return GetNativeInputBlacklistWhenUsingGoPlugin().count(pluginType) > 0;
 }
 
@@ -241,7 +240,9 @@ bool CollectionConfig::Parse() {
             }
         }
         if (i == 0) {
-            if (PluginRegistry::GetInstance()->IsValidGoPlugin(pluginType)) {
+            if (IsNativeInputBlockedWhenUsingGoPlugin(pluginType, IsOnetime())) {
+                mHasNativeInput = true;
+            } else if (PluginRegistry::GetInstance()->IsValidGoPlugin(pluginType)) {
                 mHasGoInput = true;
             } else if (PluginRegistry::GetInstance()->IsValidNativeInputPlugin(pluginType, IsOnetime())) {
                 mHasNativeInput = true;

--- a/core/unittest/config/CollectionConfigUnittest.cpp
+++ b/core/unittest/config/CollectionConfigUnittest.cpp
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "json/json.h"
 
@@ -2445,49 +2446,61 @@ void CollectionConfigUnittest::NativeInputWithGoPlugin() const {
     unique_ptr<CollectionConfig> config;
     string errorMsg;
 
-    // Legacy non-whitelist native input + Go processor/flusher must fail Parse (blacklist).
-    string configStr = R"(
-        {
-            "inputs": [
-                {
-                    "Type": "input_host_monitor"
-                }
-            ],
-            "processors": [
-                {
-                    "Type": "processor_json"
-                }
-            ],
-            "flushers": [
-                {
-                    "Type": "flusher_http"
-                }
-            ]
-        }
-    )";
-    configJson.reset(new Json::Value());
-    APSARA_TEST_TRUE(ParseJsonTable(configStr, *configJson, errorMsg));
-    config.reset(new CollectionConfig(configName, std::move(configJson), filepath));
-    APSARA_TEST_FALSE(config->Parse());
+    // Explicit blacklist (all native inputs minus legacy whitelist) must fail Parse with Go plugins.
+    const vector<string> blacklistedInputs = {
+        "input_agentsight",
+        "input_cpu_profiling",
+        "input_forward",
+        "input_host_meta",
+        "input_host_monitor",
+        "input_internal_config_container_info",
+        "input_network_observer",
+        "input_prometheus",
+    };
+    for (const auto& inputType : blacklistedInputs) {
+        string configStr = R"(
+            {
+                "inputs": [
+                    {
+                        "Type": ")" + inputType + R"("
+                    }
+                ],
+                "processors": [
+                    {
+                        "Type": "processor_json"
+                    }
+                ],
+                "flushers": [
+                    {
+                        "Type": "flusher_http"
+                    }
+                ]
+            }
+        )";
+        configJson.reset(new Json::Value());
+        APSARA_TEST_TRUE(ParseJsonTable(configStr, *configJson, errorMsg));
+        config.reset(new CollectionConfig(configName, std::move(configJson), filepath));
+        APSARA_TEST_FALSE_DESC(config->Parse(), inputType);
 
-    configStr = R"(
-        {
-            "inputs": [
-                {
-                    "Type": "input_host_monitor"
-                }
-            ],
-            "flushers": [
-                {
-                    "Type": "flusher_http"
-                }
-            ]
-        }
-    )";
-    configJson.reset(new Json::Value());
-    APSARA_TEST_TRUE(ParseJsonTable(configStr, *configJson, errorMsg));
-    config.reset(new CollectionConfig(configName, std::move(configJson), filepath));
-    APSARA_TEST_FALSE(config->Parse());
+        configStr = R"(
+            {
+                "inputs": [
+                    {
+                        "Type": ")" + inputType + R"("
+                    }
+                ],
+                "flushers": [
+                    {
+                        "Type": "flusher_http"
+                    }
+                ]
+            }
+        )";
+        configJson.reset(new Json::Value());
+        APSARA_TEST_TRUE(ParseJsonTable(configStr, *configJson, errorMsg));
+        config.reset(new CollectionConfig(configName, std::move(configJson), filepath));
+        APSARA_TEST_FALSE_DESC(config->Parse(), inputType);
+    }
 }
 
 UNIT_TEST_CASE(CollectionConfigUnittest, HandleValidConfig)

--- a/core/unittest/config/CollectionConfigUnittest.cpp
+++ b/core/unittest/config/CollectionConfigUnittest.cpp
@@ -2445,6 +2445,7 @@ void CollectionConfigUnittest::NativeInputWithGoPlugin() const {
     unique_ptr<CollectionConfig> config;
     string errorMsg;
 
+    // Legacy non-whitelist native input + Go processor/flusher must fail Parse (blacklist).
     string configStr = R"(
         {
             "inputs": [
@@ -2467,8 +2468,7 @@ void CollectionConfigUnittest::NativeInputWithGoPlugin() const {
     configJson.reset(new Json::Value());
     APSARA_TEST_TRUE(ParseJsonTable(configStr, *configJson, errorMsg));
     config.reset(new CollectionConfig(configName, std::move(configJson), filepath));
-    APSARA_TEST_TRUE(config->Parse());
-    APSARA_TEST_TRUE(config->HasGoPlugin());
+    APSARA_TEST_FALSE(config->Parse());
 
     configStr = R"(
         {
@@ -2487,8 +2487,7 @@ void CollectionConfigUnittest::NativeInputWithGoPlugin() const {
     configJson.reset(new Json::Value());
     APSARA_TEST_TRUE(ParseJsonTable(configStr, *configJson, errorMsg));
     config.reset(new CollectionConfig(configName, std::move(configJson), filepath));
-    APSARA_TEST_TRUE(config->Parse());
-    APSARA_TEST_TRUE(config->HasGoPlugin());
+    APSARA_TEST_FALSE(config->Parse());
 }
 
 UNIT_TEST_CASE(CollectionConfigUnittest, HandleValidConfig)

--- a/core/unittest/config/CollectionConfigUnittest.cpp
+++ b/core/unittest/config/CollectionConfigUnittest.cpp
@@ -2462,7 +2462,8 @@ void CollectionConfigUnittest::NativeInputWithGoPlugin() const {
             {
                 "inputs": [
                     {
-                        "Type": ")" + inputType + R"("
+                        "Type": ")"
+            + inputType + R"("
                     }
                 ],
                 "processors": [
@@ -2486,7 +2487,8 @@ void CollectionConfigUnittest::NativeInputWithGoPlugin() const {
             {
                 "inputs": [
                     {
-                        "Type": ")" + inputType + R"("
+                        "Type": ")"
+            + inputType + R"("
                     }
                 ],
                 "flushers": [

--- a/core/unittest/config/CollectionConfigUnittest.cpp
+++ b/core/unittest/config/CollectionConfigUnittest.cpp
@@ -38,6 +38,7 @@ public:
     void HandleInvalidExtensions() const;
     void TestReplaceEnvVarRef() const;
     void SelfMonitorInputWithGoFlusher() const;
+    void NativeInputWithGoPlugin() const;
 
 protected:
     static void SetUpTestCase() { PluginRegistry::GetInstance()->LoadPlugins(); }
@@ -2439,8 +2440,60 @@ void CollectionConfigUnittest::SelfMonitorInputWithGoFlusher() const {
     APSARA_TEST_TRUE(config->Parse());
 }
 
+void CollectionConfigUnittest::NativeInputWithGoPlugin() const {
+    unique_ptr<Json::Value> configJson;
+    unique_ptr<CollectionConfig> config;
+    string errorMsg;
+
+    string configStr = R"(
+        {
+            "inputs": [
+                {
+                    "Type": "input_host_monitor"
+                }
+            ],
+            "processors": [
+                {
+                    "Type": "processor_json"
+                }
+            ],
+            "flushers": [
+                {
+                    "Type": "flusher_http"
+                }
+            ]
+        }
+    )";
+    configJson.reset(new Json::Value());
+    APSARA_TEST_TRUE(ParseJsonTable(configStr, *configJson, errorMsg));
+    config.reset(new CollectionConfig(configName, std::move(configJson), filepath));
+    APSARA_TEST_TRUE(config->Parse());
+    APSARA_TEST_TRUE(config->HasGoPlugin());
+
+    configStr = R"(
+        {
+            "inputs": [
+                {
+                    "Type": "input_host_monitor"
+                }
+            ],
+            "flushers": [
+                {
+                    "Type": "flusher_http"
+                }
+            ]
+        }
+    )";
+    configJson.reset(new Json::Value());
+    APSARA_TEST_TRUE(ParseJsonTable(configStr, *configJson, errorMsg));
+    config.reset(new CollectionConfig(configName, std::move(configJson), filepath));
+    APSARA_TEST_TRUE(config->Parse());
+    APSARA_TEST_TRUE(config->HasGoPlugin());
+}
+
 UNIT_TEST_CASE(CollectionConfigUnittest, HandleValidConfig)
 UNIT_TEST_CASE(CollectionConfigUnittest, SelfMonitorInputWithGoFlusher)
+UNIT_TEST_CASE(CollectionConfigUnittest, NativeInputWithGoPlugin)
 UNIT_TEST_CASE(CollectionConfigUnittest, HandleInvalidCreateTime)
 UNIT_TEST_CASE(CollectionConfigUnittest, HandleInvalidGlobal)
 UNIT_TEST_CASE(CollectionConfigUnittest, HandleInvalidInputs)


### PR DESCRIPTION
## Summary

Closes #2596

- Replaces the legacy whitelist approach for native input + Go plugin coexistence with an explicit blacklist framework in `CollectionConfig::Parse()`
- Blacklisted native inputs (those that cannot yet coexist with Go processors/flushers): `input_agentsight`, `input_cpu_profiling`, `input_forward`, `input_host_meta`, `input_host_monitor`, `input_internal_config_container_info`, `input_network_observer`, `input_prometheus`
- Allowed native inputs (legacy whitelist parity): `input_file`, `input_container_stdio`, `input_static_file_onetime`, `input_*_security`, `input_internal_metrics`, `input_internal_alarms`
- No change to default `StructureType`

## Impact & Rollback

**Impact**: Config validation logic only — no runtime behavior change for currently-valid configs. Configs that were rejected before remain rejected (blacklist matches legacy whitelist exactly). Future A1 iterations will remove blacklist entries one-by-one after B-line matrix/E2E proves end-to-end reachability.

**Rollback**: Revert this PR to restore the original whitelist-based checks (`hasFileInput`, `hasSecurityInput`, `hasSelfMonitorInput`).

## Test plan

- [x] `collection_config_unittest` — all 11 tests pass locally (Docker build + run)
- UT cases covering this change:
  - `CollectionConfigUnittest::NativeInputWithGoPlugin` — tests all 8 blacklisted inputs with Go processor (`processor_json`) and Go flusher (`flusher_http`), verifying `Parse()` returns false for each
  - `CollectionConfigUnittest::SelfMonitorInputWithGoFlusher` — verifies allowed inputs (`input_internal_metrics`, `input_internal_alarms`) still work with Go plugins
  - `CollectionConfigUnittest::HandleValidConfig` — all 36 topology tests pass (regression)

```
$ ./collection_config_unittest
[==========] Running 11 tests from 1 test case.
[  PASSED  ] 11 tests.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)