### PR TITLE
[1928-d3] feat(monitor): self-monitor PB push/receive

### DIFF
--- a/core/monitor/MetricManager.cpp
+++ b/core/monitor/MetricManager.cpp
@@ -16,10 +16,14 @@
 
 #include <set>
 
+#include "json/json.h"
+
 #include "Monitor.h"
 #include "app_config/AppConfig.h"
 #include "go_pipeline/LogtailPlugin.h"
 #include "logger/Logger.h"
+#include "protobuf/models/ProtocolConversion.h"
+#include "protobuf/models/pipeline_event_group.pb.h"
 #include "provider/Provider.h"
 
 
@@ -229,6 +233,61 @@ void ReadMetrics::UpdateGoCppProvidedMetrics(vector<map<string, string>>& metric
             }
         }
     }
+}
+
+bool ReadMetrics::ParseGoMetricsPB(const std::string& pbData,
+                                   std::vector<std::map<std::string, std::string>>& metricsList) {
+    if (pbData.empty()) {
+        return true;
+    }
+    models::PipelineEventGroup pbGroup;
+    if (!pbGroup.ParseFromString(pbData)) {
+        LOG_WARNING(sLogger, ("receive go metrics pb", "failed to parse protobuf")("size", pbData.size()));
+        return false;
+    }
+    PipelineEventGroup eventGroup(std::make_shared<SourceBuffer>());
+    std::string errMsg;
+    if (!TransferPBToPipelineEventGroup(pbGroup, eventGroup, errMsg)) {
+        LOG_WARNING(sLogger, ("receive go metrics pb", "failed to transfer pb")("err", errMsg));
+        return false;
+    }
+
+    Json::StreamWriterBuilder writerBuilder;
+    writerBuilder["indentation"] = "";
+    for (auto& eventPtr : eventGroup.GetEvents()) {
+        if (!eventPtr.Is<MetricEvent>()) {
+            continue;
+        }
+        const MetricEvent& metricEvent = eventPtr.Cast<MetricEvent>();
+        // category is carried in MetricEvent.Name; reinsert it as the metric_category
+        // label so the record matches the GetGoMetrics map form expected by
+        // SelfMonitorMetricEvent(const std::map&).
+        Json::Value labels(Json::objectValue);
+        labels["metric_category"] = metricEvent.GetName().to_string();
+        for (auto tag = metricEvent.TagsBegin(); tag != metricEvent.TagsEnd(); ++tag) {
+            labels[tag->first.to_string()] = tag->second.to_string();
+        }
+        Json::Value counters(Json::objectValue);
+        Json::Value gauges(Json::objectValue);
+        const auto* multiValues = metricEvent.GetValue<UntypedMultiDoubleValues>();
+        if (multiValues != nullptr) {
+            for (auto it = multiValues->ValuesBegin(); it != multiValues->ValuesEnd(); ++it) {
+                const std::string name = it->first.to_string();
+                const UntypedMultiDoubleValue& value = it->second;
+                if (value.MetricType == UntypedValueMetricType::MetricTypeCounter) {
+                    counters[name] = std::to_string(static_cast<uint64_t>(value.Value));
+                } else {
+                    gauges[name] = std::to_string(value.Value);
+                }
+            }
+        }
+        std::map<std::string, std::string> record;
+        record["labels"] = Json::writeString(writerBuilder, labels);
+        record["counters"] = Json::writeString(writerBuilder, counters);
+        record["gauges"] = Json::writeString(writerBuilder, gauges);
+        metricsList.emplace_back(std::move(record));
+    }
+    return true;
 }
 
 } // namespace logtail

--- a/core/monitor/MetricManager.cpp
+++ b/core/monitor/MetricManager.cpp
@@ -14,7 +14,9 @@
 
 #include "MetricManager.h"
 
+#include <iomanip>
 #include <set>
+#include <sstream>
 
 #include "json/json.h"
 
@@ -34,6 +36,19 @@ namespace logtail {
 
 const string METRIC_EXPORT_TYPE_GO = "direct";
 const string METRIC_EXPORT_TYPE_CPP = "cpp_provided";
+
+namespace {
+// Format a gauge value to match the legacy GetGoMetrics map form byte-for-byte.
+// The Go side serializes gauges via strconv.FormatFloat(v, 'f', 4, 64) (see
+// pkg/selfmonitor/metrics_imp_v2.go), i.e. fixed notation with 4 fractional
+// digits. std::to_string(double) instead emits 6 digits ("12" -> "12.000000"),
+// which diverges from the legacy string shape downstream parsers expect.
+std::string FormatGoMetricGauge(double value) {
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(4) << value;
+    return oss.str();
+}
+} // namespace
 
 WriteMetrics::~WriteMetrics() {
     Clear();
@@ -277,7 +292,7 @@ bool ReadMetrics::ParseGoMetricsPB(const std::string& pbData,
                 if (value.MetricType == UntypedValueMetricType::MetricTypeCounter) {
                     counters[name] = std::to_string(static_cast<uint64_t>(value.Value));
                 } else {
-                    gauges[name] = std::to_string(value.Value);
+                    gauges[name] = FormatGoMetricGauge(value.Value);
                 }
             }
         }

--- a/core/monitor/MetricManager.h
+++ b/core/monitor/MetricManager.h
@@ -81,12 +81,12 @@ public:
     void ReadAsSelfMonitorMetricEvents(std::vector<SelfMonitorMetricEvent>& metricEventList) const;
     void UpdateMetrics();
 
-    // Parse self-monitor metrics pushed from Go as a serialized PipelineEventGroup
+    // Parse self-monitor metrics pulled from Go as a serialized PipelineEventGroup
     // protobuf (one MetricEvent per record) into the same map<string,string> form
     // ("labels"/"counters"/"gauges" JSON) produced by the legacy GetGoMetrics path,
-    // so the pushed metrics can be consumed identically. This is the D3 receive path;
-    // it coexists with the legacy pull-based path (removed in D5). Returns false on a
-    // protobuf parse/transfer error.
+    // so the pulled metrics can be consumed identically. This is the D3 receive side of
+    // the C++-pull path; it coexists with the legacy GetGoMetrics path (removed in D5).
+    // Returns false on a protobuf parse/transfer error.
     static bool ParseGoMetricsPB(const std::string& pbData,
                                  std::vector<std::map<std::string, std::string>>& metricsList);
 

--- a/core/monitor/MetricManager.h
+++ b/core/monitor/MetricManager.h
@@ -81,6 +81,15 @@ public:
     void ReadAsSelfMonitorMetricEvents(std::vector<SelfMonitorMetricEvent>& metricEventList) const;
     void UpdateMetrics();
 
+    // Parse self-monitor metrics pushed from Go as a serialized PipelineEventGroup
+    // protobuf (one MetricEvent per record) into the same map<string,string> form
+    // ("labels"/"counters"/"gauges" JSON) produced by the legacy GetGoMetrics path,
+    // so the pushed metrics can be consumed identically. This is the D3 receive path;
+    // it coexists with the legacy pull-based path (removed in D5). Returns false on a
+    // protobuf parse/transfer error.
+    static bool ParseGoMetricsPB(const std::string& pbData,
+                                 std::vector<std::map<std::string, std::string>>& metricsList);
+
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class MetricManagerUnittest;
 #endif

--- a/core/monitor/SelfMonitorServer.cpp
+++ b/core/monitor/SelfMonitorServer.cpp
@@ -18,7 +18,12 @@
 
 #include "MetricConstants.h"
 #include "Monitor.h"
+#include "collection_pipeline/CollectionPipelineManager.h"
+#include "common/LogtailCommonFlags.h"
 #include "go_pipeline/LogtailPlugin.h"
+#include "monitor/AlarmManager.h"
+#include "protobuf/models/ProtocolConversion.h"
+#include "protobuf/models/pipeline_event_group.pb.h"
 #include "runner/ProcessorRunner.h"
 
 using namespace std;
@@ -220,6 +225,81 @@ void SelfMonitorServer::SendAlarms() {
                 mAlarmPipelineCtx->GetProcessQueueKey(), mAlarmInputIndex, std::move(pipelineEventGroup));
         }
     }
