### PR TITLE
[2628-c1] fix(reader): seed metrics gauges on reload to avoid 0 drop

### DIFF
--- a/core/file_server/reader/LogFileReader.cpp
+++ b/core/file_server/reader/LogFileReader.cpp
@@ -2356,6 +2356,11 @@ void LogFileReader::InitMetricGauges() {
     if (fsutil::PathStat::stat(mHostLogPath, ps)) {
         fileSize = ps.GetFileSize();
     }
+    // Clamp to the read offset to preserve the source_size >= read_offset invariant even
+    // when the file was truncated across the reload (stat succeeds but reports a size
+    // smaller than the checkpoint-restored offset), avoiding an unexpected size gauge
+    // regression. The exact size is restored on the first ReportMetrics call.
+    fileSize = std::max(fileSize, readOffset);
     SET_GAUGE(mSourceReadOffsetBytes, readOffset);
     SET_GAUGE(mSourceSizeBytes, fileSize);
 }

--- a/core/file_server/reader/LogFileReader.cpp
+++ b/core/file_server/reader/LogFileReader.cpp
@@ -204,6 +204,9 @@ LogFileReader* LogFileReader::CreateLogFileReader(const string& hostLogPathDir,
 
         reader->InitReader(
             readerConfig.first->mTailingAllMatchedFiles, LogFileReader::BACKWARD_TO_FIXED_POS, exactlyonceConcurrency);
+        // Seed gauges after the checkpoint offset is restored so a config reload does not
+        // expose a transient 0 on the shared reentrant metrics record. See #2632.
+        reader->InitMetricGauges();
     }
     return reader;
 }
@@ -2335,6 +2338,26 @@ void LogFileReader::ReportMetrics(uint64_t readSize) {
     ADD_COUNTER(mOutSizeBytes, readSize);
     SET_GAUGE(mSourceReadOffsetBytes, GetLastFilePos());
     SET_GAUGE(mSourceSizeBytes, GetFileSize());
+}
+
+void LogFileReader::InitMetricGauges() {
+    // On config reload a new reader is created for the same file, sharing the same
+    // reentrant metrics record (keyed by config name + file labels). When the old
+    // reader is destroyed before the new one is built, the record is released and
+    // recreated with gauges defaulting to 0, so the source_size_bytes / read_offset_bytes
+    // series show a spurious drop to 0 until the new reader's first ReportMetrics call.
+    // Seed the gauges here with the reader's restored state to close that 0 window.
+    int64_t readOffset = GetLastFilePos();
+    // Best-effort current file size; the gauge is refreshed with the exact value on the
+    // first read. Fall back to readOffset (source_size >= read_offset always) so the size
+    // gauge never reads 0 either.
+    int64_t fileSize = readOffset;
+    fsutil::PathStat ps;
+    if (fsutil::PathStat::stat(mHostLogPath, ps)) {
+        fileSize = ps.GetFileSize();
+    }
+    SET_GAUGE(mSourceReadOffsetBytes, readOffset);
+    SET_GAUGE(mSourceSizeBytes, fileSize);
 }
 
 

--- a/core/file_server/reader/LogFileReader.h
+++ b/core/file_server/reader/LogFileReader.h
@@ -466,6 +466,9 @@ public:
     void SetEventGroupMetaAndTag(PipelineEventGroup& group);
 
     void SetMetrics();
+    // Seed source_size/read_offset gauges right after the reader is (re)created so a
+    // config reload does not briefly expose 0 on the shared reentrant metrics record.
+    void InitMetricGauges();
     void ReportMetrics(uint64_t readSize);
 
 protected:

--- a/core/unittest/reader/LogFileReaderUnittest.cpp
+++ b/core/unittest/reader/LogFileReaderUnittest.cpp
@@ -24,6 +24,8 @@
 #include "file_server/checkpoint/CheckPointManager.h"
 #include "file_server/reader/JsonLogFileReader.h"
 #include "file_server/reader/LogFileReader.h"
+#include "monitor/metric_constants/MetricConstants.h"
+#include "monitor/metric_models/ReentrantMetricsRecord.h"
 #include "unittest/Unittest.h"
 
 DECLARE_FLAG_INT32(force_release_deleted_file_fd_timeout);
@@ -72,6 +74,7 @@ public:
     void TestReadGBK();
     void TestReadUTF8();
     void TestSetExpectedFileSize();
+    void TestReloadMetricsGaugeNoZeroDrop();
 
     std::unique_ptr<char[]> expectedContent;
     static std::string logPathDir;
