### PR TITLE
support win for prometheus plugin

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -156,8 +156,11 @@ set(SUB_DIRECTORIES_LIST
         protobuf/sls protobuf/models protobuf/forward
         file_server file_server/event file_server/event_handler file_server/event_listener file_server/reader file_server/polling file_server/checkpoint
         parser
-        prometheus prometheus/labels prometheus/schedulers prometheus/async prometheus/component
         )
+if (NOT ANDROID)
+    set(SUB_DIRECTORIES_LIST ${SUB_DIRECTORIES_LIST}
+        prometheus prometheus/labels prometheus/schedulers prometheus/async prometheus/component)
+endif()
 if (LINUX)
     if (ENABLE_ENTERPRISE)
         set(SUB_DIRECTORIES_LIST ${SUB_DIRECTORIES_LIST} shennong shennong/sdk apm/forward)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -156,13 +156,13 @@ set(SUB_DIRECTORIES_LIST
         protobuf/sls protobuf/models protobuf/forward
         file_server file_server/event file_server/event_handler file_server/event_listener file_server/reader file_server/polling file_server/checkpoint
         parser
+        prometheus prometheus/labels prometheus/schedulers prometheus/async prometheus/component
         )
 if (LINUX)
     if (ENABLE_ENTERPRISE)
         set(SUB_DIRECTORIES_LIST ${SUB_DIRECTORIES_LIST} shennong shennong/sdk apm/forward)
     endif()
     set(SUB_DIRECTORIES_LIST ${SUB_DIRECTORIES_LIST} ebpf ebpf/type ebpf/type/table ebpf/util ebpf/util/sampler ebpf/protocol/http ebpf/protocol/mysql ebpf/protocol/redis ebpf/protocol ebpf/plugin/file_security ebpf/plugin/network_observer ebpf/plugin/process_security ebpf/plugin/network_security ebpf/plugin/agentsight ebpf/plugin/cpu_profiling ebpf/plugin ebpf/observer ebpf/security
-        prometheus prometheus/labels prometheus/schedulers prometheus/async prometheus/component
         host_monitor host_monitor/collector host_monitor/common forward forward/loongsuite
         )
 elseif(MSVC)

--- a/core/collection_pipeline/plugin/PluginRegistry.cpp
+++ b/core/collection_pipeline/plugin/PluginRegistry.cpp
@@ -64,6 +64,8 @@
 #include "plugin/input/InputNetworkObserver.h"
 #include "plugin/input/InputNetworkSecurity.h"
 #include "plugin/input/InputProcessSecurity.h"
+#endif
+#if !defined(__ANDROID__)
 #include "plugin/input/InputPrometheus.h"
 #include "plugin/processor/inner/ProcessorPromParseMetricNative.h"
 #include "plugin/processor/inner/ProcessorPromRelabelMetricNative.h"