+}
+
+int32_t SelfMonitorServer::ReceiveGoAlarmsPB(const std::string& pbData) {
+    if (pbData.empty()) {
+        return 0;
+    }
+    models::PipelineEventGroup pbGroup;
+    if (!pbGroup.ParseFromString(pbData)) {
+        LOG_WARNING(sLogger, ("receive go alarms pb", "failed to parse protobuf")("size", pbData.size()));
+        return 0;
+    }
+    PipelineEventGroup eventGroup(std::make_shared<SourceBuffer>());
+    std::string errMsg;
+    if (!TransferPBToPipelineEventGroup(pbGroup, eventGroup, errMsg)) {
+        LOG_WARNING(sLogger, ("receive go alarms pb", "failed to transfer pb")("err", errMsg));
+        return 0;
+    }
+
+    int32_t syncedAlarmCount = 0;
+    for (auto& eventPtr : eventGroup.GetEvents()) {
+        if (!eventPtr.Is<LogEvent>()) {
+            continue;
+        }
+        const LogEvent& logEvent = eventPtr.Cast<LogEvent>();
+        std::string alarmType = logEvent.GetContent("alarm_type").to_string();
+        if (alarmType.empty()) {
+            continue;
+        }
+        std::string alarmLevel = logEvent.GetContent("alarm_level").to_string();
+        std::string alarmMessage = logEvent.GetContent("alarm_message").to_string();
+        std::string alarmCount = logEvent.GetContent("alarm_count").to_string();
+        std::string projectName = logEvent.GetContent("project_name").to_string();
+        std::string category = logEvent.GetContent("category").to_string();
+        std::string config = logEvent.GetContent("config").to_string();
+
+        AlarmLevel level = ALARM_LEVEL_WARNING;
+        if (alarmLevel == "2") {
+            level = ALARM_LEVEL_ERROR;
+        } else if (alarmLevel == "3") {
+            level = ALARM_LEVEL_CRITICAL;
+        }
+        int32_t count = 1;
+        if (!alarmCount.empty()) {
+            try {
+                count = std::stoi(alarmCount);
+            } catch (...) {
+                count = 1;
+            }
+        }
+        if (count <= 0) {
+            count = 1;
+        }
+        // strip the "/1" or "/2" pipeline version suffix, matching GetGoAlarms
+        std::string pipelineConfig = config;
+        if (pipelineConfig.size() > 2 && pipelineConfig[pipelineConfig.size() - 2] == '/'
+            && (pipelineConfig.back() == '1' || pipelineConfig.back() == '2')) {
+            pipelineConfig = pipelineConfig.substr(0, pipelineConfig.size() - 2);
+        }
+        std::string resolvedRegion = STRING_FLAG(default_region_name);
+        const std::shared_ptr<CollectionPipeline>& pipeline
+            = CollectionPipelineManager::GetInstance()->FindConfigByName(pipelineConfig);
+        if (pipeline) {
+            const std::string& region = pipeline->GetContext().GetRegion();
+            if (!region.empty()) {
+                resolvedRegion = region;
+            }
+        }
+        AlarmManager::GetInstance()->SendExternalAlarm(
+            alarmType, level, alarmMessage, count, resolvedRegion, projectName, pipelineConfig, category);
+        ++syncedAlarmCount;
+    }
+    if (syncedAlarmCount > 0) {
+        LOG_DEBUG(sLogger, ("receive go alarms pb", "finished")("synced", syncedAlarmCount));
+    }
+    return syncedAlarmCount;
 }
 
 void SelfMonitorServer::SendTaskStatus() {

--- a/core/monitor/SelfMonitorServer.h
+++ b/core/monitor/SelfMonitorServer.h
@@ -38,6 +38,12 @@ public:
     void UpdateAlarmPipeline(CollectionPipelineContext* ctx, size_t inputIndex);
     void RemoveAlarmPipeline();
 
+    // Receive self-monitor alarms pushed from Go as a serialized PipelineEventGroup
+    // protobuf (one LogEvent per alarm) and forward each to AlarmManager. This is the
+    // D3 receive path; it coexists with the legacy pull-based LogtailPlugin::GetGoAlarms
+    // path (removed in D5). Returns the number of alarms merged.
+    int32_t ReceiveGoAlarmsPB(const std::string& pbData);
+
     void SendTaskStatus(); // use Alarm pipeline to send task status immediately in enterprise version
 
     // Task status management

--- a/core/monitor/SelfMonitorServer.h
+++ b/core/monitor/SelfMonitorServer.h
@@ -38,10 +38,11 @@ public:
     void UpdateAlarmPipeline(CollectionPipelineContext* ctx, size_t inputIndex);
     void RemoveAlarmPipeline();
 
-    // Receive self-monitor alarms pushed from Go as a serialized PipelineEventGroup
+    // Receive self-monitor alarms pulled from Go as a serialized PipelineEventGroup
     // protobuf (one LogEvent per alarm) and forward each to AlarmManager. This is the
-    // D3 receive path; it coexists with the legacy pull-based LogtailPlugin::GetGoAlarms
-    // path (removed in D5). Returns the number of alarms merged.
+    // D3 receive side of the C++-pull path; it coexists with the legacy
+    // LogtailPlugin::GetGoAlarms path (removed in D5). Returns the number of alarms
+    // merged.
     int32_t ReceiveGoAlarmsPB(const std::string& pbData);
 
     void SendTaskStatus(); // use Alarm pipeline to send task status immediately in enterprise version

--- a/core/unittest/monitor/CMakeLists.txt
+++ b/core/unittest/monitor/CMakeLists.txt
@@ -27,8 +27,12 @@ target_link_libraries(plugin_metric_manager_unittest ${UT_BASE_TARGET})
 add_executable(self_monitor_metric_event_unittest SelfMonitorMetricEventUnittest.cpp)
 target_link_libraries(self_monitor_metric_event_unittest ${UT_BASE_TARGET})
 
+add_executable(self_monitor_server_unittest SelfMonitorServerUnittest.cpp)
+target_link_libraries(self_monitor_server_unittest ${UT_BASE_TARGET})
+
 include(GoogleTest)
 gtest_discover_tests(alarm_manager_unittest)
 gtest_discover_tests(metric_manager_unittest)
 gtest_discover_tests(plugin_metric_manager_unittest)
 gtest_discover_tests(self_monitor_metric_event_unittest)
+gtest_discover_tests(self_monitor_server_unittest)

--- a/core/unittest/monitor/MetricManagerUnittest.cpp
+++ b/core/unittest/monitor/MetricManagerUnittest.cpp
@@ -342,7 +342,7 @@ void MetricManagerUnittest::TestCreateAndDeleteMetric() {
 }
 
 // Build a serialized PipelineEventGroup PB carrying one MetricEvent, mirroring the
-// D3 Go push payload, and verify ParseGoMetricsPB reconstructs the GetGoMetrics map
+// D3 Go pull payload, and verify ParseGoMetricsPB reconstructs the GetGoMetrics map
 // form that SelfMonitorMetricEvent(const std::map&) consumes.
 void MetricManagerUnittest::TestParseGoMetricsPB() {
     PipelineEventGroup group(std::make_shared<SourceBuffer>());

--- a/core/unittest/monitor/MetricManagerUnittest.cpp
+++ b/core/unittest/monitor/MetricManagerUnittest.cpp
@@ -21,6 +21,8 @@
 
 #include "MetricConstants.h"
 #include "MetricManager.h"
+#include "protobuf/models/ProtocolConversion.h"
+#include "protobuf/models/pipeline_event_group.pb.h"
 #include "unittest/Unittest.h"
 
 namespace logtail {
@@ -41,11 +43,15 @@ public:
     void TestCreateMetricAutoDelete();
     void TestCreateMetricAutoDeleteMultiThread();
     void TestCreateAndDeleteMetric();
+    void TestParseGoMetricsPB();
+    void TestParseGoMetricsPBInvalid();
 };
 
 APSARA_UNIT_TEST_CASE(MetricManagerUnittest, TestCreateMetricAutoDelete, 0);
 APSARA_UNIT_TEST_CASE(MetricManagerUnittest, TestCreateMetricAutoDeleteMultiThread, 1);
 APSARA_UNIT_TEST_CASE(MetricManagerUnittest, TestCreateAndDeleteMetric, 2);
+APSARA_UNIT_TEST_CASE(MetricManagerUnittest, TestParseGoMetricsPB, 3);
+APSARA_UNIT_TEST_CASE(MetricManagerUnittest, TestParseGoMetricsPBInvalid, 4);
 
 
 void MetricManagerUnittest::TestCreateMetricAutoDelete() {
@@ -333,6 +339,51 @@ void MetricManagerUnittest::TestCreateAndDeleteMetric() {
         }
     }
     delete fileMetric1;
+}
+
+// Build a serialized PipelineEventGroup PB carrying one MetricEvent, mirroring the
+// D3 Go push payload, and verify ParseGoMetricsPB reconstructs the GetGoMetrics map
+// form that SelfMonitorMetricEvent(const std::map&) consumes.
+void MetricManagerUnittest::TestParseGoMetricsPB() {
+    PipelineEventGroup group(std::make_shared<SourceBuffer>());
+    MetricEvent* e = group.AddMetricEvent();
+    e->SetName("plugin");
+    e->SetTimestamp(1700000000);
+    e->SetTag(std::string("plugin_type"), std::string("flusher_stdout"));
+    e->SetValue(UntypedMultiDoubleValues{{}, nullptr});
+    auto* multiValues = e->MutableValue<UntypedMultiDoubleValues>();
+    multiValues->SetValue(std::string("proc_in_records_total"),
+                          UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeCounter, 100.0});
+    multiValues->SetValue(std::string("cache_size"),
+                          UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeGauge, 12.0});
+
+    models::PipelineEventGroup pb;
+    std::string errMsg;
+    APSARA_TEST_TRUE(TransferPipelineEventGroupToPB(group, pb, errMsg));
+    std::string bytes;
+    APSARA_TEST_TRUE(pb.SerializeToString(&bytes));
+
+    std::vector<std::map<std::string, std::string>> metricsList;
+    APSARA_TEST_TRUE(ReadMetrics::ParseGoMetricsPB(bytes, metricsList));
+    APSARA_TEST_EQUAL(metricsList.size(), 1UL);
+
+    // feed through the same ctor GetGoMetrics uses, verifying end-to-end coexistence
+    SelfMonitorMetricEvent event(metricsList[0]);
+    APSARA_TEST_EQUAL(event.mCategory, std::string("plugin"));
+    APSARA_TEST_EQUAL(event.GetLabel("plugin_type"), std::string("flusher_stdout"));
+    APSARA_TEST_EQUAL(event.GetCounter("proc_in_records_total"), 100UL);
+    APSARA_TEST_EQUAL(event.GetGauge("cache_size"), 12.0);
+}
+
+// Empty input is a no-op success; malformed protobuf returns false without touching
+// the output list.
+void MetricManagerUnittest::TestParseGoMetricsPBInvalid() {
+    std::vector<std::map<std::string, std::string>> metricsList;
+    APSARA_TEST_TRUE(ReadMetrics::ParseGoMetricsPB("", metricsList));
+    APSARA_TEST_EQUAL(metricsList.size(), 0UL);
+
+    APSARA_TEST_FALSE(ReadMetrics::ParseGoMetricsPB("not-a-valid-protobuf-payload", metricsList));
+    APSARA_TEST_EQUAL(metricsList.size(), 0UL);
 }
 
 } // namespace logtail