@@ -88,6 +91,7 @@ protected:
 UNIT_TEST_CASE(LogFileReaderUnittest, TestReadGBK);
 UNIT_TEST_CASE(LogFileReaderUnittest, TestReadUTF8);
 UNIT_TEST_CASE(LogFileReaderUnittest, TestSetExpectedFileSize);
+UNIT_TEST_CASE(LogFileReaderUnittest, TestReloadMetricsGaugeNoZeroDrop);
 
 std::string LogFileReaderUnittest::logPathDir;
 std::string LogFileReaderUnittest::gbkFile;
@@ -727,6 +731,83 @@ void LogFileReaderUnittest::TestSetExpectedFileSize() {
         // Should read normally without size limit
         APSARA_TEST_LE_FATAL(reader.mLastFilePos, actualFileSize);
     }
+}
+
+// Regression test for #2632: config reload must not expose a transient 0 on the
+// source_size_bytes / read_offset_bytes gauges. On reload a new reader is created for
+// the same file, sharing the reentrant metrics record keyed by config name + file
+// labels. If the old reader is destroyed before the new one is built, the shared
+// record is released and recreated with gauges defaulting to 0. Without seeding, the
+// gauge series shows a spurious drop to 0 until the new reader's first ReportMetrics.
+void LogFileReaderUnittest::TestReloadMetricsGaugeNoZeroDrop() {
+    const std::string configName = "reload_metrics_config_2632";
+    MetricLabelsPtr defaultLabels = std::make_shared<MetricLabels>();
+    defaultLabels->emplace_back(METRIC_LABEL_KEY_PROJECT, "test_project");
+    defaultLabels->emplace_back(METRIC_LABEL_KEY_PIPELINE_NAME, configName);
+    std::unordered_map<std::string, MetricType> metricKeys = {
+        {METRIC_PLUGIN_OUT_EVENTS_TOTAL, MetricType::METRIC_TYPE_COUNTER},
+        {METRIC_PLUGIN_OUT_EVENT_GROUPS_TOTAL, MetricType::METRIC_TYPE_COUNTER},
+        {METRIC_PLUGIN_OUT_SIZE_BYTES, MetricType::METRIC_TYPE_COUNTER},
+        {METRIC_PLUGIN_SOURCE_SIZE_BYTES, MetricType::METRIC_TYPE_INT_GAUGE},
+        {METRIC_PLUGIN_SOURCE_READ_OFFSET_BYTES, MetricType::METRIC_TYPE_INT_GAUGE},
+    };
+    auto pluginMetricManager = std::make_shared<PluginMetricManager>(
+        defaultLabels, metricKeys, MetricCategory::METRIC_CATEGORY_PLUGIN_SOURCE);
+    FileServer::GetInstance()->AddPluginMetricManager(configName, pluginMetricManager);
+
+    CollectionPipelineContext reloadCtx;
+    reloadCtx.SetConfigName(configName);
+    MultilineOptions multilineOpts;
+    FileReaderOptions reloadReaderOpts;
+    reloadReaderOpts.mInputType = FileReaderOptions::InputType::InputFile;
+    // Same dev/inode across readers so both map to the same reentrant metrics record.
+    DevInode devInode(1234, 5678);
+    // Offset restored from checkpoint; kept within the real file size so source_size
+    // (from the actual on-disk file) stays >= read_offset, mirroring a normal reload.
+    const int64_t consumedOffset = 128;
+
+    // --- Old reader before reload: gauges hold a real, non-zero read offset. ---
+    uint64_t offsetBeforeReload = 0;
+    {
+        LogFileReader oldReader(logPathDir,
+                                utf8File,
+                                devInode,
+                                std::make_pair(&reloadReaderOpts, &reloadCtx),
+                                std::make_pair(&multilineOpts, &reloadCtx),
+                                std::make_pair(&fileTagOpts, &reloadCtx));
+        oldReader.SetMetrics();
+        APSARA_TEST_TRUE_FATAL(oldReader.mSourceReadOffsetBytes != nullptr);
+        oldReader.mLastFilePos = consumedOffset;
+        oldReader.ReportMetrics(0);
+        offsetBeforeReload = oldReader.mSourceReadOffsetBytes->GetValue();
+        APSARA_TEST_EQUAL_FATAL(offsetBeforeReload, (uint64_t)consumedOffset);
+    }
+    // oldReader destroyed -> ReleaseReentrantMetricsRecordRef erases the shared record.
+
+    // --- New reader after reload: fresh record, gauge starts at 0 (the reload bug). ---
+    LogFileReader newReader(logPathDir,
+                            utf8File,
+                            devInode,
+                            std::make_pair(&reloadReaderOpts, &reloadCtx),
+                            std::make_pair(&multilineOpts, &reloadCtx),
+                            std::make_pair(&fileTagOpts, &reloadCtx));
+    newReader.SetMetrics();
+    APSARA_TEST_TRUE_FATAL(newReader.mSourceReadOffsetBytes != nullptr);
+    // Reproduce the bug window: the freshly recreated record reads 0 before seeding.
+    APSARA_TEST_EQUAL_FATAL(newReader.mSourceReadOffsetBytes->GetValue(), 0UL);
+
+    // Simulate the checkpoint offset restore performed by InitReader on reload.
+    newReader.mLastFilePos = consumedOffset;
+
+    // Fix under test: seed gauges right after the reader is (re)created.
+    newReader.InitMetricGauges();
+
+    // No 0 gap: read offset is restored, and source size is the real (non-zero) file size.
+    APSARA_TEST_EQUAL_FATAL(newReader.mSourceReadOffsetBytes->GetValue(), (uint64_t)consumedOffset);
+    APSARA_TEST_GT_FATAL(newReader.mSourceSizeBytes->GetValue(), 0UL);
+    APSARA_TEST_GE_FATAL(newReader.mSourceSizeBytes->GetValue(), newReader.mSourceReadOffsetBytes->GetValue());
+
+    FileServer::GetInstance()->RemovePluginMetricManager(configName);
 }
 
 class LogMultiBytesUnittest : public ::testing::Test {

--- a/core/unittest/reader/LogFileReaderUnittest.cpp
+++ b/core/unittest/reader/LogFileReaderUnittest.cpp
@@ -759,9 +759,8 @@ void LogFileReaderUnittest::TestReloadMetricsGaugeNoZeroDrop() {
     // RAII guard: remove the manager from the global FileServer singleton on scope exit,
     // including an early return triggered by a *_FATAL (gtest ASSERT_*) assertion, so a
     // mid-test failure cannot leak a stale manager into subsequent test cases.
-    std::shared_ptr<void> managerGuard(nullptr, [&configName](void*) {
-        FileServer::GetInstance()->RemovePluginMetricManager(configName);
-    });
+    std::shared_ptr<void> managerGuard(
+        nullptr, [&configName](void*) { FileServer::GetInstance()->RemovePluginMetricManager(configName); });
 
     CollectionPipelineContext reloadCtx;
     reloadCtx.SetConfigName(configName);
@@ -837,9 +836,8 @@ void LogFileReaderUnittest::TestReloadMetricsGaugeTruncatedFile() {
     auto pluginMetricManager = std::make_shared<PluginMetricManager>(
         defaultLabels, metricKeys, MetricCategory::METRIC_CATEGORY_PLUGIN_SOURCE);
     FileServer::GetInstance()->AddPluginMetricManager(configName, pluginMetricManager);
-    std::shared_ptr<void> managerGuard(nullptr, [&configName](void*) {
-        FileServer::GetInstance()->RemovePluginMetricManager(configName);
-    });
+    std::shared_ptr<void> managerGuard(
+        nullptr, [&configName](void*) { FileServer::GetInstance()->RemovePluginMetricManager(configName); });
 
     CollectionPipelineContext reloadCtx;
     reloadCtx.SetConfigName(configName);

--- a/core/unittest/reader/LogFileReaderUnittest.cpp
+++ b/core/unittest/reader/LogFileReaderUnittest.cpp
@@ -75,6 +75,7 @@ public:
     void TestReadUTF8();
     void TestSetExpectedFileSize();
     void TestReloadMetricsGaugeNoZeroDrop();
+    void TestReloadMetricsGaugeTruncatedFile();
 
     std::unique_ptr<char[]> expectedContent;
     static std::string logPathDir;
@@ -92,6 +93,7 @@ UNIT_TEST_CASE(LogFileReaderUnittest, TestReadGBK);
 UNIT_TEST_CASE(LogFileReaderUnittest, TestReadUTF8);
 UNIT_TEST_CASE(LogFileReaderUnittest, TestSetExpectedFileSize);
 UNIT_TEST_CASE(LogFileReaderUnittest, TestReloadMetricsGaugeNoZeroDrop);
+UNIT_TEST_CASE(LogFileReaderUnittest, TestReloadMetricsGaugeTruncatedFile);
 
 std::string LogFileReaderUnittest::logPathDir;
 std::string LogFileReaderUnittest::gbkFile;
@@ -812,6 +814,62 @@ void LogFileReaderUnittest::TestReloadMetricsGaugeNoZeroDrop() {
     APSARA_TEST_EQUAL_FATAL(newReader.mSourceReadOffsetBytes->GetValue(), (uint64_t)consumedOffset);
     APSARA_TEST_GT_FATAL(newReader.mSourceSizeBytes->GetValue(), 0UL);
     APSARA_TEST_GE_FATAL(newReader.mSourceSizeBytes->GetValue(), newReader.mSourceReadOffsetBytes->GetValue());
+    // managerGuard removes the PluginMetricManager on scope exit.
+}
+
+// Regression test for #2632 maintainer feedback: when the file is truncated across a
+// reload (stat succeeds but reports a size smaller than the checkpoint-restored offset),
+// InitMetricGauges must clamp source_size_bytes up to read_offset_bytes so the
+// source_size >= read_offset invariant holds and the size gauge does not regress below
+// the offset.
+void LogFileReaderUnittest::TestReloadMetricsGaugeTruncatedFile() {
+    const std::string configName = "reload_metrics_config_2632_truncated";
+    MetricLabelsPtr defaultLabels = std::make_shared<MetricLabels>();
+    defaultLabels->emplace_back(METRIC_LABEL_KEY_PROJECT, "test_project");
+    defaultLabels->emplace_back(METRIC_LABEL_KEY_PIPELINE_NAME, configName);
+    std::unordered_map<std::string, MetricType> metricKeys = {
+        {METRIC_PLUGIN_OUT_EVENTS_TOTAL, MetricType::METRIC_TYPE_COUNTER},
+        {METRIC_PLUGIN_OUT_EVENT_GROUPS_TOTAL, MetricType::METRIC_TYPE_COUNTER},
+        {METRIC_PLUGIN_OUT_SIZE_BYTES, MetricType::METRIC_TYPE_COUNTER},
+        {METRIC_PLUGIN_SOURCE_SIZE_BYTES, MetricType::METRIC_TYPE_INT_GAUGE},
+        {METRIC_PLUGIN_SOURCE_READ_OFFSET_BYTES, MetricType::METRIC_TYPE_INT_GAUGE},
+    };
+    auto pluginMetricManager = std::make_shared<PluginMetricManager>(
+        defaultLabels, metricKeys, MetricCategory::METRIC_CATEGORY_PLUGIN_SOURCE);
+    FileServer::GetInstance()->AddPluginMetricManager(configName, pluginMetricManager);
+    std::shared_ptr<void> managerGuard(nullptr, [&configName](void*) {
+        FileServer::GetInstance()->RemovePluginMetricManager(configName);
+    });
+
+    CollectionPipelineContext reloadCtx;
+    reloadCtx.SetConfigName(configName);
+    MultilineOptions multilineOpts;
+    FileReaderOptions reloadReaderOpts;
+    reloadReaderOpts.mInputType = FileReaderOptions::InputType::InputFile;
+    DevInode devInode(4321, 8765);
+
+    LogFileReader reader(logPathDir,
+                         utf8File,
+                         devInode,
+                         std::make_pair(&reloadReaderOpts, &reloadCtx),
+                         std::make_pair(&multilineOpts, &reloadCtx),
+                         std::make_pair(&fileTagOpts, &reloadCtx));
+    reader.SetMetrics();
+    APSARA_TEST_TRUE_FATAL(reader.mSourceReadOffsetBytes != nullptr);
+    APSARA_TEST_TRUE_FATAL(reader.mSourceSizeBytes != nullptr);
+
+    // Restore an offset far beyond the real on-disk file size, simulating a file that
+    // was truncated between the two readers while the checkpoint still holds the old,
+    // larger offset. stat() succeeds here but returns a size smaller than the offset.
+    const int64_t truncatedOffset = 1LL << 30; // 1 GiB, well above the small test file.
+    reader.mLastFilePos = truncatedOffset;
+
+    reader.InitMetricGauges();
+
+    // Clamp under test: size gauge is raised to the offset, never below it.
+    APSARA_TEST_EQUAL_FATAL(reader.mSourceReadOffsetBytes->GetValue(), (uint64_t)truncatedOffset);
+    APSARA_TEST_EQUAL_FATAL(reader.mSourceSizeBytes->GetValue(), (uint64_t)truncatedOffset);
+    APSARA_TEST_GE_FATAL(reader.mSourceSizeBytes->GetValue(), reader.mSourceReadOffsetBytes->GetValue());
     // managerGuard removes the PluginMetricManager on scope exit.
 }
 

--- a/core/unittest/reader/LogFileReaderUnittest.cpp
+++ b/core/unittest/reader/LogFileReaderUnittest.cpp
@@ -754,6 +754,12 @@ void LogFileReaderUnittest::TestReloadMetricsGaugeNoZeroDrop() {
     auto pluginMetricManager = std::make_shared<PluginMetricManager>(
         defaultLabels, metricKeys, MetricCategory::METRIC_CATEGORY_PLUGIN_SOURCE);
     FileServer::GetInstance()->AddPluginMetricManager(configName, pluginMetricManager);
+    // RAII guard: remove the manager from the global FileServer singleton on scope exit,
+    // including an early return triggered by a *_FATAL (gtest ASSERT_*) assertion, so a
+    // mid-test failure cannot leak a stale manager into subsequent test cases.
+    std::shared_ptr<void> managerGuard(nullptr, [&configName](void*) {
+        FileServer::GetInstance()->RemovePluginMetricManager(configName);
+    });
 
     CollectionPipelineContext reloadCtx;
     reloadCtx.SetConfigName(configName);
@@ -806,8 +812,7 @@ void LogFileReaderUnittest::TestReloadMetricsGaugeNoZeroDrop() {
     APSARA_TEST_EQUAL_FATAL(newReader.mSourceReadOffsetBytes->GetValue(), (uint64_t)consumedOffset);
     APSARA_TEST_GT_FATAL(newReader.mSourceSizeBytes->GetValue(), 0UL);
     APSARA_TEST_GE_FATAL(newReader.mSourceSizeBytes->GetValue(), newReader.mSourceReadOffsetBytes->GetValue());
-
-    FileServer::GetInstance()->RemovePluginMetricManager(configName);
+    // managerGuard removes the PluginMetricManager on scope exit.
 }
 
 class LogMultiBytesUnittest : public ::testing::Test {


### PR DESCRIPTION
## 背景 / Why
config reload 时新旧 reader 共享同一 reentrant metrics record（按 config name + file labels）。当旧 reader 先于新 reader 析构时（析构/创建顺序不定），共享 record 被释放并重建，gauge 归零，导致 `source_size_bytes` / `read_offset_bytes` 在新 reader 首次 `ReportMetrics` 前短暂**跌 0**，干扰人工与大模型排查。**纯监控数字问题，不涉及数据面 / checkpoint。**

## 改动 / What
- 新增 `LogFileReader::InitMetricGauges()`：新 reader 初始化后（`InitReader` 恢复 checkpoint offset 之后）立即用真实 read_offset / file size 刷新 gauge，关闭 0 窗口。source size 采用一次 best-effort `PathStat::stat`，stat 失败时回退到 read_offset（`source_size >= read_offset` 恒成立），保证 size gauge 同样不跌 0。
- 在工厂 `CreateLogFileReader` 中 `InitReader` 之后调用一次。
- **未触碰任何 checkpoint / reader 生命周期 / 数据面逻辑**（`InitReader`、dump/load、`CheckPointManager.*` 等均未改）。

## 范围
仅改动 `core/file_server/reader/LogFileReader.{cpp,h}` 与其单测，符合 Issue 范围锁。

## Test plan
本地 Docker 构建镜像（`loongcollector-build-linux:2.1.17`）编译 C++ 核心并运行 reader 单测（`WITHSPL=OFF ENABLE_AGENTSIGHT=OFF`，`-Werror` 通过）：

- 新增回归 UT：**`LogFileReaderUnittest.TestReloadMetricsGaugeNoZeroDrop`**
  - 模拟 reload：旧 reader 设 read_offset gauge 非 0 → 析构释放共享 record → 新 reader `SetMetrics()` 得到全新 record（断言 gauge==0，**复现 bug 窗口**）→ 恢复 checkpoint offset → `InitMetricGauges()` → 断言 `read_offset==128`、`source_size>0` 且 `source_size>=read_offset`（**无 0 间隙**）。
- 结果：
  - `log_file_reader_unittest --gtest_filter=LogFileReaderUnittest.*` → **4/4 PASSED**
  - `log_file_reader_unittest`（全量 7 suites / 22 tests）→ **22/22 PASSED**

Closes #2632

🤖 Generated with [Claude Code](https://claude.com/claude-code)