@@ -162,9 +164,11 @@ void PluginRegistry::LoadStaticPlugins() {
     RegisterContinuousInputCreator(new StaticInputCreator<InputInternalAlarms>(), true);
     RegisterContinuousInputCreator(new StaticInputCreator<InputInternalMetrics>(), true);
     RegisterContinuousInputCreator(new StaticInputCreator<InputInternalMatchedContainerInfo>(), true);
+#if !defined(__ANDROID__)
+    RegisterContinuousInputCreator(new StaticInputCreator<InputPrometheus>());
+#endif
 #if defined(__linux__) && !defined(__ANDROID__)
     RegisterContinuousInputCreator(new StaticInputCreator<InputContainerStdio>());
-    RegisterContinuousInputCreator(new StaticInputCreator<InputPrometheus>());
     // TODO: remove these gflag when plugin is stablized
     if (BOOL_FLAG(enable_ebpf_network_observer)) {
         RegisterContinuousInputCreator(new StaticInputCreator<InputNetworkObserver>(), false);
@@ -196,7 +200,7 @@ void PluginRegistry::LoadStaticPlugins() {
     RegisterProcessorCreator(new StaticProcessorCreator<ProcessorMergeMultilineLogNative>());
     RegisterProcessorCreator(new StaticProcessorCreator<ProcessorParseContainerLogNative>());
     RegisterProcessorCreator(new StaticProcessorCreator<ProcessorParseFromPBNative>());
-#if defined(__linux__) && !defined(__ANDROID__)
+#if !defined(__ANDROID__)
     RegisterProcessorCreator(new StaticProcessorCreator<ProcessorPromRelabelMetricNative>());
     RegisterProcessorCreator(new StaticProcessorCreator<ProcessorPromParseMetricNative>());
 #endif

--- a/core/plugin/input/input.cmake
+++ b/core/plugin/input/input.cmake
@@ -29,7 +29,6 @@ if(MSVC)
         ${CMAKE_SOURCE_DIR}/plugin/input/InputCpuProfiling.cpp
         ${CMAKE_SOURCE_DIR}/plugin/input/InputHostMeta.cpp
         ${CMAKE_SOURCE_DIR}/plugin/input/InputHostMonitor.cpp
-        ${CMAKE_SOURCE_DIR}/plugin/input/InputPrometheus.cpp
         ${CMAKE_SOURCE_DIR}/plugin/input/InputForward.cpp
         ${CMAKE_SOURCE_DIR}/plugin/input/InputAgentSight.cpp
         )

--- a/core/plugin/processor/processor.cmake
+++ b/core/plugin/processor/processor.cmake
@@ -21,12 +21,6 @@ file(GLOB THIS_SOURCE_FILES ${CMAKE_SOURCE_DIR}/plugin/processor/*.c ${CMAKE_SOU
 list(APPEND THIS_SOURCE_FILES_LIST ${THIS_SOURCE_FILES})
 # add processor/inner
 file(GLOB THIS_SOURCE_FILES ${CMAKE_SOURCE_DIR}/plugin/processor/inner/*.c ${CMAKE_SOURCE_DIR}/plugin/processor/inner/*.cc ${CMAKE_SOURCE_DIR}/plugin/processor/inner/*.cpp ${CMAKE_SOURCE_DIR}/plugin/processor/inner/*.h)
-if (MSVC)
-    list(REMOVE_ITEM THIS_SOURCE_FILES ${CMAKE_SOURCE_DIR}/plugin/processor/inner/ProcessorPromRelabelMetricNative.cpp)
-    list(REMOVE_ITEM THIS_SOURCE_FILES ${CMAKE_SOURCE_DIR}/plugin/processor/inner/ProcessorPromParseMetricNative.cpp)
-    list(REMOVE_ITEM THIS_SOURCE_FILES ${CMAKE_SOURCE_DIR}/plugin/processor/inner/ProcessorPromRelabelMetricNative.h)
-    list(REMOVE_ITEM THIS_SOURCE_FILES ${CMAKE_SOURCE_DIR}/plugin/processor/inner/ProcessorPromParseMetricNative.h)
-endif()
 list(APPEND THIS_SOURCE_FILES_LIST ${THIS_SOURCE_FILES})
 
 # Set source files to parent

--- a/core/prometheus/component/StreamScraper.cpp
+++ b/core/prometheus/component/StreamScraper.cpp
@@ -2,8 +2,10 @@
 
 #include <cstddef>
 
+#include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 #include <utility>
 
 #include "Flags.h"
@@ -122,7 +124,7 @@ void StreamScraper::PushEventGroup(PipelineEventGroup&& eGroup) const {
             LOG_DEBUG(sLogger, ("prometheus stream scraper", "queue not exist"));
             break;
         }
-        usleep(10 * 1000);
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 }
 


### PR DESCRIPTION
## 背景与目的

  Prometheus 采集插件（Input + Processor）此前仅在 Linux 平台编译启用，Windows(MSVC) 平台被排除在外。本次改动将 Prometheus
  
  ## 主要改动
  
  ### 1. 构建配置：Prometheus 模块跨平台化
  
  - **`core/CMakeLists.txt`**：将 `prometheus` 及其子目录（`labels`、`schedulers`、`async`、`component`）从 Linux 专属块中移出，改为
  `if (NOT ANDROID)` 通用编译，使 Windows 也参与构建。
  - **`core/plugin/input/input.cmake`**：移除 MSVC 下对 `InputPrometheus.cpp` 的排除，Windows 现在编译该源文件。
  - **`core/plugin/processor/processor.cmake`**：移除 MSVC 下对 `ProcessorPromRelabelMetricNative` /
  `ProcessorPromParseMetricNative`（.cpp/.h）的排除。
  
  ### 2. 插件注册：放开平台限制
  
  - **`core/collection_pipeline/plugin/PluginRegistry.cpp`**：
    - 将 `InputPrometheus`、`ProcessorPromParseMetricNative`、`ProcessorPromRelabelMetricNative` 等头文件的包含条件从 `__linux__` 
  调整为 `!defined(__ANDROID__)`。
    - `InputPrometheus` 的注册从 Linux 专属块移出，改为 `#if !defined(__ANDROID__)` 下注册（Windows 生效）。
    - Prometheus 两个 inner Processor 的注册条件由 `__linux__ && !__ANDROID__` 放宽为 `!__ANDROID__`。

  ### 3. 跨平台兼容修复

  - **`core/prometheus/component/StreamScraper.cpp`**：将 POSIX 专属的 `usleep(10 * 1000)` 替换为标准 C++ 的 
  `std::this_thread::sleep_for(std::chrono::milliseconds(10))`，并补充 `<chrono>`、`<thread>` 头文件，以在 Windows(MSVC) 下正常编译。
  
  ## 影响范围
  
  - **Windows**：新增 Prometheus 输入插件与相关 Processor 编译及注册。
  - **Android**：明确排除 Prometheus 模块（构建、头文件、注册均跳过），避免不支持平台的编译错误。
  - **Linux**：行为保持不变。