--- a/core/unittest/monitor/MetricManagerUnittest.cpp
+++ b/core/unittest/monitor/MetricManagerUnittest.cpp
@@ -373,8 +373,7 @@ void MetricManagerUnittest::TestParseGoMetricsPB() {
     // counters are integral strings, gauges use fixed 4-fractional-digit notation
     // (Go: strconv.FormatFloat(v, 'f', 4, 64)), not std::to_string's 6 digits.
     APSARA_TEST_EQUAL(metricsList[0]["counters"], std::string(R"({"proc_in_records_total":"100"})"));
-    APSARA_TEST_EQUAL(metricsList[0]["gauges"],
-                      std::string(R"({"avg_delay_ms":"50.5000","cache_size":"12.0000"})"));
+    APSARA_TEST_EQUAL(metricsList[0]["gauges"], std::string(R"({"avg_delay_ms":"50.5000","cache_size":"12.0000"})"));
 
     // feed through the same ctor GetGoMetrics uses, verifying end-to-end coexistence
     SelfMonitorMetricEvent event(metricsList[0]);

--- a/core/unittest/monitor/MetricManagerUnittest.cpp
+++ b/core/unittest/monitor/MetricManagerUnittest.cpp
@@ -356,6 +356,8 @@ void MetricManagerUnittest::TestParseGoMetricsPB() {
                           UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeCounter, 100.0});
     multiValues->SetValue(std::string("cache_size"),
                           UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeGauge, 12.0});
+    multiValues->SetValue(std::string("avg_delay_ms"),
+                          UntypedMultiDoubleValue{UntypedValueMetricType::MetricTypeGauge, 50.5});
 
     models::PipelineEventGroup pb;
     std::string errMsg;
@@ -367,12 +369,20 @@ void MetricManagerUnittest::TestParseGoMetricsPB() {
     APSARA_TEST_TRUE(ReadMetrics::ParseGoMetricsPB(bytes, metricsList));
     APSARA_TEST_EQUAL(metricsList.size(), 1UL);
 
+    // The reconstructed string form must match the legacy GetGoMetrics map shape:
+    // counters are integral strings, gauges use fixed 4-fractional-digit notation
+    // (Go: strconv.FormatFloat(v, 'f', 4, 64)), not std::to_string's 6 digits.
+    APSARA_TEST_EQUAL(metricsList[0]["counters"], std::string(R"({"proc_in_records_total":"100"})"));
+    APSARA_TEST_EQUAL(metricsList[0]["gauges"],
+                      std::string(R"({"avg_delay_ms":"50.5000","cache_size":"12.0000"})"));
+
     // feed through the same ctor GetGoMetrics uses, verifying end-to-end coexistence
     SelfMonitorMetricEvent event(metricsList[0]);
     APSARA_TEST_EQUAL(event.mCategory, std::string("plugin"));
     APSARA_TEST_EQUAL(event.GetLabel("plugin_type"), std::string("flusher_stdout"));
     APSARA_TEST_EQUAL(event.GetCounter("proc_in_records_total"), 100UL);
     APSARA_TEST_EQUAL(event.GetGauge("cache_size"), 12.0);
+    APSARA_TEST_EQUAL(event.GetGauge("avg_delay_ms"), 50.5);
 }
 
 // Empty input is a no-op success; malformed protobuf returns false without touching

--- a/core/unittest/monitor/SelfMonitorServerUnittest.cpp
+++ b/core/unittest/monitor/SelfMonitorServerUnittest.cpp
@@ -45,7 +45,14 @@ private:
             return "";
         }
         std::string bytes;
-        pb.SerializeToString(&bytes);
+        bool serialized = pb.SerializeToString(&bytes);
+        // Guard the boolean: on failure `bytes` may be empty/partial, which would make
+        // downstream assertions misleading. Fail loudly with context and return "" so the
+        // callers' APSARA_TEST_FALSE(bytes.empty()) check stops the test deterministically.
+        EXPECT_TRUE(serialized) << "SerializeToString failed, ByteSizeLong=" << pb.ByteSizeLong();
+        if (!serialized) {
+            return "";
+        }
         return bytes;
     }
 };

--- a/core/unittest/monitor/SelfMonitorServerUnittest.cpp
+++ b/core/unittest/monitor/SelfMonitorServerUnittest.cpp
@@ -1,0 +1,89 @@
+// Copyright 2026 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include "models/PipelineEventGroup.h"
+#include "monitor/SelfMonitorServer.h"
+#include "protobuf/models/ProtocolConversion.h"
+#include "protobuf/models/pipeline_event_group.pb.h"
+#include "unittest/Unittest.h"
+
+namespace logtail {
+
+class SelfMonitorServerUnittest : public ::testing::Test {
+public:
+    void TestReceiveGoAlarmsPB();
+    void TestReceiveGoAlarmsPBInvalid();
+
+private:
+    // Serialize a PipelineEventGroup of alarm LogEvents into PB bytes, mirroring the
+    // D3 Go push payload produced by helper.TransferAlarmsToPipelineEventGroup.
+    static std::string BuildAlarmsPB(const std::vector<std::map<std::string, std::string>>& alarms) {
+        PipelineEventGroup group(std::make_shared<SourceBuffer>());
+        for (const auto& alarm : alarms) {
+            LogEvent* logEvent = group.AddLogEvent();
+            logEvent->SetTimestamp(1700000000);
+            for (const auto& kv : alarm) {
+                logEvent->SetContent(kv.first, kv.second);
+            }
+        }
+        models::PipelineEventGroup pb;
+        std::string errMsg;
+        if (!TransferPipelineEventGroupToPB(group, pb, errMsg)) {
+            return "";
+        }
+        std::string bytes;
+        pb.SerializeToString(&bytes);
+        return bytes;
+    }
+};
+
+// A batch with two well-formed alarms and one missing alarm_type: only the two valid
+// alarms are forwarded to AlarmManager.
+void SelfMonitorServerUnittest::TestReceiveGoAlarmsPB() {
+    std::vector<std::map<std::string, std::string>> alarms = {
+        {{"alarm_type", "PARSE_ERROR_ALARM"},
+         {"alarm_level", "2"},
+         {"alarm_message", "parse failed"},
+         {"alarm_count", "3"},
+         {"project_name", "proj-a"},
+         {"category", "logstore-a"},
+         {"config", "config-a/1"}},
+        {{"alarm_type", "SEND_ALARM"}, {"alarm_level", "3"}, {"alarm_message", "send failed"}, {"alarm_count", "1"}},
+        {{"alarm_level", "1"}, {"alarm_message", "no type, should be dropped"}},
+    };
+    std::string bytes = BuildAlarmsPB(alarms);
+    APSARA_TEST_FALSE(bytes.empty());
+
+    int32_t synced = SelfMonitorServer::GetInstance()->ReceiveGoAlarmsPB(bytes);
+    APSARA_TEST_EQUAL(synced, 2);
+}
+
+// Empty and malformed payloads forward nothing.
+void SelfMonitorServerUnittest::TestReceiveGoAlarmsPBInvalid() {
+    APSARA_TEST_EQUAL(SelfMonitorServer::GetInstance()->ReceiveGoAlarmsPB(""), 0);
+    APSARA_TEST_EQUAL(SelfMonitorServer::GetInstance()->ReceiveGoAlarmsPB("not-a-valid-protobuf-payload"), 0);
+}
+
+APSARA_UNIT_TEST_CASE(SelfMonitorServerUnittest, TestReceiveGoAlarmsPB, 0);
+APSARA_UNIT_TEST_CASE(SelfMonitorServerUnittest, TestReceiveGoAlarmsPBInvalid, 1);
+
+} // namespace logtail
+
+int main(int argc, char** argv) {
+    logtail::Logger::Instance().InitGlobalLoggers();
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/core/unittest/monitor/SelfMonitorServerUnittest.cpp
+++ b/core/unittest/monitor/SelfMonitorServerUnittest.cpp
@@ -29,7 +29,7 @@ public:
 
 private:
     // Serialize a PipelineEventGroup of alarm LogEvents into PB bytes, mirroring the
-    // D3 Go push payload produced by helper.TransferAlarmsToPipelineEventGroup.
+    // D3 Go pull payload produced by helper.TransferAlarmsToPipelineEventGroup.
     static std::string BuildAlarmsPB(const std::vector<std::map<std::string, std::string>>& alarms) {
         PipelineEventGroup group(std::make_shared<SourceBuffer>());
         for (const auto& alarm : alarms) {

--- a/plugin_main/plugin_export.go
+++ b/plugin_main/plugin_export.go
@@ -93,13 +93,11 @@ typedef struct {
 
 // PBBuffer carries a serialized PipelineEventGroup protobuf that the C++ self-monitor
 // timer pulls from Go via GetGoSelfMonitor*PB. data is allocated inside
-// libGoPluginBase.so and stays owned by it: the C++ caller only copies the bytes out
-// on receive and never frees anything. Because pulls are synchronous and serialized
-// (the single self-monitor timer copies the bytes before issuing the next pull), Go
-// reclaims each buffer on the following pull. Keeping both allocation and release
-// inside this module means no memory crosses the module boundary and there is no free
-// export for C++ to call. size is the byte length; data is NULL and size is 0 when
-// there is nothing to pull or on marshal failure.
+// libGoPluginBase.so; after the C++ caller copies the bytes on receive it must
+// release the buffer via FreeSelfMonitorPB (never free() directly) so that allocation
+// and release stay in the same module and no memory crosses the module boundary. size
+// is the byte length; data is NULL and size is 0 when there is nothing to pull or on
+// marshal failure.
 typedef struct {
     char* data;
     int size;
@@ -416,30 +414,12 @@ func marshalMetricsPB(rawMetrics []map[string]string, now time.Time) ([]byte, er
 	return group.Marshal()
 }
 
-// selfMonitorAlarmsPBBuf / selfMonitorMetricsPBBuf hold the C buffer returned by the
-// most recent GetGoSelfMonitor*PB pull so it can be released on the *next* pull. The
-// C++ self-monitor timer pulls synchronously — it copies the bytes into a std::string
-// before issuing the next pull — so the previous buffer is always fully consumed by
-// the time we free it here. Freeing inside libGoPluginBase.so (where C.CBytes
-// allocated it) keeps allocation and release in the same module, so no memory crosses
-// the boundary and the C++ side never has to call a free export. Only the single
-// self-monitor pull thread touches these; alarms and metrics keep separate slots so
-// their pulls never race each other.
-var (
-	selfMonitorAlarmsPBBuf  unsafe.Pointer
-	selfMonitorMetricsPBBuf unsafe.Pointer
-)
-
-// toPBBuffer releases whatever the previous pull left in *slot, then copies data into
-// a fresh buffer allocated inside libGoPluginBase.so and records it in *slot. The C++
-// caller only copies the bytes out on receive; the buffer is reclaimed on the
-// following pull. An empty or failed marshal releases the prior buffer and yields a
-// nil buffer, which the receiver treats as no-op.
-func toPBBuffer(slot *unsafe.Pointer, data []byte, err error) C.PBBuffer {
-	if *slot != nil {
-		C.free(*slot)
-		*slot = nil
-	}
+// toPBBuffer copies data into a buffer allocated inside libGoPluginBase.so. The C++
+// caller copies the bytes on receive and then releases the buffer via
+// FreeSelfMonitorPB (not free()), keeping allocation and release in the same module
+// so no memory crosses the boundary. An empty or failed marshal yields a nil buffer,
+// which the receiver treats as no-op.
+func toPBBuffer(data []byte, err error) C.PBBuffer {
 	var buf C.PBBuffer
 	if err != nil {
 		logger.Error(context.Background(), selfmonitor.PluginAlarm, "marshal self-monitor PB error", err)
@@ -450,36 +430,50 @@ func toPBBuffer(slot *unsafe.Pointer, data []byte, err error) C.PBBuffer {
 	}
 	buf.data = (*C.char)(C.CBytes(data))
 	buf.size = C.int(len(data))
-	*slot = unsafe.Pointer(buf.data)
 	return buf
 }
 
 // GetGoSelfMonitorAlarmsPB lets the C++ self-monitor timer pull Go self-monitor
 // alarms as a serialized PipelineEventGroup protobuf. C++ copies the bytes into a
-// std::string and feeds them to SelfMonitorServer::ReceiveGoAlarmsPB; Go owns the
-// buffer and reclaims it on the next pull, so C++ never frees it. This is the D3 pull
-// path (C++ drives collection, mirroring the legacy getter structure); it coexists
-// with the legacy GetGoAlarms CGO struct path (removed in D5). Runtime wiring
-// (LoadMethod + the timer call) lands in D4, matching this PR's deferred-wiring stance
-// on the receive side.
+// std::string, feeds them to SelfMonitorServer::ReceiveGoAlarmsPB, then releases the
+// buffer via FreeSelfMonitorPB. This is the D3 pull path (C++ drives collection,
+// mirroring the legacy getter structure); it coexists with the legacy GetGoAlarms CGO
+// struct path (removed in D5). Runtime wiring (LoadMethod + the timer call) lands in
+// D4, matching this PR's deferred-wiring stance on the receive side.
 //
 //export GetGoSelfMonitorAlarmsPB
 func GetGoSelfMonitorAlarmsPB() C.PBBuffer {
 	data, err := marshalAlarmsPB(pluginmanager.GetAlarmMessages(), time.Now())
-	return toPBBuffer(&selfMonitorAlarmsPBBuf, data, err)
+	return toPBBuffer(data, err)
 }
 
 // GetGoSelfMonitorMetricsPB lets the C++ self-monitor timer pull Go self-monitor
 // metrics of the given export type as a serialized PipelineEventGroup protobuf. C++
-// copies the bytes into a std::string and feeds them to ReadMetrics::ParseGoMetricsPB;
-// Go owns the buffer and reclaims it on the next pull, so C++ never frees it. This is
-// the D3 pull path; it coexists with the legacy GetGoMetrics CGO struct path (removed
-// in D5). Runtime wiring lands in D4.
+// copies the bytes into a std::string, feeds them to ReadMetrics::ParseGoMetricsPB,
+// then releases the buffer via FreeSelfMonitorPB. This is the D3 pull path; it
+// coexists with the legacy GetGoMetrics CGO struct path (removed in D5). Runtime
+// wiring lands in D4.
 //
 //export GetGoSelfMonitorMetricsPB
 func GetGoSelfMonitorMetricsPB(metricType string) C.PBBuffer {
 	data, err := marshalMetricsPB(pluginmanager.GetMetrics(metricType), time.Now())
-	return toPBBuffer(&selfMonitorMetricsPBBuf, data, err)
+	return toPBBuffer(data, err)
+}
+
+// FreeSelfMonitorPB releases a PBBuffer.data block previously returned by
+// GetGoSelfMonitorAlarmsPB / GetGoSelfMonitorMetricsPB. Both the allocation
+// (C.CBytes in toPBBuffer) and this release run inside libGoPluginBase.so, so the
+// buffer is never freed across the module boundary — this satisfies the dynamic
+// library rule that memory must be allocated and freed within the same module and
+// avoids relying on a shared CRT heap under static-CRT linking (the cross-boundary
+// free pattern tracked as the Windows crash risk in #2645). A nil pointer is a no-op,
+// so callers may invoke it unconditionally.
+//
+//export FreeSelfMonitorPB
+func FreeSelfMonitorPB(data *C.char) {
+	if data != nil {
+		C.free(unsafe.Pointer(data))
+	}
 }
 
 func initPluginBase(cfgStr string) int {

--- a/plugin_main/plugin_export.go
+++ b/plugin_main/plugin_export.go
@@ -92,8 +92,10 @@ typedef struct {
 } InnerGoAlarms;
 
 // PBBuffer carries a serialized PipelineEventGroup protobuf pushed from Go to C++.
-// The caller (C++) owns data and must free() it. size is the byte length; data is
-// NULL and size is 0 when there is nothing to push or on marshal failure.
+// data is allocated inside libGoPluginBase.so; the C++ caller must release it via
+// FreeSelfMonitorPB (never free() directly) so that allocation and release stay in
+// the same module. size is the byte length; data is NULL and size is 0 when there
+// is nothing to push or on marshal failure.
 typedef struct {
     char* data;
     int size;
@@ -408,8 +410,10 @@ func marshalMetricsPB(rawMetrics []map[string]string, now time.Time) ([]byte, er
 	return group.Marshal()
 }
 
-// toPBBuffer copies data into a C-owned buffer. The C++ caller must free() data.
-// An empty or failed marshal yields a nil buffer, which the receiver treats as no-op.
+// toPBBuffer copies data into a buffer allocated inside libGoPluginBase.so. The C++
+// caller must release it via FreeSelfMonitorPB (not free()), keeping allocation and
+// release in the same module. An empty or failed marshal yields a nil buffer, which
+// the receiver treats as no-op.
 func toPBBuffer(data []byte, err error) C.PBBuffer {
 	var buf C.PBBuffer
 	if err != nil {
@@ -442,6 +446,21 @@ func GetGoSelfMonitorAlarmsPB() C.PBBuffer {
 func GetGoSelfMonitorMetricsPB(metricType string) C.PBBuffer {
 	data, err := marshalMetricsPB(pluginmanager.GetMetrics(metricType), time.Now())
 	return toPBBuffer(data, err)
+}
+
+// FreeSelfMonitorPB releases a PBBuffer.data block previously returned by
+// GetGoSelfMonitorAlarmsPB / GetGoSelfMonitorMetricsPB. Both the allocation
+// (C.CBytes in toPBBuffer) and this release run inside libGoPluginBase.so, so the
+// buffer is never freed across the module boundary — this satisfies the dynamic
+// library rule that memory must be allocated and freed within the same module and
+// avoids relying on a shared CRT heap under static-CRT linking. A nil pointer is a
+// no-op, so callers may invoke it unconditionally.
+//
+//export FreeSelfMonitorPB
+func FreeSelfMonitorPB(data *C.char) {
+	if data != nil {
+		C.free(unsafe.Pointer(data))
+	}
 }
 
 func initPluginBase(cfgStr string) int {

--- a/plugin_main/plugin_export.go
+++ b/plugin_main/plugin_export.go
@@ -93,11 +93,13 @@ typedef struct {
 
 // PBBuffer carries a serialized PipelineEventGroup protobuf that the C++ self-monitor
 // timer pulls from Go via GetGoSelfMonitor*PB. data is allocated inside
-// libGoPluginBase.so; after the C++ caller copies the bytes on receive it must
-// release the buffer via FreeSelfMonitorPB (never free() directly) so that allocation
-// and release stay in the same module and no memory crosses the module boundary. size
-// is the byte length; data is NULL and size is 0 when there is nothing to pull or on
-// marshal failure.
+// libGoPluginBase.so and stays owned by it: the C++ caller only copies the bytes out
+// on receive and never frees anything. Because pulls are synchronous and serialized
+// (the single self-monitor timer copies the bytes before issuing the next pull), Go
+// reclaims each buffer on the following pull. Keeping both allocation and release
+// inside this module means no memory crosses the module boundary and there is no free
+// export for C++ to call. size is the byte length; data is NULL and size is 0 when
+// there is nothing to pull or on marshal failure.
 typedef struct {
     char* data;
     int size;
@@ -414,12 +416,30 @@ func marshalMetricsPB(rawMetrics []map[string]string, now time.Time) ([]byte, er
 	return group.Marshal()
 }
 
-// toPBBuffer copies data into a buffer allocated inside libGoPluginBase.so. The C++
-// caller copies the bytes on receive and then releases the buffer via
-// FreeSelfMonitorPB (not free()), keeping allocation and release in the same module
-// so no memory crosses the boundary. An empty or failed marshal yields a nil buffer,
-// which the receiver treats as no-op.
-func toPBBuffer(data []byte, err error) C.PBBuffer {
+// selfMonitorAlarmsPBBuf / selfMonitorMetricsPBBuf hold the C buffer returned by the
+// most recent GetGoSelfMonitor*PB pull so it can be released on the *next* pull. The
+// C++ self-monitor timer pulls synchronously — it copies the bytes into a std::string
+// before issuing the next pull — so the previous buffer is always fully consumed by
+// the time we free it here. Freeing inside libGoPluginBase.so (where C.CBytes
+// allocated it) keeps allocation and release in the same module, so no memory crosses
+// the boundary and the C++ side never has to call a free export. Only the single
+// self-monitor pull thread touches these; alarms and metrics keep separate slots so
+// their pulls never race each other.
+var (
+	selfMonitorAlarmsPBBuf  unsafe.Pointer
+	selfMonitorMetricsPBBuf unsafe.Pointer
+)
+
+// toPBBuffer releases whatever the previous pull left in *slot, then copies data into
+// a fresh buffer allocated inside libGoPluginBase.so and records it in *slot. The C++
+// caller only copies the bytes out on receive; the buffer is reclaimed on the
+// following pull. An empty or failed marshal releases the prior buffer and yields a
+// nil buffer, which the receiver treats as no-op.
+func toPBBuffer(slot *unsafe.Pointer, data []byte, err error) C.PBBuffer {
+	if *slot != nil {
+		C.free(*slot)
+		*slot = nil
+	}
 	var buf C.PBBuffer
 	if err != nil {
 		logger.Error(context.Background(), selfmonitor.PluginAlarm, "marshal self-monitor PB error", err)
@@ -430,50 +450,36 @@ func toPBBuffer(data []byte, err error) C.PBBuffer {
 	}
 	buf.data = (*C.char)(C.CBytes(data))
 	buf.size = C.int(len(data))
+	*slot = unsafe.Pointer(buf.data)
 	return buf
 }
 
 // GetGoSelfMonitorAlarmsPB lets the C++ self-monitor timer pull Go self-monitor
 // alarms as a serialized PipelineEventGroup protobuf. C++ copies the bytes into a
-// std::string, feeds them to SelfMonitorServer::ReceiveGoAlarmsPB, then releases the
-// buffer via FreeSelfMonitorPB. This is the D3 pull path (C++ drives collection,
-// mirroring the legacy getter structure); it coexists with the legacy GetGoAlarms CGO
-// struct path (removed in D5). Runtime wiring (LoadMethod + the timer call) lands in
-// D4, matching this PR's deferred-wiring stance on the receive side.
+// std::string and feeds them to SelfMonitorServer::ReceiveGoAlarmsPB; Go owns the
+// buffer and reclaims it on the next pull, so C++ never frees it. This is the D3 pull
+// path (C++ drives collection, mirroring the legacy getter structure); it coexists
+// with the legacy GetGoAlarms CGO struct path (removed in D5). Runtime wiring
+// (LoadMethod + the timer call) lands in D4, matching this PR's deferred-wiring stance
+// on the receive side.
 //
 //export GetGoSelfMonitorAlarmsPB
 func GetGoSelfMonitorAlarmsPB() C.PBBuffer {
 	data, err := marshalAlarmsPB(pluginmanager.GetAlarmMessages(), time.Now())
-	return toPBBuffer(data, err)
+	return toPBBuffer(&selfMonitorAlarmsPBBuf, data, err)
 }
 
 // GetGoSelfMonitorMetricsPB lets the C++ self-monitor timer pull Go self-monitor
 // metrics of the given export type as a serialized PipelineEventGroup protobuf. C++
-// copies the bytes into a std::string, feeds them to ReadMetrics::ParseGoMetricsPB,
-// then releases the buffer via FreeSelfMonitorPB. This is the D3 pull path; it
-// coexists with the legacy GetGoMetrics CGO struct path (removed in D5). Runtime
-// wiring lands in D4.
+// copies the bytes into a std::string and feeds them to ReadMetrics::ParseGoMetricsPB;
+// Go owns the buffer and reclaims it on the next pull, so C++ never frees it. This is
+// the D3 pull path; it coexists with the legacy GetGoMetrics CGO struct path (removed
+// in D5). Runtime wiring lands in D4.
 //
 //export GetGoSelfMonitorMetricsPB
 func GetGoSelfMonitorMetricsPB(metricType string) C.PBBuffer {
 	data, err := marshalMetricsPB(pluginmanager.GetMetrics(metricType), time.Now())
-	return toPBBuffer(data, err)
-}
-
-// FreeSelfMonitorPB releases a PBBuffer.data block previously returned by
-// GetGoSelfMonitorAlarmsPB / GetGoSelfMonitorMetricsPB. Both the allocation
-// (C.CBytes in toPBBuffer) and this release run inside libGoPluginBase.so, so the
-// buffer is never freed across the module boundary — this satisfies the dynamic
-// library rule that memory must be allocated and freed within the same module and
-// avoids relying on a shared CRT heap under static-CRT linking (the cross-boundary
-// free pattern tracked as the Windows crash risk in #2645). A nil pointer is a no-op,
-// so callers may invoke it unconditionally.
-//
-//export FreeSelfMonitorPB
-func FreeSelfMonitorPB(data *C.char) {
-	if data != nil {
-		C.free(unsafe.Pointer(data))
-	}
+	return toPBBuffer(&selfMonitorMetricsPBBuf, data, err)
 }
 
 func initPluginBase(cfgStr string) int {

--- a/plugin_main/plugin_export.go
+++ b/plugin_main/plugin_export.go
@@ -96,11 +96,13 @@ typedef struct {
 // libGoPluginBase.so; after the C++ caller copies the bytes on receive it must
 // release the buffer via FreeSelfMonitorPB (never free() directly) so that allocation
 // and release stay in the same module and no memory crosses the module boundary. size
-// is the byte length; data is NULL and size is 0 when there is nothing to pull or on
-// marshal failure.
+// is the byte length; it is size_t (unsigned, pointer-sized) rather than int so the
+// cross-language length matches the C++ std::string consumer and cannot overflow or go
+// negative on the ABI boundary. data is NULL and size is 0 when there is nothing to
+// pull or on marshal failure.
 typedef struct {
     char* data;
-    int size;
+    size_t size;
 } PBBuffer;
 
 static KeyValue** makeKeyValueArray(int size) {
@@ -429,7 +431,7 @@ func toPBBuffer(data []byte, err error) C.PBBuffer {
 		return buf
 	}
 	buf.data = (*C.char)(C.CBytes(data))
-	buf.size = C.int(len(data))
+	buf.size = C.size_t(len(data))
 	return buf
 }
 

--- a/plugin_main/plugin_export.go
+++ b/plugin_main/plugin_export.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/alibaba/ilogtail/pkg/config"
 	"github.com/alibaba/ilogtail/pkg/flags"
+	"github.com/alibaba/ilogtail/pkg/helper"
 	"github.com/alibaba/ilogtail/pkg/helper/containercenter"
 	"github.com/alibaba/ilogtail/pkg/helper/k8smeta"
 	"github.com/alibaba/ilogtail/pkg/logger"
@@ -89,6 +90,14 @@ typedef struct {
     InnerGoAlarm** alarms;
     int count;
 } InnerGoAlarms;
+
+// PBBuffer carries a serialized PipelineEventGroup protobuf pushed from Go to C++.
+// The caller (C++) owns data and must free() it. size is the byte length; data is
+// NULL and size is 0 when there is nothing to push or on marshal failure.
+typedef struct {
+    char* data;
+    int size;
+} PBBuffer;
 
 static KeyValue** makeKeyValueArray(int size) {
     return malloc(sizeof(KeyValue*) * size);
@@ -378,6 +387,61 @@ func GetGoAlarms() *C.InnerGoAlarms {
 		runtime.KeepAlive(cAlarm)
 	}
 	return cAlarms
+}
+
+// marshalAlarmsPB collects Go self-monitor alarms into a PipelineEventGroup PB
+// (one LogEvent per alarm) using the D2 contract helper and returns the serialized
+// bytes. Factored out of the CGO export so it can be unit-tested without cgo types.
+func marshalAlarmsPB(alarms []selfmonitor.AlarmExportMessage, now time.Time) ([]byte, error) {
+	group, err := helper.TransferAlarmsToPipelineEventGroup(alarms, now)
+	if err != nil {
+		return nil, err
+	}
+	return group.Marshal()
+}
+
+// marshalMetricsPB collects Go self-monitor metrics of the given export type into a
+// PipelineEventGroup PB (one MetricEvent per record) using the D2 contract helper
+// and returns the serialized bytes.
+func marshalMetricsPB(rawMetrics []map[string]string, now time.Time) ([]byte, error) {
+	group := helper.TransferRawMetricsToPipelineEventGroup(rawMetrics, now)
+	return group.Marshal()
+}
+
+// toPBBuffer copies data into a C-owned buffer. The C++ caller must free() data.
+// An empty or failed marshal yields a nil buffer, which the receiver treats as no-op.
+func toPBBuffer(data []byte, err error) C.PBBuffer {
+	var buf C.PBBuffer
+	if err != nil {
+		logger.Error(context.Background(), selfmonitor.PluginAlarm, "marshal self-monitor PB error", err)
+		return buf
+	}
+	if len(data) == 0 {
+		return buf
+	}
+	buf.data = (*C.char)(C.CBytes(data))
+	buf.size = C.int(len(data))
+	return buf
+}
+
+// GetGoSelfMonitorAlarmsPB pushes Go self-monitor alarms to C++ as a serialized
+// PipelineEventGroup protobuf. This is the D3 push path; it coexists with the legacy
+// GetGoAlarms CGO struct path (removed in D5).
+//
+//export GetGoSelfMonitorAlarmsPB
+func GetGoSelfMonitorAlarmsPB() C.PBBuffer {
+	data, err := marshalAlarmsPB(pluginmanager.GetAlarmMessages(), time.Now())
+	return toPBBuffer(data, err)
+}
+
+// GetGoSelfMonitorMetricsPB pushes Go self-monitor metrics of the given export type
+// to C++ as a serialized PipelineEventGroup protobuf. This is the D3 push path; it
+// coexists with the legacy GetGoMetrics CGO struct path (removed in D5).
+//
+//export GetGoSelfMonitorMetricsPB
+func GetGoSelfMonitorMetricsPB(metricType string) C.PBBuffer {
+	data, err := marshalMetricsPB(pluginmanager.GetMetrics(metricType), time.Now())
+	return toPBBuffer(data, err)
 }
 
 func initPluginBase(cfgStr string) int {

--- a/plugin_main/plugin_export.go
+++ b/plugin_main/plugin_export.go
@@ -91,16 +91,6 @@ typedef struct {
     int count;
 } InnerGoAlarms;
 
-// PBBuffer carries a serialized PipelineEventGroup protobuf pushed from Go to C++.
-// data is allocated inside libGoPluginBase.so; the C++ caller must release it via
-// FreeSelfMonitorPB (never free() directly) so that allocation and release stay in
-// the same module. size is the byte length; data is NULL and size is 0 when there
-// is nothing to push or on marshal failure.
-typedef struct {
-    char* data;
-    int size;
-} PBBuffer;
-
 static KeyValue** makeKeyValueArray(int size) {
     return malloc(sizeof(KeyValue*) * size);
 }
@@ -391,9 +381,12 @@ func GetGoAlarms() *C.InnerGoAlarms {
 	return cAlarms
 }
 
-// marshalAlarmsPB collects Go self-monitor alarms into a PipelineEventGroup PB
-// (one LogEvent per alarm) using the D2 contract helper and returns the serialized
-// bytes. Factored out of the CGO export so it can be unit-tested without cgo types.
+// marshalAlarmsPB packs Go self-monitor alarms into a PipelineEventGroup PB (one
+// LogEvent per alarm) via the D2 contract helper and returns the serialized bytes.
+// These bytes are the payload for the Go->C++ self-monitor push, which follows the
+// flusher_sls SendPb model (Go owns the buffer, C++ copies it on receive, so no
+// memory crosses the module boundary). The C++ receiver is
+// SelfMonitorServer::ReceiveGoAlarmsPB; the push call is wired in D4.
 func marshalAlarmsPB(alarms []selfmonitor.AlarmExportMessage, now time.Time) ([]byte, error) {
 	group, err := helper.TransferAlarmsToPipelineEventGroup(alarms, now)
 	if err != nil {
@@ -402,65 +395,13 @@ func marshalAlarmsPB(alarms []selfmonitor.AlarmExportMessage, now time.Time) ([]
 	return group.Marshal()
 }
 
-// marshalMetricsPB collects Go self-monitor metrics of the given export type into a
-// PipelineEventGroup PB (one MetricEvent per record) using the D2 contract helper
-// and returns the serialized bytes.
+// marshalMetricsPB packs Go self-monitor metrics of the given export type into a
+// PipelineEventGroup PB (one MetricEvent per record) via the D2 contract helper and
+// returns the serialized bytes, the payload for the Go->C++ push consumed by
+// ReadMetrics::ParseGoMetricsPB (see marshalAlarmsPB for the ownership model).
 func marshalMetricsPB(rawMetrics []map[string]string, now time.Time) ([]byte, error) {
 	group := helper.TransferRawMetricsToPipelineEventGroup(rawMetrics, now)
 	return group.Marshal()
-}
-
-// toPBBuffer copies data into a buffer allocated inside libGoPluginBase.so. The C++
-// caller must release it via FreeSelfMonitorPB (not free()), keeping allocation and
-// release in the same module. An empty or failed marshal yields a nil buffer, which
-// the receiver treats as no-op.
-func toPBBuffer(data []byte, err error) C.PBBuffer {
-	var buf C.PBBuffer
-	if err != nil {
-		logger.Error(context.Background(), selfmonitor.PluginAlarm, "marshal self-monitor PB error", err)
-		return buf
-	}
-	if len(data) == 0 {
-		return buf
-	}
-	buf.data = (*C.char)(C.CBytes(data))
-	buf.size = C.int(len(data))
-	return buf
-}
-
-// GetGoSelfMonitorAlarmsPB pushes Go self-monitor alarms to C++ as a serialized
-// PipelineEventGroup protobuf. This is the D3 push path; it coexists with the legacy
-// GetGoAlarms CGO struct path (removed in D5).
-//
-//export GetGoSelfMonitorAlarmsPB
-func GetGoSelfMonitorAlarmsPB() C.PBBuffer {
-	data, err := marshalAlarmsPB(pluginmanager.GetAlarmMessages(), time.Now())
-	return toPBBuffer(data, err)
-}
-
-// GetGoSelfMonitorMetricsPB pushes Go self-monitor metrics of the given export type
-// to C++ as a serialized PipelineEventGroup protobuf. This is the D3 push path; it
-// coexists with the legacy GetGoMetrics CGO struct path (removed in D5).
-//
-//export GetGoSelfMonitorMetricsPB
-func GetGoSelfMonitorMetricsPB(metricType string) C.PBBuffer {
-	data, err := marshalMetricsPB(pluginmanager.GetMetrics(metricType), time.Now())
-	return toPBBuffer(data, err)
-}
-
-// FreeSelfMonitorPB releases a PBBuffer.data block previously returned by
-// GetGoSelfMonitorAlarmsPB / GetGoSelfMonitorMetricsPB. Both the allocation
-// (C.CBytes in toPBBuffer) and this release run inside libGoPluginBase.so, so the
-// buffer is never freed across the module boundary — this satisfies the dynamic
-// library rule that memory must be allocated and freed within the same module and
-// avoids relying on a shared CRT heap under static-CRT linking. A nil pointer is a
-// no-op, so callers may invoke it unconditionally.
-//
-//export FreeSelfMonitorPB
-func FreeSelfMonitorPB(data *C.char) {
-	if data != nil {
-		C.free(unsafe.Pointer(data))
-	}
 }
 
 func initPluginBase(cfgStr string) int {

--- a/plugin_main/plugin_export.go
+++ b/plugin_main/plugin_export.go
@@ -91,6 +91,18 @@ typedef struct {
     int count;
 } InnerGoAlarms;
 
+// PBBuffer carries a serialized PipelineEventGroup protobuf that the C++ self-monitor
+// timer pulls from Go via GetGoSelfMonitor*PB. data is allocated inside
+// libGoPluginBase.so; after the C++ caller copies the bytes on receive it must
+// release the buffer via FreeSelfMonitorPB (never free() directly) so that allocation
+// and release stay in the same module and no memory crosses the module boundary. size
+// is the byte length; data is NULL and size is 0 when there is nothing to pull or on
+// marshal failure.
+typedef struct {
+    char* data;
+    int size;
+} PBBuffer;
+
 static KeyValue** makeKeyValueArray(int size) {
     return malloc(sizeof(KeyValue*) * size);
 }
@@ -381,12 +393,10 @@ func GetGoAlarms() *C.InnerGoAlarms {
 	return cAlarms
 }
 
-// marshalAlarmsPB packs Go self-monitor alarms into a PipelineEventGroup PB (one
-// LogEvent per alarm) via the D2 contract helper and returns the serialized bytes.
-// These bytes are the payload for the Go->C++ self-monitor push, which follows the
-// flusher_sls SendPb model (Go owns the buffer, C++ copies it on receive, so no
-// memory crosses the module boundary). The C++ receiver is
-// SelfMonitorServer::ReceiveGoAlarmsPB; the push call is wired in D4.
+// marshalAlarmsPB collects Go self-monitor alarms into a PipelineEventGroup PB
+// (one LogEvent per alarm) using the D2 contract helper and returns the serialized
+// bytes. These bytes are what GetGoSelfMonitorAlarmsPB hands to C++ when C++ pulls;
+// factored out of the CGO export so it can be unit-tested without cgo types.
 func marshalAlarmsPB(alarms []selfmonitor.AlarmExportMessage, now time.Time) ([]byte, error) {
 	group, err := helper.TransferAlarmsToPipelineEventGroup(alarms, now)
 	if err != nil {
@@ -395,13 +405,75 @@ func marshalAlarmsPB(alarms []selfmonitor.AlarmExportMessage, now time.Time) ([]
 	return group.Marshal()
 }
 
-// marshalMetricsPB packs Go self-monitor metrics of the given export type into a
-// PipelineEventGroup PB (one MetricEvent per record) via the D2 contract helper and
-// returns the serialized bytes, the payload for the Go->C++ push consumed by
-// ReadMetrics::ParseGoMetricsPB (see marshalAlarmsPB for the ownership model).
+// marshalMetricsPB collects Go self-monitor metrics of the given export type into a
+// PipelineEventGroup PB (one MetricEvent per record) using the D2 contract helper
+// and returns the serialized bytes, the payload GetGoSelfMonitorMetricsPB hands to
+// C++ on pull and that ReadMetrics::ParseGoMetricsPB consumes.
 func marshalMetricsPB(rawMetrics []map[string]string, now time.Time) ([]byte, error) {
 	group := helper.TransferRawMetricsToPipelineEventGroup(rawMetrics, now)
 	return group.Marshal()
+}
+
+// toPBBuffer copies data into a buffer allocated inside libGoPluginBase.so. The C++
+// caller copies the bytes on receive and then releases the buffer via
+// FreeSelfMonitorPB (not free()), keeping allocation and release in the same module
+// so no memory crosses the boundary. An empty or failed marshal yields a nil buffer,
+// which the receiver treats as no-op.
+func toPBBuffer(data []byte, err error) C.PBBuffer {
+	var buf C.PBBuffer
+	if err != nil {
+		logger.Error(context.Background(), selfmonitor.PluginAlarm, "marshal self-monitor PB error", err)
+		return buf
+	}
+	if len(data) == 0 {
+		return buf
+	}
+	buf.data = (*C.char)(C.CBytes(data))
+	buf.size = C.int(len(data))
+	return buf
+}
+
+// GetGoSelfMonitorAlarmsPB lets the C++ self-monitor timer pull Go self-monitor
+// alarms as a serialized PipelineEventGroup protobuf. C++ copies the bytes into a
+// std::string, feeds them to SelfMonitorServer::ReceiveGoAlarmsPB, then releases the
+// buffer via FreeSelfMonitorPB. This is the D3 pull path (C++ drives collection,
+// mirroring the legacy getter structure); it coexists with the legacy GetGoAlarms CGO
+// struct path (removed in D5). Runtime wiring (LoadMethod + the timer call) lands in
+// D4, matching this PR's deferred-wiring stance on the receive side.
+//
+//export GetGoSelfMonitorAlarmsPB
+func GetGoSelfMonitorAlarmsPB() C.PBBuffer {
+	data, err := marshalAlarmsPB(pluginmanager.GetAlarmMessages(), time.Now())
+	return toPBBuffer(data, err)
+}
+
+// GetGoSelfMonitorMetricsPB lets the C++ self-monitor timer pull Go self-monitor
+// metrics of the given export type as a serialized PipelineEventGroup protobuf. C++
+// copies the bytes into a std::string, feeds them to ReadMetrics::ParseGoMetricsPB,
+// then releases the buffer via FreeSelfMonitorPB. This is the D3 pull path; it
+// coexists with the legacy GetGoMetrics CGO struct path (removed in D5). Runtime
+// wiring lands in D4.
+//
+//export GetGoSelfMonitorMetricsPB
+func GetGoSelfMonitorMetricsPB(metricType string) C.PBBuffer {
+	data, err := marshalMetricsPB(pluginmanager.GetMetrics(metricType), time.Now())
+	return toPBBuffer(data, err)
+}
+
+// FreeSelfMonitorPB releases a PBBuffer.data block previously returned by
+// GetGoSelfMonitorAlarmsPB / GetGoSelfMonitorMetricsPB. Both the allocation
+// (C.CBytes in toPBBuffer) and this release run inside libGoPluginBase.so, so the
+// buffer is never freed across the module boundary — this satisfies the dynamic
+// library rule that memory must be allocated and freed within the same module and
+// avoids relying on a shared CRT heap under static-CRT linking (the cross-boundary
+// free pattern tracked as the Windows crash risk in #2645). A nil pointer is a no-op,
+// so callers may invoke it unconditionally.
+//
+//export FreeSelfMonitorPB
+func FreeSelfMonitorPB(data *C.char) {
+	if data != nil {
+		C.free(unsafe.Pointer(data))
+	}
 }
 
 func initPluginBase(cfgStr string) int {

--- a/plugin_main/plugin_export_selfmonitor_test.go
+++ b/plugin_main/plugin_export_selfmonitor_test.go
@@ -26,8 +26,9 @@ import (
 	"github.com/alibaba/ilogtail/pkg/selfmonitor"
 )
 
-// TestMarshalAlarmsPBRoundTrip verifies that alarms marshaled by the D3 push path
-// deserialize back to the same AlarmExportMessage set via the D2 contract helper.
+// TestMarshalAlarmsPBRoundTrip verifies that alarms marshaled on the Go side for the
+// D3 pull path deserialize back to the same AlarmExportMessage set via the D2 contract
+// helper.
 func TestMarshalAlarmsPBRoundTrip(t *testing.T) {
 	now := time.Unix(1700000000, 0)
 	alarms := []selfmonitor.AlarmExportMessage{
@@ -79,8 +80,8 @@ func TestMarshalAlarmsPBEmpty(t *testing.T) {
 	assert.Empty(t, helper.TransferPipelineEventGroupToAlarms(group))
 }
 
-// TestMarshalMetricsPBRoundTrip verifies that raw metric records marshaled by the D3
-// push path deserialize back to the expected MetricExportRecord set.
+// TestMarshalMetricsPBRoundTrip verifies that raw metric records marshaled on the Go
+// side for the D3 pull path deserialize back to the expected MetricExportRecord set.
 func TestMarshalMetricsPBRoundTrip(t *testing.T) {
 	now := time.Unix(1700000000, 0)
 	raw := []map[string]string{

--- a/plugin_main/plugin_export_selfmonitor_test.go
+++ b/plugin_main/plugin_export_selfmonitor_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/alibaba/ilogtail/pkg/helper"
+	"github.com/alibaba/ilogtail/pkg/protocol"
+	"github.com/alibaba/ilogtail/pkg/selfmonitor"
+)
+
+// TestMarshalAlarmsPBRoundTrip verifies that alarms marshaled by the D3 push path
+// deserialize back to the same AlarmExportMessage set via the D2 contract helper.
+func TestMarshalAlarmsPBRoundTrip(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	alarms := []selfmonitor.AlarmExportMessage{
+		{
+			AlarmType:    "PARSE_ERROR_ALARM",
+			AlarmLevel:   "2",
+			AlarmMessage: "parse failed",
+			Count:        3,
+			ProjectName:  "proj-a",
+			Category:     "logstore-a",
+			Config:       "config-a",
+		},
+		{
+			AlarmType:    "SEND_ALARM",
+			AlarmLevel:   "3",
+			AlarmMessage: "send failed",
+			Count:        1,
+		},
+	}
+
+	data, err := marshalAlarmsPB(alarms, now)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	group := &protocol.PipelineEventGroup{}
+	require.NoError(t, group.Unmarshal(data))
+
+	got := helper.TransferPipelineEventGroupToAlarms(group)
+	require.Len(t, got, len(alarms))
+	for i, want := range alarms {
+		assert.Equal(t, want.AlarmType, got[i].AlarmType)
+		assert.Equal(t, want.AlarmLevel, got[i].AlarmLevel)
+		assert.Equal(t, want.AlarmMessage, got[i].AlarmMessage)
+		assert.Equal(t, want.Count, got[i].Count)
+		assert.Equal(t, want.ProjectName, got[i].ProjectName)
+		assert.Equal(t, want.Category, got[i].Category)
+		assert.Equal(t, want.Config, got[i].Config)
+	}
+}
+
+// TestMarshalAlarmsPBEmpty verifies an empty alarm batch still produces a valid,
+// parseable PipelineEventGroup (yielding zero alarms).
+func TestMarshalAlarmsPBEmpty(t *testing.T) {
+	data, err := marshalAlarmsPB(nil, time.Unix(1700000000, 0))
+	require.NoError(t, err)
+
+	group := &protocol.PipelineEventGroup{}
+	require.NoError(t, group.Unmarshal(data))
+	assert.Empty(t, helper.TransferPipelineEventGroupToAlarms(group))
+}
+
+// TestMarshalMetricsPBRoundTrip verifies that raw metric records marshaled by the D3
+// push path deserialize back to the expected MetricExportRecord set.
+func TestMarshalMetricsPBRoundTrip(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	raw := []map[string]string{
+		{
+			selfmonitor.MetricLabelPrefix:   `{"metric_category":"plugin","plugin_type":"flusher_stdout"}`,
+			selfmonitor.MetricCounterPrefix: `{"proc_in_records_total":"100"}`,
+			selfmonitor.MetricGaugePrefix:   `{}`,
+		},
+		{
+			selfmonitor.MetricLabelPrefix:   `{"metric_category":"runner","runner_name":"k8s_meta"}`,
+			selfmonitor.MetricCounterPrefix: `{"proc_in_records_total":"5"}`,
+			selfmonitor.MetricGaugePrefix:   `{"cache_size":"12"}`,
+		},
+	}
+
+	data, err := marshalMetricsPB(raw, now)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	group := &protocol.PipelineEventGroup{}
+	require.NoError(t, group.Unmarshal(data))
+
+	got := helper.TransferPipelineEventGroupToMetrics(group)
+	require.Len(t, got, len(raw))
+
+	byCategory := make(map[string]selfmonitor.MetricExportRecord, len(got))
+	for _, r := range got {
+		byCategory[r.Category] = r
+	}
+
+	plugin, ok := byCategory["plugin"]
+	require.True(t, ok)
+	assert.Equal(t, "flusher_stdout", plugin.Labels["plugin_type"])
+	assert.Equal(t, uint64(100), plugin.Counters["proc_in_records_total"])
+
+	runner, ok := byCategory["runner"]
+	require.True(t, ok)
+	assert.Equal(t, "k8s_meta", runner.Labels["runner_name"])
+	assert.Equal(t, uint64(5), runner.Counters["proc_in_records_total"])
+	assert.Equal(t, float64(12), runner.Gauges["cache_size"])
+}


### PR DESCRIPTION
## 背景与目的

Closes #2608（Epic #2595 · 轨道 **D3**）。

新增一条基于 protobuf 的自监控传输通路：Go 侧把自监控**指标/告警**打包成序列化的
`PipelineEventGroup` PB，C++ 侧解析并汇入既有的自监控消费点。新通路与旧的
`GetGoMetrics` / `GetGoAlarms` CGO 结构体通路**并存**，旧通路本 PR 不动，留待 **D5** 删除。
本 PR 直接构建在 D2 契约辅助函数（#2625）之上。

> 本节以下整理了 review 过程中讨论沉淀的内容：**方向选型（pull vs push）**、**最终代码形态**、
> **内存分配/释放模型**、**CGO 交互全景**，以及 **未来演进链路**，便于 review。

---

## 一、方向选型：C++ 主动拉取 PB（已定，选 A）

经 review 讨论，最终方向为 **A：C++ 自监控定时器主动 pull PB**（沿用旧 getter 结构），
**不采用** B（Go 主动 push）。理由：

1. **节拍归属**：自监控唯一节拍源是 C++ 侧、由宿主进程拥有并停止的 60s 定时线程
   （`SelfMonitorServer::Monitor`）。pull 原地复用它，**不新增任何线程/生命周期**；push 会在
   `.so` 内引入第二个 Go 侧节拍，需新增 goroutine 生命周期并保证其在 C++ 拆除
   `AlarmManager`/`ReadMetrics` 之前静默，否则迟到的一次 push 会打到已析构的单例。这与
   review-standards「自监控涉及重启的功能应由 LogtailMonitor 统一管理」「动态库线程资源必须
   由主程序控制」一致。
2. **内存安全无差异**：#2645 的跨模块 free 隐患是靠「单块 PB buffer + 同模块配对释放」根治的，
   与 pull/push 方向无关——两方向都是一块连续内存 + 边界拷贝。
3. **接入成本**：pull 复用现有链路，getter 已在本 PR，D4 只需替换两处调用点；push 需新增注册
   export + Go 调度器 + 与 SelfMonitorServer 同步的 start/stop，纯增代码与失败面，产出相同。
4. **与既有模型一致**：今天 Go 自监控本就是 pull 语义（`GetMetrics` / `GetAlarmMessages` 是
   累积-drain 访问器）。PB pull 是它的原地现代化。

> push 真正有价值的是事件驱动/低延迟场景（critical 告警立即推、不等 60s），超出 D3 范围，
> 需另行拆分并先把生命周期做扎实。

---

## 二、最终代码形态

### Go 生产端 —— `plugin_main/plugin_export.go`

- `marshalAlarmsPB(alarms, now) ([]byte, error)`：纯构造器，经 D2 helper
  `helper.TransferAlarmsToPipelineEventGroup` 把 Go 自监控告警打包成 `PipelineEventGroup`
  （每条告警一个 `LogEvent`）后 `Marshal()`。
- `marshalMetricsPB(rawMetrics, now) ([]byte, error)`：纯构造器，经 D2 helper
  `helper.TransferRawMetricsToPipelineEventGroup` 打包指标（每条一个 `MetricEvent`）后 `Marshal()`。
  两个构造器从 CGO export 中拆出，可脱离 cgo 类型单测。
- `toPBBuffer(data, err) C.PBBuffer`：用 `C.CBytes` 在 **`libGoPluginBase.so` 内**分配单块连续
  内存装进 `PBBuffer`；空数据 / marshal 失败 → 返回零值 buffer（`data=NULL, size=0`），接收方 no-op。
- `//export GetGoSelfMonitorAlarmsPB() C.PBBuffer`：C++ pull 告警 PB（源 `GetAlarmMessages()`）。
- `//export GetGoSelfMonitorMetricsPB(metricType string) C.PBBuffer`：C++ pull 指标 PB（源 `GetMetrics(type)`）。
- `//export FreeSelfMonitorPB(data *C.char)`：`C.free` 释放 getter 返回的缓冲，**释放同样发生在
  `.so` 内**；nil 入参 no-op，可无条件调用。
- `PBBuffer{char* data; int size;}` C 类型：字节缓冲的载体（指针 + 长度），**不是**逐字段 CGO struct。

### C++ 接收端 —— `core/monitor/*`

- `SelfMonitorServer::ReceiveGoAlarmsPB(const std::string& pbData) -> int32_t`
  （`core/monitor/SelfMonitorServer.{h,cpp}`）：经 `TransferPBToPipelineEventGroup` 解析 PB，把每条
  告警转发给 `AlarmManager::SendExternalAlarm`，行为对齐 `GetGoAlarms`（等级映射、`/1`·`/2` config
  版本后缀裁剪、region 解析）。返回合并的告警条数。
- `ReadMetrics::ParseGoMetricsPB(const std::string& pbData, std::vector<std::map<string,string>>& out) -> bool`
  （`core/monitor/MetricManager.{h,cpp}`）：解析 PB 并重建与 `GetGoMetrics` **完全相同**的
  `labels`/`counters`/`gauges` JSON map 形态，使 push 上来的指标能原样喂入既有的
  `SelfMonitorMetricEvent(const std::map&)` 通路。protobuf 解析/转换失败返回 `false`。

两个接收方法均 `const std::string&`、**接收即拷贝**，不持有跨边界缓冲。

---

## 三、内存分配与释放模型（本 PR 核心改进）

对照旧路径最清楚：

| | 旧 CGO 结构体路径（`GetGoMetrics`/`GetGoAlarms`） | 新 PB 路径（本 PR） |
|---|---|---|
| 分配 | `.so` 内 malloc 一棵**嵌套 C 结构体树** | `.so` 内 `C.CBytes` 分配**单块**连续内存 |
| 跨边界传递 | 裸指针 + 嵌套结构 | `PBBuffer{data,size}`（一块字节） |
| 释放 | **C++ 侧逐节点 `free()`** → 跨模块 free | C++ 调 **`FreeSelfMonitorPB`** → `.so` 内 `C.free` |
| 是否跨模块申请/释放 | **是**（违反动态库规则，#2645 Windows crash 隐患） | **否**（同模块配对） |

新路径生命周期：Go marshal 出的 `[]byte` 由 Go GC 管；`C.CBytes` 复制到的 C 堆块由 `.so`
（`FreeSelfMonitorPB`）管；C++ 侧 `std::string`/`PipelineEventGroup` 由 C++ RAII 管——三段各自独立，
边界处只做**一次拷贝**。C++ 拷完字节后**立即**调 `FreeSelfMonitorPB` 释放，pull 间隔内不留任何缓冲
（曾评估「Go 包级 slot 延迟释放」以省掉 free 导出，但会在 pull 间隔内常驻一块 payload，已否决）。

结果：不再有嵌套树、不再有跨模块 free、不依赖共享 CRT 堆，从根上规避 #2645，符合
review-standards §6「动态库内存申请/释放必须配对，不允许跨主程序和动态库申请/释放」。

---

## 四、CGO 交互全景（review 参考）

进程内 Go(`libGoPluginBase.so`) ↔ C++ core 的 CGO 只有两个方向：

- **方向一 C++→Go**（C++ 调 Go `//export`）：生命周期/配置（`InitPluginBase`、`LoadPipeline`…，
  只传字符串，无跨边界 free）；容器元信息（`GetContainerMeta`/`GetAllContainers`/`GetDiffContainers`，
  **Go malloc、C++ 逐字段 free → 跨边界**，即 #2645）；数据面 `ProcessPipelineEventGroup`
  （C++ 把 PB 作为 `GoSlice` 传入、Go 只读、C++ 自己析构——**调用方拥有内存**，最干净）。
- **方向二 Go→C++**（Go 调 adapter 注册回调）：`LogtailSendPb`/`SendPbV2`（`flusher_sls` 发送路径，
  **Go 拥有缓冲、C++ 同步拷入、零跨边界 free**）。

**本 PR 的自监控 PB pull** 属方向一：与数据面一样传「一整包 PB」，并通过 `FreeSelfMonitorPB`
把释放收回 `.so`，做到同模块配对。删除旧自监控（D5）后，唯一残留的跨边界分配点是**容器元信息**，
已单独整理并提 issue **#2645**。

---

## 五、运行时接线与演进（重要）

**新通路目前尚未在运行时接通。** C++ 侧对新导出（`GetGoSelfMonitorAlarmsPB` /
`GetGoSelfMonitorMetricsPB` / `FreeSelfMonitorPB`）无任何引用（`grep -rn "GetGoSelfMonitor" core/`
无结果），既未 `LoadMethod` 加载、也未调用；新接收方法（`ReceiveGoAlarmsPB` / `ParseGoMetricsPB`）
当前仅被单测覆盖。

因此**现阶段所有自监控数据仍全部走旧通路**（指标 `MetricManager.cpp:179,185` → `GetGoMetrics`；
告警 `SelfMonitorServer.cpp:211` → `GetGoAlarms`）。让 C++ 运行时**调用**新导出的 CGO 胶水位于
`core/go_pipeline/LogtailPlugin.{h,cpp}`（在 #2608 范围锁之外），故**有意推迟**——与 D2（#2625）
一致：先交付契约 + 单测，不做运行时接线。

演进路线：

- **D3（本 PR）**：交付 pull 生产端、receive/merge 逻辑、配对内存管理与两侧单测，不接线；新旧通路并存。
- **D4**：`GetGoSelfMonitor*PB` 经 `LoadMethod` 接到 C++ 自监控定时器（替换 `GetGoMetrics`/`GetGoAlarms`
  两处调用点），并在 C++ 侧调用 `FreeSelfMonitorPB`；自监控数据实际走 PB 通路，行为与旧路径等价。
- **D5**：删除旧 CGO getter 及跨模块 free，PB 成为唯一通路。

---

## 六、测试计划（均本地执行）

**Go** —— `CGO_ENABLED=1 go test ./plugin_main/ -run 'TestMarshalAlarmsPB|TestMarshalMetricsPB' -v`
- `TestMarshalAlarmsPBRoundTrip` ✅
- `TestMarshalAlarmsPBEmpty` ✅
- `TestMarshalMetricsPBRoundTrip` ✅

**C++**（在 `loongcollector-build-linux:2.1.17` 镜像内构建，
`BUILD_LOGTAIL=OFF BUILD_LOGTAIL_UT=ON WITHSPL=OFF ENABLE_AGENTSIGHT=OFF`）：
- `self_monitor_server_unittest` —— `TestReceiveGoAlarmsPB`、`TestReceiveGoAlarmsPBInvalid` ✅（2/2）
- `metric_manager_unittest` —— `TestParseGoMetricsPB`、`TestParseGoMetricsPBInvalid` + 既有用例 ✅（无回归）

本地结果：

```
Go:  plugin_main 3 个用例 PASS ; gofmt/go vet/golangci-lint clean ; security-check clear
C++: self_monitor_server_unittest  2/2 PASS
C++: metric_manager_unittest       PASS（含既有用例，无回归）
```

## 验收标准

- [x] Go/C++ 单测通过 —— 见测试计划
- [x] 与 `GetGoMetrics` 路径可并存（D5 再删）—— 旧通路保持不动，新通路为增量叠加

🤖 Generated with [Claude Code](https://claude.com/claude-code)
