### PR TITLE
feat(input): auto-configure rsyslog forwarding for service_syslog

### DIFF
--- a/docs/cn/plugins/input/extended/service-syslog.md
+++ b/docs/cn/plugins/input/extended/service-syslog.md
@@ -87,11 +87,21 @@ flushers:
 
 ## 自动配置 rsyslog 转发
 
-开启 `AutoConfigRsyslog` 后，LoongCollector 会在 `/etc/rsyslog.d/` 目录下自动生成 rsyslog v8+ 转发配置文件（文件名格式为 `10-loongcollector-{configName}.conf`），并在配置内容变更时自动重启 rsyslogd。
+开启 `AutoConfigRsyslog` 后，LoongCollector 会在 `/etc/rsyslog.d/` 目录下自动生成 rsyslog v8+ 转发配置文件（文件名格式为 `10-loongcollector-{configName}.conf`），并在生成的转发配置内容发生变化时自动重启 rsyslogd 使其生效。
 
 > **注意**：文件名中的 `{configName}` 会经过清洗——所有非 `[a-zA-Z0-9_-]` 的字符（如空格、`/`、`.`、`:`、中文等）都会被替换为 `_`。例如采集配置名为 `my config.a` 时，实际生成的文件为 `10-loongcollector-my_config_a.conf`。请按清洗后的名称查找文件；此外，若两个配置名清洗后相同，会指向同一个文件，需注意避免相互覆盖。
 
-> **副作用与清理**：由于 rsyslog v8+ 的 `reload`/`SIGHUP` 不会重载配置，应用新配置只能通过 **重启 rsyslogd**（`systemctl restart rsyslog` 或 `service rsyslog restart`）实现。这是 **宿主机全局操作**，会短暂影响该主机上所有基于 rsyslog 的日志链路，且仅在配置内容确有变化时触发。当采集配置被停止或删除时，LoongCollector 会自动删除对应的转发配置文件并重启一次 rsyslogd，以避免残留的转发规则持续向已停止的端口投递并堆积磁盘队列。
+> **副作用与清理**：由于 rsyslog v8+ 的 `reload`/`SIGHUP` 不会重载配置，应用或撤销转发配置只能通过 **重启 rsyslogd**（`systemctl restart rsyslog` 或 `service rsyslog restart`）实现。这是 **宿主机全局操作**，会短暂影响该主机上所有基于 rsyslog 的日志链路。当采集配置被停止或删除时，LoongCollector 会自动删除对应的转发配置文件并重启 rsyslogd，以避免残留的转发规则持续向已停止的端口投递并堆积磁盘队列。
+>
+> **重启次数**：LoongCollector 的配置热更新会将整条采集配置对应的 pipeline 先停止再启动。因此每次涉及该采集配置的变更所触发的 rsyslogd 重启次数如下：
+>
+> | 场景 | rsyslogd 重启次数 |
+> |------|------|
+> | 采集配置未发生变更 | 0（pipeline 不停不起） |
+> | 删除采集配置 | 1（停止时删除转发配置并重启） |
+> | 修改采集配置 | 2（停止旧 pipeline 删除并重启 + 启动新 pipeline 写入并重启） |
+>
+> ⚠️ 注意：只要该采集配置的 **任意部分**发生改动（即使与 syslog/rsyslog 转发无关，例如调整某个 processor 或 flusher），都会触发整条 pipeline 的停止与启动，进而产生上表中「修改采集配置」的 2 次全局重启。若宿主机对 rsyslog 抖动敏感，请尽量减少对开启了 `AutoConfigRsyslog` 的采集配置的频繁热更新。
 
 **前提条件**：
 - 需要 root 权限运行 LoongCollector

--- a/docs/cn/plugins/input/extended/service-syslog.md
+++ b/docs/cn/plugins/input/extended/service-syslog.md
@@ -91,17 +91,16 @@ flushers:
 
 > **注意**：文件名中的 `{configName}` 会经过清洗——所有非 `[a-zA-Z0-9_-]` 的字符（如空格、`/`、`.`、`:`、中文等）都会被替换为 `_`。例如采集配置名为 `my config.a` 时，实际生成的文件为 `10-loongcollector-my_config_a.conf`。请按清洗后的名称查找文件；此外，若两个配置名清洗后相同，会指向同一个文件，需注意避免相互覆盖。
 
-> **副作用与清理**：由于 rsyslog v8+ 的 `reload`/`SIGHUP` 不会重载配置，应用或撤销转发配置只能通过 **重启 rsyslogd**（`systemctl restart rsyslog` 或 `service rsyslog restart`）实现。这是 **宿主机全局操作**，会短暂影响该主机上所有基于 rsyslog 的日志链路。当采集配置被停止或删除时，LoongCollector 会自动删除对应的转发配置文件并重启 rsyslogd，以避免残留的转发规则持续向已停止的端口投递并堆积磁盘队列。
+> **副作用与清理**：由于 rsyslog v8+ 的 `reload`/`SIGHUP` 不会重载配置，应用或撤销转发配置只能通过 **重启 rsyslogd**（`systemctl restart rsyslog` 或 `service rsyslog restart`）实现。这是 **宿主机全局操作**，会短暂影响该主机上所有基于 rsyslog 的日志链路，因此仅在确有必要时触发。当采集配置被 **永久删除** 时，LoongCollector 会自动删除对应的转发配置文件并重启 rsyslogd，以避免残留的转发规则持续向已停止的端口投递并堆积磁盘队列。
 >
-> **重启次数**：LoongCollector 的配置热更新会将整条采集配置对应的 pipeline 先停止再启动。因此每次涉及该采集配置的变更所触发的 rsyslogd 重启次数如下：
+> **重启次数**：仅当生成的 rsyslog 转发配置**内容真正发生变化**时才会重启 rsyslogd。各场景如下：
 >
 > | 场景 | rsyslogd 重启次数 |
 > |------|------|
-> | 采集配置未发生变更 | 0（pipeline 不停不起） |
-> | 删除采集配置 | 1（停止时删除转发配置并重启） |
-> | 修改采集配置 | 2（停止旧 pipeline 删除并重启 + 启动新 pipeline 写入并重启） |
->
-> ⚠️ 注意：只要该采集配置的 **任意部分**发生改动（即使与 syslog/rsyslog 转发无关，例如调整某个 processor 或 flusher），都会触发整条 pipeline 的停止与启动，进而产生上表中「修改采集配置」的 2 次全局重启。若宿主机对 rsyslog 抖动敏感，请尽量减少对开启了 `AutoConfigRsyslog` 的采集配置的频繁热更新。
+> | 修改采集配置中与 syslog/rsyslog 转发**无关**的部分（如某个 processor/flusher） | 0（转发配置内容不变，重载时按内容比对跳过重启） |
+> | 修改会影响转发的部分（监听地址/端口、`RsyslogFilters` 等） | 1（内容变化，重写并重启） |
+> | 删除采集配置 | 1（删除转发配置并重启） |
+> | LoongCollector 进程退出 / 升级重启 | 0（保留转发配置，日志继续在 rsyslog 磁盘队列中缓冲，待 agent 恢复后送达） |
 
 **前提条件**：
 - 需要 root 权限运行 LoongCollector

--- a/docs/cn/plugins/input/extended/service-syslog.md
+++ b/docs/cn/plugins/input/extended/service-syslog.md
@@ -91,6 +91,8 @@ flushers:
 
 > **注意**：文件名中的 `{configName}` 会经过清洗——所有非 `[a-zA-Z0-9_-]` 的字符（如空格、`/`、`.`、`:`、中文等）都会被替换为 `_`。例如采集配置名为 `my config.a` 时，实际生成的文件为 `10-loongcollector-my_config_a.conf`。请按清洗后的名称查找文件；此外，若两个配置名清洗后相同，会指向同一个文件，需注意避免相互覆盖。
 
+> **副作用与清理**：由于 rsyslog v8+ 的 `reload`/`SIGHUP` 不会重载配置，应用新配置只能通过 **重启 rsyslogd**（`systemctl restart rsyslog` 或 `service rsyslog restart`）实现。这是 **宿主机全局操作**，会短暂影响该主机上所有基于 rsyslog 的日志链路，且仅在配置内容确有变化时触发。当采集配置被停止或删除时，LoongCollector 会自动删除对应的转发配置文件并重启一次 rsyslogd，以避免残留的转发规则持续向已停止的端口投递并堆积磁盘队列。
+
 **前提条件**：
 - 需要 root 权限运行 LoongCollector
 - 仅支持 TCP 和 UDP 协议（不支持 unixgram）

--- a/docs/cn/plugins/input/extended/service-syslog.md
+++ b/docs/cn/plugins/input/extended/service-syslog.md
@@ -89,6 +89,8 @@ flushers:
 
 开启 `AutoConfigRsyslog` 后，LoongCollector 会在 `/etc/rsyslog.d/` 目录下自动生成 rsyslog v8+ 转发配置文件（文件名格式为 `10-loongcollector-{configName}.conf`），并在配置内容变更时自动重启 rsyslogd。
 
+> **注意**：文件名中的 `{configName}` 会经过清洗——所有非 `[a-zA-Z0-9_-]` 的字符（如空格、`/`、`.`、`:`、中文等）都会被替换为 `_`。例如采集配置名为 `my config.a` 时，实际生成的文件为 `10-loongcollector-my_config_a.conf`。请按清洗后的名称查找文件；此外，若两个配置名清洗后相同，会指向同一个文件，需注意避免相互覆盖。
+
 **前提条件**：
 - 需要 root 权限运行 LoongCollector
 - 仅支持 TCP 和 UDP 协议（不支持 unixgram）

--- a/docs/cn/plugins/input/extended/service-syslog.md
+++ b/docs/cn/plugins/input/extended/service-syslog.md
@@ -93,14 +93,35 @@ flushers:
 
 > **副作用与清理**：由于 rsyslog v8+ 的 `reload`/`SIGHUP` 不会重载配置，应用或撤销转发配置只能通过 **重启 rsyslogd**（`systemctl restart rsyslog` 或 `service rsyslog restart`）实现。这是 **宿主机全局操作**，会短暂影响该主机上所有基于 rsyslog 的日志链路，因此仅在确有必要时触发。当采集配置被 **永久删除** 时，LoongCollector 会自动删除对应的转发配置文件并重启 rsyslogd，以避免残留的转发规则持续向已停止的端口投递并堆积磁盘队列。
 >
-> **重启次数**：仅当生成的 rsyslog 转发配置**内容真正发生变化**时才会重启 rsyslogd。各场景如下：
+> **重启判定原则**：生成的转发配置内容仅由 `Address` 解析出的 **目标地址 / 端口 / 网络协议（tcp、udp）** 以及 **`RsyslogFilters`** 决定。仅当这些字段变化、导致转发配置**内容真正改变**时才重启 rsyslogd；接收端参数（如 `MaxConnections`、`TimeoutSeconds`、`KeepAliveSeconds`、`ParseProtocol` 等）与转发规则无关，改动它们不会触发重启。判定通过“重写前先与磁盘上现有文件逐字节比对”实现，因此纯重载（reload）本身不会重启。
 >
-> | 场景 | rsyslogd 重启次数 |
-> |------|------|
-> | 修改采集配置中与 syslog/rsyslog 转发**无关**的部分（如某个 processor/flusher） | 0（转发配置内容不变，重载时按内容比对跳过重启） |
-> | 修改会影响转发的部分（监听地址/端口、`RsyslogFilters` 等） | 1（内容变化，重写并重启） |
-> | 删除采集配置 | 1（删除转发配置并重启） |
-> | LoongCollector 进程退出 / 升级重启 | 0（保留转发配置，日志继续在 rsyslog 磁盘队列中缓冲，待 agent 恢复后送达） |
+> **各场景重启行为**：
+>
+> | 场景 | 是否影响转发配置 | rsyslogd 重启次数 | 说明 |
+> |------|:---:|:---:|------|
+> | 采集配置未开启 `AutoConfigRsyslog`（默认） | — | 0 | 不生成任何转发配置，不介入 rsyslog |
+> | 首次开启 `AutoConfigRsyslog`（新建配置，或将开关由 false 改为 true） | 是（首次建立） | 1 | 转发配置文件此前不存在，写入并重启 |
+> | 修改 `MaxConnections` / `TimeoutSeconds` / `KeepAliveSeconds` 等接收端参数 | 否 | 0 | 转发配置内容不变，重载时按内容比对跳过重启（日志：`rsyslog config unchanged (no restart needed)`） |
+> | 修改 `ParseProtocol`（如 rfc3164 → rfc5424） | 否 | 0 | 报文解析协议仅作用于接收端，不写入转发配置 |
+> | 修改监听 **端口**（如 9001 → 9002） | 是 | 1 | omfwd 的 `Port` 变化，重写并重启 |
+> | 修改 **网络协议**（`Address` scheme，如 tcp → udp） | 是 | 1 | omfwd 的 `Protocol` 变化，重写并重启（注意与 `ParseProtocol` 区分） |
+> | 修改目标 **地址 / 主机** 或 `RsyslogFilters` | 是 | 1 | omfwd 的 `target` / 过滤选择器变化，重写并重启 |
+> | **永久删除** 采集配置 | 是（移除） | 1 | 删除对应转发配置文件并重启，避免残留转发规则持续向已停端口投递、堆积磁盘队列 |
+> | LoongCollector 进程退出 / 升级重启 | — | 0 | 保留转发配置，日志继续在 rsyslog 磁盘队列中缓冲，待 agent 恢复后送达 |
+>
+> 每次真正的重启在日志中都表现为一对配对记录，便于核对重启次数：
+>
+> ```text
+> [configureRsyslogIfNeeded] rsyslog config updated, restarting rsyslogd:configName ...
+> [restartRsyslog] rsyslog restarted successfully:via systemctl
+> ```
+>
+> 删除配置触发的重启则为：
+>
+> ```text
+> [cleanupRsyslogConfig] rsyslog config removed on stop, restarting rsyslogd:configName ...
+> [restartRsyslog] rsyslog restarted successfully:via systemctl
+> ```
 
 **前提条件**：
 - 需要 root 权限运行 LoongCollector

--- a/docs/cn/plugins/input/extended/service-syslog.md
+++ b/docs/cn/plugins/input/extended/service-syslog.md
@@ -34,6 +34,8 @@
 | ParseProtocol | string，`""` | 指定解析日志所使用的协议，默认为空，表示不解析。其中：`rfc3164`：指定使用RFC3164协议解析日志。`rfc5424`：指定使用RFC5424协议解析日志。`auto`：指定插件根据日志内容自动选择合适的解析协议。 |
 | IgnoreParseFailure | bool，`true` | 指定解析失败后的操作，不配置表示放弃解析，直接填充所返回的content字段。配置为`false` ，表示解析失败时丢弃日志。 |
 | AddHostname | bool，`false` | 当从/dev/log监听unixgram时，log中不包括hostname字段，所以使用rfc3164会导致解析错误，这时将AddHostname设置为`true`，就会给解析器当前主机的hostname，然后解析器就可以解析tag、program、content字段了。 |
+| AutoConfigRsyslog | bool，`false` | 是否自动配置 rsyslog 转发。开启后，LoongCollector 会自动在 `/etc/rsyslog.d/` 下生成转发配置并重启 rsyslogd。仅支持 TCP 和 UDP 协议，需要 root 权限。 |
+| RsyslogFilters | string 数组，不配置则默认转发所有日志（`*.*`） | 通过 rsyslog 过滤规则选择采集哪些日志。每个条目为 rsyslog 标准的 `facility.severity` 格式（如 "auth.warning"、"kern.err"）。仅在 AutoConfigRsyslog 为 true 时生效。 |
 
 ## 样例
 
@@ -82,3 +84,30 @@ flushers:
 | `_content_` | 日志内容, 如果解析失败的话, 此字段包含末解析日志的所有内容。 |
 | `_ip_` | 当前主机的IP地址。 |
 |`_client_ip_`|传输日志的客户端ip地址。|
+
+## 自动配置 rsyslog 转发
+
+开启 `AutoConfigRsyslog` 后，LoongCollector 会在 `/etc/rsyslog.d/` 目录下自动生成 rsyslog v8+ 转发配置文件（文件名格式为 `10-loongcollector-{configName}.conf`），并在配置内容变更时自动重启 rsyslogd。
+
+**前提条件**：
+- 需要 root 权限运行 LoongCollector
+- 仅支持 TCP 和 UDP 协议（不支持 unixgram）
+- 目标机器需安装 rsyslogd v8 及以上版本
+
+* 采集配置
+
+```yaml
+enable: true
+inputs:
+  - Type: service_syslog
+    Address: tcp://127.0.0.1:9000
+    AutoConfigRsyslog: true
+    RsyslogFilters:
+      - "auth.warning"
+      - "kern.err"
+flushers:
+  - Type: flusher_stdout
+    OnlyStdout: true
+```
+
+上述配置将自动在 `/etc/rsyslog.d/` 下生成仅转发 `auth.warning` 和 `kern.err` 级别日志的配置，并重启 rsyslogd 使其生效。若不配置 `RsyslogFilters`，则默认转发所有日志（`*.*`）。

--- a/pkg/pipeline/input.go
+++ b/pkg/pipeline/input.go
@@ -57,6 +57,17 @@ type ServiceInputV1 interface {
 	Start(Collector) error
 }
 
+// PipelineRemovedCleaner is an optional interface a ServiceInput may implement to run
+// cleanup when its pipeline config is permanently removed. It is invoked ONLY on genuine
+// config removal — not on a reload/restart of the same config, and not on process
+// shutdown — so plugins can safely tear down host-global external state they installed
+// (e.g. an rsyslog forwarding drop-in) without disturbing it on ordinary reloads.
+type PipelineRemovedCleaner interface {
+	// OnPipelineRemoved is called after the pipeline has stopped and just before its
+	// config is deleted. Implementations must not block for long.
+	OnPipelineRemoved()
+}
+
 type ServiceInputV2 interface {
 	ServiceInput
 	// StartService starts the ServiceInput's service, whatever that may be

--- a/pkg/selfmonitor/alarm_type.go
+++ b/pkg/selfmonitor/alarm_type.go
@@ -228,6 +228,8 @@ const (
 	ServiceSyslogInitAlarm              AlarmType = "SERVICE_SYSLOG_INIT_ALARM"
 	ServiceSyslogPacketAlarm            AlarmType = "SERVICE_SYSLOG_PACKET_ALARM"
 	ServiceSyslogParseAlarm             AlarmType = "SERVICE_SYSLOG_PARSE_ALARM"
+	ServiceSyslogRsyslogConfigAlarm     AlarmType = "SERVICE_SYSLOG_RSYSLOG_CONFIG_ALARM"
+	ServiceSyslogRsyslogRestartAlarm    AlarmType = "SERVICE_SYSLOG_RSYSLOG_RESTART_ALARM"
 	ServiceSyslogStreamAlarm            AlarmType = "SERVICE_SYSLOG_STREAM_ALARM"
 	ServiceTelegrafOverwriteConfigAlarm AlarmType = "SERVICE_TELEGRAF_OVERWRITE_CONFIG_ALARM"
 	ServiceTelegrafRemoveConfigAlarm    AlarmType = "SERVICE_TELEGRAF_REMOVE_CONFIG_ALARM"

--- a/pluginmanager/plugin_manager.go
+++ b/pluginmanager/plugin_manager.go
@@ -210,10 +210,38 @@ func DeleteLogstoreConfig(config *LogstoreConfig, removedFlag bool) {
 func DeleteLogstoreConfigFromLogtailConfig(configName string, removedFlag bool) {
 	LogtailConfigLock.Lock()
 	if config, ok := LogtailConfig[configName]; ok {
+		if removedFlag {
+			notifyPipelineRemoved(config)
+		}
 		DeleteLogstoreConfig(config, removedFlag)
 		delete(LogtailConfig, configName)
 	}
 	LogtailConfigLock.Unlock()
+}
+
+// notifyPipelineRemoved invokes the optional pipeline.PipelineRemovedCleaner hook on every
+// service input of a config that is being permanently removed. It is called only from the
+// genuine per-config removal paths (removedFlag=true), never from reloads or from
+// StopAllPipelines on shutdown, so plugins clean up host-global state only on real removal.
+// It must run before DeleteLogstoreConfig, which nils out the runner.
+func notifyPipelineRemoved(config *LogstoreConfig) {
+	if config == nil || config.PluginRunner == nil {
+		return
+	}
+	switch runner := config.PluginRunner.(type) {
+	case *pluginv1Runner:
+		for _, sw := range runner.ServicePlugins {
+			if cleaner, ok := sw.Input.(pipeline.PipelineRemovedCleaner); ok {
+				cleaner.OnPipelineRemoved()
+			}
+		}
+	case *pluginv2Runner:
+		for _, sw := range runner.ServicePlugins {
+			if cleaner, ok := sw.Input.(pipeline.PipelineRemovedCleaner); ok {
+				cleaner.OnPipelineRemoved()
+			}
+		}
+	}
 }
 
 // StopBuiltInModulesConfig stops built-in services (container and checkpoint manager).
@@ -237,7 +265,13 @@ func Stop(configName string, removedFlag bool) error {
 	LogtailConfigLock.RLock()
 	if config, exists := LogtailConfig[configName]; exists {
 		LogtailConfigLock.RUnlock()
-		if hasStopped := timeoutStop(config, removedFlag); !hasStopped {
+		hasStopped := timeoutStop(config, removedFlag)
+		// Notify service plugins of genuine removal after the pipeline has stopped and
+		// while the runner is still intact (DeleteLogstoreConfig below nils it out).
+		if removedFlag {
+			notifyPipelineRemoved(config)
+		}
+		if !hasStopped {
 			logger.Error(config.Context.GetRuntimeContext(), selfmonitor.ConfigStopTimeoutAlarm, "timeout when stop config, goroutine might leak")
 			DisabledLogtailConfigLock.Lock()
 			DisabledLogtailConfig[config] = struct{}{}

--- a/pluginmanager/plugin_manager.go
+++ b/pluginmanager/plugin_manager.go
@@ -208,15 +208,24 @@ func DeleteLogstoreConfig(config *LogstoreConfig, removedFlag bool) {
 }
 
 func DeleteLogstoreConfigFromLogtailConfig(configName string, removedFlag bool) {
+	// Only take the config out of the map under the lock; run notifyPipelineRemoved
+	// (which may execute external commands / IO, e.g. rewriting rsyslog config and
+	// restarting rsyslogd with a timeout) and DeleteLogstoreConfig outside the lock so
+	// the global config lock is never held across a slow, potentially reentrant hook.
+	var cfg *LogstoreConfig
 	LogtailConfigLock.Lock()
 	if config, ok := LogtailConfig[configName]; ok {
-		if removedFlag {
-			notifyPipelineRemoved(config)
-		}
-		DeleteLogstoreConfig(config, removedFlag)
+		cfg = config
 		delete(LogtailConfig, configName)
 	}
 	LogtailConfigLock.Unlock()
+	if cfg == nil {
+		return
+	}
+	if removedFlag {
+		notifyPipelineRemoved(cfg)
+	}
+	DeleteLogstoreConfig(cfg, removedFlag)
 }
 
 // notifyPipelineRemoved invokes the optional pipeline.PipelineRemovedCleaner hook on every
@@ -266,9 +275,11 @@ func Stop(configName string, removedFlag bool) error {
 	if config, exists := LogtailConfig[configName]; exists {
 		LogtailConfigLock.RUnlock()
 		hasStopped := timeoutStop(config, removedFlag)
-		// Notify service plugins of genuine removal after the pipeline has stopped and
-		// while the runner is still intact (DeleteLogstoreConfig below nils it out).
-		if removedFlag {
+		// Notify service plugins of genuine removal only after the pipeline has actually
+		// stopped and while the runner is still intact (DeleteLogstoreConfig below nils it
+		// out). On stop timeout (hasStopped=false) goroutines/services may still be running,
+		// so we skip the host-global cleanup hook to avoid disrupting a live service.
+		if removedFlag && hasStopped {
 			notifyPipelineRemoved(config)
 		}
 		if !hasStopped {

--- a/pluginmanager/plugin_pipeline_removed_test.go
+++ b/pluginmanager/plugin_pipeline_removed_test.go
@@ -1,0 +1,67 @@
+// Copyright 2021 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pluginmanager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/alibaba/ilogtail/pkg/pipeline"
+)
+
+// fakeRemovableServiceInput is a minimal ServiceInputV1 that also implements
+// pipeline.PipelineRemovedCleaner, used to verify removal-hook routing.
+type fakeRemovableServiceInput struct {
+	removedCount int
+}
+
+func (f *fakeRemovableServiceInput) Init(pipeline.Context) (int, error) { return 0, nil }
+func (f *fakeRemovableServiceInput) Description() string                { return "fake-removable" }
+func (f *fakeRemovableServiceInput) Stop() error                        { return nil }
+func (f *fakeRemovableServiceInput) Start(pipeline.Collector) error     { return nil }
+func (f *fakeRemovableServiceInput) OnPipelineRemoved()                 { f.removedCount++ }
+
+// fakePlainServiceInput does NOT implement PipelineRemovedCleaner.
+type fakePlainServiceInput struct{}
+
+func (f *fakePlainServiceInput) Init(pipeline.Context) (int, error) { return 0, nil }
+func (f *fakePlainServiceInput) Description() string                { return "fake-plain" }
+func (f *fakePlainServiceInput) Stop() error                        { return nil }
+func (f *fakePlainServiceInput) Start(pipeline.Collector) error     { return nil }
+
+func TestNotifyPipelineRemoved(t *testing.T) {
+	removable := &fakeRemovableServiceInput{}
+	config := &LogstoreConfig{
+		PluginRunner: &pluginv1Runner{
+			ServicePlugins: []*ServiceWrapperV1{
+				{Input: removable},
+				{Input: &fakePlainServiceInput{}}, // must be skipped, not panic
+			},
+		},
+	}
+
+	notifyPipelineRemoved(config)
+	require.Equal(t, 1, removable.removedCount, "hook should fire exactly once for a removable input")
+
+	// Idempotent-safe on repeated calls (each call notifies once more).
+	notifyPipelineRemoved(config)
+	require.Equal(t, 2, removable.removedCount)
+
+	// nil-safe: nil config and a config without a runner must be no-ops.
+	notifyPipelineRemoved(nil)
+	notifyPipelineRemoved(&LogstoreConfig{})
+	require.Equal(t, 2, removable.removedCount)
+}

--- a/plugins/input/syslog/rsyslog.go
+++ b/plugins/input/syslog/rsyslog.go
@@ -139,25 +139,28 @@ func generateRsyslogConfig(cfg *SyslogForwardingConfig) string {
 }
 
 // writeRsyslogConfig writes the rsyslog config file if content has changed.
-// It returns whether the file was written (changed) and the previous content
-// (empty if the file did not exist), so the caller can roll back on validation failure.
-func writeRsyslogConfig(configName string, content string) (changed bool, oldContent string, err error) {
+// It returns whether the file was written (changed) and the previous content:
+// a nil oldContent means the file did not exist, while a non-nil pointer (even
+// to "") means it existed, so the caller can roll back correctly on validation
+// failure — distinguishing "delete the file" from "restore an empty file".
+func writeRsyslogConfig(configName string, content string) (changed bool, oldContent *string, err error) {
 	path := rsyslogConfigFilePath(configName)
 
 	// Read existing content (if any) so we can compare and roll back.
 	existing, readErr := os.ReadFile(path)
 	switch {
 	case readErr == nil:
-		oldContent = string(existing)
-		if oldContent == content {
+		prev := string(existing)
+		oldContent = &prev
+		if prev == content {
 			return false, oldContent, nil
 		}
 	case !os.IsNotExist(readErr):
 		// The file exists but cannot be read. Overwriting now would destroy the
-		// original, and on a later rollback an empty oldContent would be mistaken
+		// original, and on a later rollback a nil oldContent would be mistaken
 		// for "no previous file" and delete the config. Abort instead so existing
 		// rsyslog forwarding is never broken.
-		return false, "", fmt.Errorf("read existing rsyslog config %s: %w", path, readErr)
+		return false, nil, fmt.Errorf("read existing rsyslog config %s: %w", path, readErr)
 	}
 
 	if writeErr := os.WriteFile(path, []byte(content), 0644); writeErr != nil {
@@ -168,13 +171,14 @@ func writeRsyslogConfig(configName string, content string) (changed bool, oldCon
 }
 
 // restoreRsyslogConfig rolls back a config file to its previous state: it restores
-// oldContent if there was a previous version, otherwise removes the file.
-func restoreRsyslogConfig(configName string, oldContent string) error {
+// the previous content if the file existed (oldContent non-nil, including an empty
+// file), otherwise removes the file (oldContent nil).
+func restoreRsyslogConfig(configName string, oldContent *string) error {
 	path := rsyslogConfigFilePath(configName)
-	if oldContent == "" {
+	if oldContent == nil {
 		return removeRsyslogConfig(configName)
 	}
-	if err := os.WriteFile(path, []byte(oldContent), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(*oldContent), 0644); err != nil {
 		return fmt.Errorf("restore rsyslog config %s: %w", path, err)
 	}
 	return nil

--- a/plugins/input/syslog/rsyslog.go
+++ b/plugins/input/syslog/rsyslog.go
@@ -143,11 +143,19 @@ func writeRsyslogConfig(configName string, content string) (changed bool, oldCon
 	path := rsyslogConfigFilePath(configName)
 
 	// Read existing content (if any) so we can compare and roll back.
-	if existing, readErr := os.ReadFile(path); readErr == nil {
+	existing, readErr := os.ReadFile(path)
+	switch {
+	case readErr == nil:
 		oldContent = string(existing)
 		if oldContent == content {
 			return false, oldContent, nil
 		}
+	case !os.IsNotExist(readErr):
+		// The file exists but cannot be read. Overwriting now would destroy the
+		// original, and on a later rollback an empty oldContent would be mistaken
+		// for "no previous file" and delete the config. Abort instead so existing
+		// rsyslog forwarding is never broken.
+		return false, "", fmt.Errorf("read existing rsyslog config %s: %w", path, readErr)
 	}
 
 	if writeErr := os.WriteFile(path, []byte(content), 0644); writeErr != nil {

--- a/plugins/input/syslog/rsyslog.go
+++ b/plugins/input/syslog/rsyslog.go
@@ -62,6 +62,21 @@ type SyslogForwardingConfig struct {
 	Filters    []string // rsyslog filter rules like "auth.warning", default ["*.*"]
 }
 
+// normalizeRsyslogProtocol maps a Go network scheme to the value accepted by the
+// rsyslog omfwd "Protocol" parameter, which only understands "tcp" or "udp".
+// The IPv4/IPv6 variants allowed by net.Listen (tcp4/tcp6/udp4/udp6) would fail
+// `rsyslogd -N1` validation and trigger a rollback, so collapse them here.
+func normalizeRsyslogProtocol(scheme string) string {
+	switch scheme {
+	case "tcp4", "tcp6":
+		return "tcp"
+	case "udp4", "udp6":
+		return "udp"
+	default:
+		return scheme
+	}
+}
+
 // rsyslogConfigFilePath returns the full path for the rsyslog config file.
 func rsyslogConfigFilePath(configName string) string {
 	return fmt.Sprintf("%s/%s-%s.conf", rsyslogConfigDir, rsyslogFilePrefix, sanitizeConfigName(configName))

--- a/plugins/input/syslog/rsyslog.go
+++ b/plugins/input/syslog/rsyslog.go
@@ -22,10 +22,19 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/alibaba/ilogtail/pkg/logger"
 )
+
+// rsyslogOpMu serializes the "write + validate + restart" critical section (and the
+// Stop-time cleanup) across pipelines. `rsyslogd -N1` validates the whole effective
+// config, so a concurrent half-written drop-in from another pipeline could otherwise
+// fail an unrelated pipeline's validation and trigger a spurious rollback; concurrent
+// restarts could also stomp on each other. All host-global rsyslog operations run
+// under this lock.
+var rsyslogOpMu sync.Mutex
 
 const (
 	rsyslogFilePrefix = "10-loongcollector"
@@ -80,6 +89,19 @@ func normalizeRsyslogProtocol(scheme string) string {
 // rsyslogConfigFilePath returns the full path for the rsyslog config file.
 func rsyslogConfigFilePath(configName string) string {
 	return fmt.Sprintf("%s/%s-%s.conf", rsyslogConfigDir, rsyslogFilePrefix, sanitizeConfigName(configName))
+}
+
+// validateRsyslogFilters rejects filter entries that contain a carriage return or
+// newline, which would break out of the selector line and inject extra rsyslog
+// directives. Other syntax errors are still caught by `rsyslogd -N1`, but newlines
+// are the structural hazard worth failing fast on with a clear alarm.
+func validateRsyslogFilters(filters []string) error {
+	for _, f := range filters {
+		if strings.ContainsAny(f, "\r\n") {
+			return fmt.Errorf("rsyslog filter %q contains a newline", f)
+		}
+	}
+	return nil
 }
 
 // sanitizeConfigName replaces any character that is NOT [a-zA-Z0-9_-] with '_'.
@@ -176,7 +198,8 @@ func writeRsyslogConfig(configName string, content string) (changed bool, oldCon
 func restoreRsyslogConfig(configName string, oldContent *string) error {
 	path := rsyslogConfigFilePath(configName)
 	if oldContent == nil {
-		return removeRsyslogConfig(configName)
+		_, err := removeRsyslogConfig(configName)
+		return err
 	}
 	if err := os.WriteFile(path, []byte(*oldContent), 0644); err != nil {
 		return fmt.Errorf("restore rsyslog config %s: %w", path, err)
@@ -185,15 +208,17 @@ func restoreRsyslogConfig(configName string, oldContent *string) error {
 }
 
 // removeRsyslogConfig removes the rsyslog config file for the given config name.
-func removeRsyslogConfig(configName string) error {
+// It returns removed=true only when a file actually existed and was deleted, so the
+// caller can decide whether a rsyslog restart is warranted. A missing file is a no-op.
+func removeRsyslogConfig(configName string) (removed bool, err error) {
 	path := rsyslogConfigFilePath(configName)
 	if err := os.Remove(path); err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return false, nil
 		}
-		return fmt.Errorf("remove rsyslog config %s: %w", path, err)
+		return false, fmt.Errorf("remove rsyslog config %s: %w", path, err)
 	}
-	return nil
+	return true, nil
 }
 
 // runCommand runs an external command bounded by timeout and returns its combined output.

--- a/plugins/input/syslog/rsyslog.go
+++ b/plugins/input/syslog/rsyslog.go
@@ -169,7 +169,8 @@ func writeRsyslogConfig(configName string, content string) (changed bool, oldCon
 	path := rsyslogConfigFilePath(configName)
 
 	// Read existing content (if any) so we can compare and roll back.
-	existing, readErr := os.ReadFile(path)
+	// path is derived from a sanitized config name under the fixed rsyslog dir.
+	existing, readErr := os.ReadFile(path) //nolint:gosec
 	switch {
 	case readErr == nil:
 		prev := string(existing)

--- a/plugins/input/syslog/rsyslog.go
+++ b/plugins/input/syslog/rsyslog.go
@@ -111,7 +111,9 @@ func generateRsyslogConfig(cfg *SyslogForwardingConfig) string {
 
 	var b strings.Builder
 	b.WriteString("# LoongCollector auto-generated rsyslog forwarding configuration\n")
-	b.WriteString(fmt.Sprintf("# Config: %s\n", cfg.ConfigName))
+	// %q escapes newlines/control chars so a crafted ConfigName cannot break out
+	// of the comment and inject extra rsyslog directives.
+	b.WriteString(fmt.Sprintf("# Config: %q\n", cfg.ConfigName))
 	b.WriteString("# DO NOT EDIT - managed by LoongCollector service_syslog plugin\n")
 	b.WriteString("\n")
 	b.WriteString("template(name=\"LC_TraditionalForwardFormat\" type=\"string\"\n")

--- a/plugins/input/syslog/rsyslog.go
+++ b/plugins/input/syslog/rsyslog.go
@@ -1,0 +1,239 @@
+// Copyright 2021 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inputsyslog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/alibaba/ilogtail/pkg/logger"
+)
+
+const (
+	rsyslogFilePrefix = "10-loongcollector"
+
+	// minRsyslogMajorVersion is the minimum rsyslog major version required for the
+	// action(type="omfwd" ...) syntax used by the generated config.
+	minRsyslogMajorVersion = 8
+
+	// restartTimeout bounds how long we wait for rsyslog to restart, preventing a
+	// stuck rsyslogd from blocking the plugin indefinitely.
+	restartTimeout = 30 * time.Second
+	// versionCheckTimeout / validateTimeout bound the auxiliary rsyslogd invocations.
+	versionCheckTimeout = 5 * time.Second
+	validateTimeout     = 15 * time.Second
+)
+
+// rsyslogConfigDir is the directory where rsyslog loads drop-in config files.
+// It is a var (not const) so unit tests can redirect writes to a temp directory.
+var rsyslogConfigDir = "/etc/rsyslog.d"
+
+// systemdMarkerPath, when present, indicates the host uses systemd as its init system.
+var systemdMarkerPath = "/run/systemd/system"
+
+// rsyslogVersionRegex extracts the major version from `rsyslogd -v` output,
+// e.g. "rsyslogd 8.2102.0-...".
+var rsyslogVersionRegex = regexp.MustCompile(`rsyslogd\s+(\d+)\.`)
+
+// SyslogForwardingConfig holds parsed info for rsyslog forwarding.
+type SyslogForwardingConfig struct {
+	ConfigName string   // pipeline config name, used for filename
+	Protocol   string   // "tcp" or "udp", parsed from Address
+	Target     string   // IP/hostname, parsed from Address
+	Port       string   // port number, parsed from Address
+	Filters    []string // rsyslog filter rules like "auth.warning", default ["*.*"]
+}
+
+// rsyslogConfigFilePath returns the full path for the rsyslog config file.
+func rsyslogConfigFilePath(configName string) string {
+	return fmt.Sprintf("%s/%s-%s.conf", rsyslogConfigDir, rsyslogFilePrefix, sanitizeConfigName(configName))
+}
+
+// sanitizeConfigName replaces any character that is NOT [a-zA-Z0-9_-] with '_'.
+func sanitizeConfigName(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+// generateRsyslogConfig generates rsyslog v8+ action() syntax config content.
+// The template mirrors the Azure Monitor Agent (AMA) reference config: it defines a
+// traditional forward format template (to preserve PRI/timestamp/hostname downstream)
+// and a disk-assisted queue with infinite retry so logs survive LoongCollector restarts.
+func generateRsyslogConfig(cfg *SyslogForwardingConfig) string {
+	sanitized := sanitizeConfigName(cfg.ConfigName)
+
+	// Build filter selector: default to all facilities/severities.
+	filterSelector := "*.*"
+	if len(cfg.Filters) > 0 {
+		filterSelector = strings.Join(cfg.Filters, ";")
+	}
+
+	var b strings.Builder
+	b.WriteString("# LoongCollector auto-generated rsyslog forwarding configuration\n")
+	b.WriteString(fmt.Sprintf("# Config: %s\n", cfg.ConfigName))
+	b.WriteString("# DO NOT EDIT - managed by LoongCollector service_syslog plugin\n")
+	b.WriteString("\n")
+	b.WriteString("template(name=\"LC_TraditionalForwardFormat\" type=\"string\"\n")
+	b.WriteString("  string=\"<%PRI%>%TIMESTAMP% %HOSTNAME% %syslogtag%%msg:::sp-if-no-1st-sp%%msg%\")\n")
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("%s action(type=\"omfwd\"\n", filterSelector))
+	b.WriteString("  template=\"LC_TraditionalForwardFormat\"\n")
+	b.WriteString("  queue.type=\"LinkedList\"\n")
+	b.WriteString(fmt.Sprintf("  queue.filename=\"omfwd-loongcollector-%s\"\n", sanitized))
+	b.WriteString("  queue.maxFileSize=\"32m\"\n")
+	b.WriteString("  queue.maxDiskSpace=\"1g\"\n")
+	b.WriteString("  queue.size=\"25000\"\n")
+	b.WriteString("  queue.workerThreads=\"100\"\n")
+	b.WriteString("  queue.dequeueBatchSize=\"2048\"\n")
+	b.WriteString("  queue.saveonshutdown=\"on\"\n")
+	b.WriteString("  action.resumeRetryCount=\"-1\"\n")
+	b.WriteString("  action.resumeInterval=\"5\"\n")
+	b.WriteString("  action.reportSuspension=\"on\"\n")
+	b.WriteString("  action.reportSuspensionContinuation=\"on\"\n")
+	b.WriteString(fmt.Sprintf("  target=\"%s\" Port=\"%s\" Protocol=\"%s\")\n", cfg.Target, cfg.Port, cfg.Protocol))
+
+	return b.String()
+}
+
+// writeRsyslogConfig writes the rsyslog config file if content has changed.
+// It returns whether the file was written (changed) and the previous content
+// (empty if the file did not exist), so the caller can roll back on validation failure.
+func writeRsyslogConfig(configName string, content string) (changed bool, oldContent string, err error) {
+	path := rsyslogConfigFilePath(configName)
+
+	// Read existing content (if any) so we can compare and roll back.
+	if existing, readErr := os.ReadFile(path); readErr == nil {
+		oldContent = string(existing)
+		if oldContent == content {
+			return false, oldContent, nil
+		}
+	}
+
+	if writeErr := os.WriteFile(path, []byte(content), 0644); writeErr != nil {
+		return false, oldContent, fmt.Errorf("write rsyslog config %s: %w", path, writeErr)
+	}
+
+	return true, oldContent, nil
+}
+
+// restoreRsyslogConfig rolls back a config file to its previous state: it restores
+// oldContent if there was a previous version, otherwise removes the file.
+func restoreRsyslogConfig(configName string, oldContent string) error {
+	path := rsyslogConfigFilePath(configName)
+	if oldContent == "" {
+		return removeRsyslogConfig(configName)
+	}
+	if err := os.WriteFile(path, []byte(oldContent), 0644); err != nil {
+		return fmt.Errorf("restore rsyslog config %s: %w", path, err)
+	}
+	return nil
+}
+
+// removeRsyslogConfig removes the rsyslog config file for the given config name.
+func removeRsyslogConfig(configName string) error {
+	path := rsyslogConfigFilePath(configName)
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("remove rsyslog config %s: %w", path, err)
+	}
+	return nil
+}
+
+// runCommand runs an external command bounded by timeout and returns its combined output.
+// It tolerates the "no child process" error that exec throws under the c-shared build mode.
+func runCommand(ctx context.Context, timeout time.Duration, name string, args ...string) (string, error) {
+	cctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(cctx, name, args...).CombinedOutput() //nolint:gosec
+	if err != nil && strings.Contains(err.Error(), "no child process") {
+		// Workaround: exec throws "wait: no child process" under c-shared buildmode
+		// even though the command succeeded.
+		err = nil
+	}
+	return string(out), err
+}
+
+// checkRsyslogVersion returns the rsyslog major version by parsing `rsyslogd -v`.
+func checkRsyslogVersion(ctx context.Context) (int, error) {
+	out, err := runCommand(ctx, versionCheckTimeout, "rsyslogd", "-v")
+	if err != nil {
+		return 0, fmt.Errorf("run rsyslogd -v: %w", err)
+	}
+	return parseRsyslogMajorVersion(out)
+}
+
+// parseRsyslogMajorVersion extracts the major version number from `rsyslogd -v` output.
+func parseRsyslogMajorVersion(output string) (int, error) {
+	m := rsyslogVersionRegex.FindStringSubmatch(output)
+	if len(m) < 2 {
+		return 0, fmt.Errorf("cannot parse rsyslog version from output: %q", strings.TrimSpace(output))
+	}
+	major, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, fmt.Errorf("parse rsyslog major version %q: %w", m[1], err)
+	}
+	return major, nil
+}
+
+// validateRsyslogConfig runs `rsyslogd -N1` to check the whole effective config
+// (including the file we just wrote via $IncludeConfig) for syntax errors.
+func validateRsyslogConfig(ctx context.Context) error {
+	out, err := runCommand(ctx, validateTimeout, "rsyslogd", "-N1")
+	if err != nil {
+		return fmt.Errorf("rsyslogd -N1 validation failed: %w, output: %s", err, strings.TrimSpace(out))
+	}
+	return nil
+}
+
+// detectInitSystem returns the command and args to restart rsyslog based on the
+// host's init system: systemd if the systemd runtime marker exists, otherwise SysV.
+func detectInitSystem() (name string, args []string) {
+	if fi, err := os.Stat(systemdMarkerPath); err == nil && fi.IsDir() {
+		return "systemctl", []string{"restart", "rsyslog"}
+	}
+	return "service", []string{"rsyslog", "restart"}
+}
+
+// restartRsyslog restarts the rsyslog service, bounded by restartTimeout.
+func restartRsyslog(ctx context.Context) error {
+	name, args := detectInitSystem()
+	if _, err := runCommand(ctx, restartTimeout, name, args...); err != nil {
+		return fmt.Errorf("restart rsyslog via %s: %w", name, err)
+	}
+	logger.Info(ctx, "rsyslog restarted successfully", "via", name)
+	return nil
+}
+
+// isRoot returns true if the current process is running as root.
+func isRoot() bool {
+	return os.Getuid() == 0
+}

--- a/plugins/input/syslog/rsyslog_test.go
+++ b/plugins/input/syslog/rsyslog_test.go
@@ -129,11 +129,11 @@ func TestWriteRsyslogConfig_ChangeDetection(t *testing.T) {
 	const name = "testcfg"
 	path := rsyslogConfigFilePath(name)
 
-	// First write: changed, no previous content.
+	// First write: changed, no previous file (nil oldContent).
 	changed, oldContent, err := writeRsyslogConfig(name, "content-v1")
 	require.NoError(t, err)
 	assert.True(t, changed)
-	assert.Empty(t, oldContent)
+	assert.Nil(t, oldContent)
 	data, err := os.ReadFile(path)
 	require.NoError(t, err)
 	assert.Equal(t, "content-v1", string(data))
@@ -142,13 +142,15 @@ func TestWriteRsyslogConfig_ChangeDetection(t *testing.T) {
 	changed, oldContent, err = writeRsyslogConfig(name, "content-v1")
 	require.NoError(t, err)
 	assert.False(t, changed)
-	assert.Equal(t, "content-v1", oldContent)
+	require.NotNil(t, oldContent)
+	assert.Equal(t, "content-v1", *oldContent)
 
 	// Different content: changed, returns previous content.
 	changed, oldContent, err = writeRsyslogConfig(name, "content-v2")
 	require.NoError(t, err)
 	assert.True(t, changed)
-	assert.Equal(t, "content-v1", oldContent)
+	require.NotNil(t, oldContent)
+	assert.Equal(t, "content-v1", *oldContent)
 	data, err = os.ReadFile(path)
 	require.NoError(t, err)
 	assert.Equal(t, "content-v2", string(data))
@@ -170,7 +172,7 @@ func TestWriteRsyslogConfig_UnreadableExistingFile(t *testing.T) {
 	changed, oldContent, err := writeRsyslogConfig(name, "content-v1")
 	require.Error(t, err)
 	assert.False(t, changed)
-	assert.Empty(t, oldContent)
+	assert.Nil(t, oldContent)
 
 	// The existing path must be left untouched, not overwritten.
 	fi, statErr := os.Stat(path)
@@ -187,16 +189,26 @@ func TestRestoreRsyslogConfig(t *testing.T) {
 	const name = "restorecfg"
 	path := rsyslogConfigFilePath(name)
 
-	// Restore with empty oldContent removes the file.
+	// Restore with nil oldContent (file did not exist before) removes the file.
 	require.NoError(t, os.WriteFile(path, []byte("bad"), 0644))
-	require.NoError(t, restoreRsyslogConfig(name, ""))
+	require.NoError(t, restoreRsyslogConfig(name, nil))
 	_, err := os.Stat(path)
 	assert.True(t, os.IsNotExist(err))
 
+	// Restore with a non-nil empty oldContent (previously an empty file) keeps an
+	// empty file rather than deleting it.
+	require.NoError(t, os.WriteFile(path, []byte("new-bad"), 0644))
+	empty := ""
+	require.NoError(t, restoreRsyslogConfig(name, &empty))
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Empty(t, string(data))
+
 	// Restore with oldContent rewrites the previous content.
 	require.NoError(t, os.WriteFile(path, []byte("new-bad"), 0644))
-	require.NoError(t, restoreRsyslogConfig(name, "good-old"))
-	data, err := os.ReadFile(path)
+	good := "good-old"
+	require.NoError(t, restoreRsyslogConfig(name, &good))
+	data, err = os.ReadFile(path)
 	require.NoError(t, err)
 	assert.Equal(t, "good-old", string(data))
 }

--- a/plugins/input/syslog/rsyslog_test.go
+++ b/plugins/input/syslog/rsyslog_test.go
@@ -136,6 +136,30 @@ func TestWriteRsyslogConfig_ChangeDetection(t *testing.T) {
 	assert.Equal(t, "content-v2", string(data))
 }
 
+func TestWriteRsyslogConfig_UnreadableExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	old := rsyslogConfigDir
+	rsyslogConfigDir = dir
+	defer func() { rsyslogConfigDir = old }()
+
+	const name = "unreadablecfg"
+	path := rsyslogConfigFilePath(name)
+
+	// Make the config path a directory so os.ReadFile fails with a non-NotExist
+	// error (EISDIR) regardless of the test user (root bypasses file perms).
+	require.NoError(t, os.Mkdir(path, 0755))
+
+	changed, oldContent, err := writeRsyslogConfig(name, "content-v1")
+	require.Error(t, err)
+	assert.False(t, changed)
+	assert.Empty(t, oldContent)
+
+	// The existing path must be left untouched, not overwritten.
+	fi, statErr := os.Stat(path)
+	require.NoError(t, statErr)
+	assert.True(t, fi.IsDir())
+}
+
 func TestRestoreRsyslogConfig(t *testing.T) {
 	dir := t.TempDir()
 	old := rsyslogConfigDir

--- a/plugins/input/syslog/rsyslog_test.go
+++ b/plugins/input/syslog/rsyslog_test.go
@@ -1,0 +1,207 @@
+// Copyright 2021 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inputsyslog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeConfigName(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"simple", "simple"},
+		{"with-dash_and_9", "with-dash_and_9"},
+		{"has space", "has_space"},
+		{"a/b.c:d", "a_b_c_d"},
+		{"中文名", "___"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, sanitizeConfigName(c.in), "input=%q", c.in)
+	}
+}
+
+func TestRsyslogConfigFilePath(t *testing.T) {
+	old := rsyslogConfigDir
+	rsyslogConfigDir = "/etc/rsyslog.d"
+	defer func() { rsyslogConfigDir = old }()
+
+	assert.Equal(t, "/etc/rsyslog.d/10-loongcollector-my_config.conf", rsyslogConfigFilePath("my config"))
+	assert.Equal(t, "/etc/rsyslog.d/10-loongcollector-abc.conf", rsyslogConfigFilePath("abc"))
+}
+
+func TestGenerateRsyslogConfig_DefaultFilter(t *testing.T) {
+	cfg := &SyslogForwardingConfig{
+		ConfigName: "cfg1",
+		Protocol:   "tcp",
+		Target:     "127.0.0.1",
+		Port:       "9999",
+		// Filters nil -> default *.*
+	}
+	got := generateRsyslogConfig(cfg)
+
+	assert.Contains(t, got, "template(name=\"LC_TraditionalForwardFormat\"")
+	assert.Contains(t, got, "*.* action(type=\"omfwd\"")
+	assert.Contains(t, got, "template=\"LC_TraditionalForwardFormat\"")
+	assert.Contains(t, got, "queue.type=\"LinkedList\"")
+	assert.Contains(t, got, "queue.filename=\"omfwd-loongcollector-cfg1\"")
+	assert.Contains(t, got, "queue.maxDiskSpace=\"1g\"")
+	assert.Contains(t, got, "action.resumeRetryCount=\"-1\"")
+	assert.Contains(t, got, "action.reportSuspension=\"on\"")
+	assert.Contains(t, got, "target=\"127.0.0.1\" Port=\"9999\" Protocol=\"tcp\")")
+}
+
+func TestGenerateRsyslogConfig_CustomFilters(t *testing.T) {
+	cfg := &SyslogForwardingConfig{
+		ConfigName: "auth cfg",
+		Protocol:   "udp",
+		Target:     "10.0.0.2",
+		Port:       "9514",
+		Filters:    []string{"auth.warning", "kern.err", "daemon.info"},
+	}
+	got := generateRsyslogConfig(cfg)
+
+	assert.Contains(t, got, "auth.warning;kern.err;daemon.info action(type=\"omfwd\"")
+	assert.Contains(t, got, "target=\"10.0.0.2\" Port=\"9514\" Protocol=\"udp\")")
+	// config name is sanitized in the queue filename
+	assert.Contains(t, got, "queue.filename=\"omfwd-loongcollector-auth_cfg\"")
+}
+
+func TestWriteRsyslogConfig_ChangeDetection(t *testing.T) {
+	dir := t.TempDir()
+	old := rsyslogConfigDir
+	rsyslogConfigDir = dir
+	defer func() { rsyslogConfigDir = old }()
+
+	const name = "testcfg"
+	path := rsyslogConfigFilePath(name)
+
+	// First write: changed, no previous content.
+	changed, oldContent, err := writeRsyslogConfig(name, "content-v1")
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Empty(t, oldContent)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "content-v1", string(data))
+
+	// Same content: unchanged, returns previous content.
+	changed, oldContent, err = writeRsyslogConfig(name, "content-v1")
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Equal(t, "content-v1", oldContent)
+
+	// Different content: changed, returns previous content.
+	changed, oldContent, err = writeRsyslogConfig(name, "content-v2")
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Equal(t, "content-v1", oldContent)
+	data, err = os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "content-v2", string(data))
+}
+
+func TestRestoreRsyslogConfig(t *testing.T) {
+	dir := t.TempDir()
+	old := rsyslogConfigDir
+	rsyslogConfigDir = dir
+	defer func() { rsyslogConfigDir = old }()
+
+	const name = "restorecfg"
+	path := rsyslogConfigFilePath(name)
+
+	// Restore with empty oldContent removes the file.
+	require.NoError(t, os.WriteFile(path, []byte("bad"), 0644))
+	require.NoError(t, restoreRsyslogConfig(name, ""))
+	_, err := os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+
+	// Restore with oldContent rewrites the previous content.
+	require.NoError(t, os.WriteFile(path, []byte("new-bad"), 0644))
+	require.NoError(t, restoreRsyslogConfig(name, "good-old"))
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "good-old", string(data))
+}
+
+func TestRemoveRsyslogConfig(t *testing.T) {
+	dir := t.TempDir()
+	old := rsyslogConfigDir
+	rsyslogConfigDir = dir
+	defer func() { rsyslogConfigDir = old }()
+
+	const name = "removecfg"
+	path := rsyslogConfigFilePath(name)
+
+	// Removing a non-existent file is a no-op (no error).
+	require.NoError(t, removeRsyslogConfig(name))
+
+	// Removing an existing file deletes it.
+	require.NoError(t, os.WriteFile(path, []byte("x"), 0644))
+	require.NoError(t, removeRsyslogConfig(name))
+	_, err := os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestParseRsyslogMajorVersion(t *testing.T) {
+	cases := []struct {
+		name    string
+		output  string
+		want    int
+		wantErr bool
+	}{
+		{"v8", "rsyslogd 8.2102.0-15.el8 (aka 2021.02)\n...", 8, false},
+		{"v7", "rsyslogd 7.4.7, compiled with:\n...", 7, false},
+		{"v10", "rsyslogd 10.0.1", 10, false},
+		{"garbage", "some unrelated output", 0, true},
+		{"empty", "", 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := parseRsyslogMajorVersion(c.output)
+			if c.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestDetectInitSystem(t *testing.T) {
+	old := systemdMarkerPath
+	defer func() { systemdMarkerPath = old }()
+
+	// Marker exists and is a directory -> systemd.
+	dir := t.TempDir()
+	systemdMarkerPath = filepath.Join(dir, "systemd-system")
+	require.NoError(t, os.Mkdir(systemdMarkerPath, 0755))
+	name, args := detectInitSystem()
+	assert.Equal(t, "systemctl", name)
+	assert.Equal(t, []string{"restart", "rsyslog"}, args)
+
+	// Marker missing -> SysV.
+	systemdMarkerPath = filepath.Join(dir, "does-not-exist")
+	name, args = detectInitSystem()
+	assert.Equal(t, "service", name)
+	assert.Equal(t, []string{"rsyslog", "restart"}, args)
+}

--- a/plugins/input/syslog/rsyslog_test.go
+++ b/plugins/input/syslog/rsyslog_test.go
@@ -102,6 +102,24 @@ func TestGenerateRsyslogConfig_CustomFilters(t *testing.T) {
 	assert.Contains(t, got, "queue.filename=\"omfwd-loongcollector-auth_cfg\"")
 }
 
+func TestGenerateRsyslogConfig_ConfigNameInjection(t *testing.T) {
+	cfg := &SyslogForwardingConfig{
+		ConfigName: "evil\n*.* action(type=\"omfwd\" target=\"attacker\" Port=\"514\" Protocol=\"tcp\")",
+		Protocol:   "tcp",
+		Target:     "127.0.0.1",
+		Port:       "9999",
+	}
+	got := generateRsyslogConfig(cfg)
+
+	// The crafted newline must be escaped, keeping the comment on a single line
+	// so no extra rsyslog directive is injected.
+	assert.NotContains(t, got, "# Config: evil\n")
+	assert.Contains(t, got, `# Config: "evil\n*.* action`)
+	// Only the legitimate action line should target 127.0.0.1; the injected
+	// "attacker" target must remain inert inside the escaped comment.
+	assert.Contains(t, got, "target=\"127.0.0.1\" Port=\"9999\" Protocol=\"tcp\")")
+}
+
 func TestWriteRsyslogConfig_ChangeDetection(t *testing.T) {
 	dir := t.TempDir()
 	old := rsyslogConfigDir

--- a/plugins/input/syslog/rsyslog_test.go
+++ b/plugins/input/syslog/rsyslog_test.go
@@ -39,6 +39,23 @@ func TestSanitizeConfigName(t *testing.T) {
 	}
 }
 
+func TestNormalizeRsyslogProtocol(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"tcp", "tcp"},
+		{"udp", "udp"},
+		{"tcp4", "tcp"},
+		{"tcp6", "tcp"},
+		{"udp4", "udp"},
+		{"udp6", "udp"},
+		{"unixgram", "unixgram"}, // untouched; unixgram never reaches config generation
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, normalizeRsyslogProtocol(c.in), "input=%q", c.in)
+	}
+}
+
 func TestRsyslogConfigFilePath(t *testing.T) {
 	old := rsyslogConfigDir
 	rsyslogConfigDir = "/etc/rsyslog.d"

--- a/plugins/input/syslog/rsyslog_test.go
+++ b/plugins/input/syslog/rsyslog_test.go
@@ -222,14 +222,29 @@ func TestRemoveRsyslogConfig(t *testing.T) {
 	const name = "removecfg"
 	path := rsyslogConfigFilePath(name)
 
-	// Removing a non-existent file is a no-op (no error).
-	require.NoError(t, removeRsyslogConfig(name))
+	// Removing a non-existent file is a no-op (no error, removed=false).
+	removed, err := removeRsyslogConfig(name)
+	require.NoError(t, err)
+	assert.False(t, removed)
 
-	// Removing an existing file deletes it.
+	// Removing an existing file deletes it and reports removed=true.
 	require.NoError(t, os.WriteFile(path, []byte("x"), 0644))
-	require.NoError(t, removeRsyslogConfig(name))
-	_, err := os.Stat(path)
-	assert.True(t, os.IsNotExist(err))
+	removed, err = removeRsyslogConfig(name)
+	require.NoError(t, err)
+	assert.True(t, removed)
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestValidateRsyslogFilters(t *testing.T) {
+	// Valid: empty, nil, and normal facility.severity selectors.
+	require.NoError(t, validateRsyslogFilters(nil))
+	require.NoError(t, validateRsyslogFilters([]string{}))
+	require.NoError(t, validateRsyslogFilters([]string{"*.*", "auth.warning", "kern.err"}))
+
+	// Invalid: a newline would break out of the selector line.
+	require.Error(t, validateRsyslogFilters([]string{"auth.warning\n*.* action(type=\"omfwd\")"}))
+	require.Error(t, validateRsyslogFilters([]string{"ok.info", "bad\rentry"}))
 }
 
 func TestParseRsyslogMajorVersion(t *testing.T) {

--- a/plugins/input/syslog/syslog.go
+++ b/plugins/input/syslog/syslog.go
@@ -184,12 +184,6 @@ func (s *Syslog) Stop() error {
 	s.wg.Wait()
 	s.connectionsWg.Wait()
 
-	// Tear down auto-generated rsyslog forwarding so a removed pipeline does not leave
-	// rsyslog forwarding (and accumulating a disk queue) to a port no longer listened on.
-	if s.AutoConfigRsyslog {
-		s.cleanupRsyslogConfig()
-	}
-
 	// If scheme type is "unixgram", remove unix socket file after close.
 	if s.isUnix {
 		_, host, err := getAddressParts(s.Address)
@@ -316,10 +310,23 @@ func (s *Syslog) configureRsyslogIfNeeded(scheme, host string) {
 	}
 }
 
-// cleanupRsyslogConfig removes the auto-generated rsyslog config on Stop and restarts
-// rsyslogd so the forwarding action (and its disk-assisted retry queue) is torn down
-// instead of lingering and endlessly retrying against a port nobody listens on. It only
-// restarts when a file was actually removed, and skips silently when not running as root.
+// OnPipelineRemoved implements pipeline.PipelineRemovedCleaner. It is invoked only when
+// this pipeline config is permanently removed (not on reload/restart, and not on process
+// shutdown), which is exactly when the generated rsyslog forwarding should be torn down.
+// Reloads are handled by Start's content comparison instead, so an unrelated edit to the
+// pipeline does not churn rsyslog; process shutdown deliberately leaves the config in
+// place so rsyslog keeps queuing until the agent returns.
+func (s *Syslog) OnPipelineRemoved() {
+	if !s.AutoConfigRsyslog {
+		return
+	}
+	s.cleanupRsyslogConfig()
+}
+
+// cleanupRsyslogConfig removes the auto-generated rsyslog config and restarts rsyslogd so
+// the forwarding action (and its disk-assisted retry queue) is torn down instead of
+// lingering and endlessly retrying against a port nobody listens on. It only restarts when
+// a file was actually removed, and skips silently when not running as root.
 func (s *Syslog) cleanupRsyslogConfig() {
 	ctx := s.context.GetRuntimeContext()
 

--- a/plugins/input/syslog/syslog.go
+++ b/plugins/input/syslog/syslog.go
@@ -54,6 +54,17 @@ type Syslog struct {
 	IgnoreParseFailure bool   // When parse failure happened, ignore error and set content field if it is set.
 	AddHostname        bool   // When listen unixgram from /dev/log, the hostname field is not included in the log, so use rfc3164 will cause parse error, so AddHostname give parser it's own hostname, then parser can parse tag, program, content field currently.
 
+	// AutoConfigRsyslog enables automatic rsyslog forwarding configuration.
+	// When true, LoongCollector will generate a forwarding rule in /etc/rsyslog.d/
+	// and restart rsyslogd. Only supports TCP and UDP (not unixgram).
+	// Requires root privileges. Default: false.
+	AutoConfigRsyslog bool
+	// RsyslogFilters specifies which syslog messages to forward via rsyslog filter rules.
+	// Each entry should be in rsyslog "facility.severity" format (e.g. "auth.warning").
+	// If empty or nil, all messages (*.*) are forwarded.
+	// Only effective when AutoConfigRsyslog is true.
+	RsyslogFilters []string
+
 	done chan struct{}
 	mu   sync.Mutex
 	wg   sync.WaitGroup
@@ -124,6 +135,11 @@ func (s *Syslog) Start(collector pipeline.Collector) error {
 		return fmt.Errorf("unknown protocol '%s' in '%s'", scheme, host)
 	}
 
+	// Auto-configure rsyslog if enabled
+	if s.AutoConfigRsyslog {
+		s.configureRsyslogIfNeeded(scheme, host)
+	}
+
 	if s.isStream {
 		l, err := net.Listen(scheme, host)
 		if err != nil {
@@ -182,6 +198,110 @@ func (s *Syslog) Stop() error {
 		}
 	}
 	return nil
+}
+
+// configureRsyslogIfNeeded generates rsyslog forwarding config and restarts rsyslogd.
+// It only proceeds if: the protocol is TCP or UDP (not unixgram), running as root,
+// rsyslog is v8+, and the config content has changed. On any precondition failure it
+// alarms and skips without affecting the plugin's normal operation. Before restarting,
+// the newly written config is validated with `rsyslogd -N1`; if validation fails, the
+// change is rolled back so existing rsyslog forwarding is never broken.
+func (s *Syslog) configureRsyslogIfNeeded(scheme, host string) {
+	ctx := s.context.GetRuntimeContext()
+
+	// Check protocol support.
+	if scheme == "unixgram" {
+		logger.Warning(ctx, selfmonitor.ServiceSyslogRsyslogConfigAlarm,
+			"AutoConfigRsyslog does not support unixgram protocol, skipping rsyslog auto-configuration",
+			"Address", s.Address)
+		return
+	}
+
+	// Check root permission.
+	if !isRoot() {
+		logger.Warning(ctx, selfmonitor.ServiceSyslogRsyslogConfigAlarm,
+			"AutoConfigRsyslog requires root privileges, skipping rsyslog auto-configuration",
+			"Address", s.Address)
+		return
+	}
+
+	// Check rsyslog version (needs v8+ for the action(type="omfwd" ...) syntax).
+	major, verErr := checkRsyslogVersion(ctx)
+	if verErr != nil {
+		logger.Warning(ctx, selfmonitor.ServiceSyslogRsyslogConfigAlarm,
+			"failed to detect rsyslog version, skipping rsyslog auto-configuration", verErr)
+		return
+	}
+	if major < minRsyslogMajorVersion {
+		logger.Warning(ctx, selfmonitor.ServiceSyslogRsyslogConfigAlarm,
+			"rsyslog version too old for auto-configuration (requires v8+), skipping",
+			"detectedMajorVersion", major)
+		return
+	}
+
+	// Parse address for rsyslog config.
+	configName := s.context.GetConfigName()
+	target, port, err := parseTargetPort(host)
+	if err != nil {
+		logger.Warning(ctx, selfmonitor.ServiceSyslogRsyslogConfigAlarm,
+			"failed to parse address for rsyslog config", err,
+			"Address", s.Address)
+		return
+	}
+
+	cfg := &SyslogForwardingConfig{
+		ConfigName: configName,
+		Protocol:   scheme,
+		Target:     target,
+		Port:       port,
+		Filters:    s.RsyslogFilters,
+	}
+
+	content := generateRsyslogConfig(cfg)
+	changed, oldContent, writeErr := writeRsyslogConfig(configName, content)
+	if writeErr != nil {
+		logger.Warning(ctx, selfmonitor.ServiceSyslogRsyslogConfigAlarm,
+			"failed to write rsyslog config", writeErr,
+			"configName", configName)
+		return
+	}
+
+	if !changed {
+		logger.Info(ctx, "rsyslog config unchanged (no restart needed)",
+			"configName", configName)
+		return
+	}
+
+	// Validate the written config before restarting; roll back on failure so a bad
+	// config never takes down rsyslog's existing forwarding.
+	if validateErr := validateRsyslogConfig(ctx); validateErr != nil {
+		logger.Warning(ctx, selfmonitor.ServiceSyslogRsyslogConfigAlarm,
+			"rsyslog config validation failed, rolling back and skipping auto-configuration", validateErr,
+			"configName", configName)
+		if restoreErr := restoreRsyslogConfig(configName, oldContent); restoreErr != nil {
+			logger.Warning(ctx, selfmonitor.ServiceSyslogRsyslogConfigAlarm,
+				"failed to roll back rsyslog config after validation failure", restoreErr,
+				"configName", configName)
+		}
+		return
+	}
+
+	logger.Info(ctx, "rsyslog config updated, restarting rsyslogd",
+		"configName", configName,
+		"configFile", rsyslogConfigFilePath(configName))
+	if restartErr := restartRsyslog(ctx); restartErr != nil {
+		logger.Warning(ctx, selfmonitor.ServiceSyslogRsyslogRestartAlarm,
+			"failed to restart rsyslogd", restartErr)
+	}
+}
+
+// parseTargetPort splits "host:port" into target and port strings.
+func parseTargetPort(host string) (target, port string, err error) {
+	target, port, err = net.SplitHostPort(host)
+	if err != nil {
+		return "", "", fmt.Errorf("split host port from %s: %w", host, err)
+	}
+	return target, port, nil
 }
 
 func getAddressParts(a string) (string, string, error) {
@@ -453,6 +573,8 @@ func newSyslog() *Syslog {
 		KeepAliveSeconds:   300,
 		MaxMessageSize:     64 * 1024,
 		IgnoreParseFailure: true,
+		AutoConfigRsyslog:  false,
+		// RsyslogFilters defaults to nil (zero value for slices)
 	}
 }
 

--- a/plugins/input/syslog/syslog.go
+++ b/plugins/input/syslog/syslog.go
@@ -301,6 +301,12 @@ func parseTargetPort(host string) (target, port string, err error) {
 	if err != nil {
 		return "", "", fmt.Errorf("split host port from %s: %w", host, err)
 	}
+	switch target {
+	case "", "0.0.0.0":
+		target = "127.0.0.1"
+	case "::":
+		target = "::1"
+	}
 	return target, port, nil
 }
 

--- a/plugins/input/syslog/syslog.go
+++ b/plugins/input/syslog/syslog.go
@@ -251,7 +251,7 @@ func (s *Syslog) configureRsyslogIfNeeded(scheme, host string) {
 
 	cfg := &SyslogForwardingConfig{
 		ConfigName: configName,
-		Protocol:   scheme,
+		Protocol:   normalizeRsyslogProtocol(scheme),
 		Target:     target,
 		Port:       port,
 		Filters:    s.RsyslogFilters,

--- a/plugins/input/syslog/syslog.go
+++ b/plugins/input/syslog/syslog.go
@@ -135,11 +135,6 @@ func (s *Syslog) Start(collector pipeline.Collector) error {
 		return fmt.Errorf("unknown protocol '%s' in '%s'", scheme, host)
 	}
 
-	// Auto-configure rsyslog if enabled
-	if s.AutoConfigRsyslog {
-		s.configureRsyslogIfNeeded(scheme, host)
-	}
-
 	if s.isStream {
 		l, err := net.Listen(scheme, host)
 		if err != nil {
@@ -164,6 +159,12 @@ func (s *Syslog) Start(collector pipeline.Collector) error {
 
 		s.wg.Add(1)
 		go s.listenPacket(collector)
+	}
+
+	// Auto-configure rsyslog only after the listener is bound successfully, so a
+	// failed bind never leaves rsyslog forwarding to an unlistened port.
+	if s.AutoConfigRsyslog {
+		s.configureRsyslogIfNeeded(scheme, host)
 	}
 
 	return nil

--- a/plugins/input/syslog/syslog.go
+++ b/plugins/input/syslog/syslog.go
@@ -184,6 +184,12 @@ func (s *Syslog) Stop() error {
 	s.wg.Wait()
 	s.connectionsWg.Wait()
 
+	// Tear down auto-generated rsyslog forwarding so a removed pipeline does not leave
+	// rsyslog forwarding (and accumulating a disk queue) to a port no longer listened on.
+	if s.AutoConfigRsyslog {
+		s.cleanupRsyslogConfig()
+	}
+
 	// If scheme type is "unixgram", remove unix socket file after close.
 	if s.isUnix {
 		_, host, err := getAddressParts(s.Address)
@@ -225,6 +231,14 @@ func (s *Syslog) configureRsyslogIfNeeded(scheme, host string) {
 		return
 	}
 
+	// Reject filters that could break the generated config structure.
+	if filterErr := validateRsyslogFilters(s.RsyslogFilters); filterErr != nil {
+		logger.Warning(ctx, selfmonitor.ServiceSyslogRsyslogConfigAlarm,
+			"invalid RsyslogFilters, skipping rsyslog auto-configuration", filterErr,
+			"Address", s.Address)
+		return
+	}
+
 	// Check rsyslog version (needs v8+ for the action(type="omfwd" ...) syntax).
 	major, verErr := checkRsyslogVersion(ctx)
 	if verErr != nil {
@@ -258,6 +272,13 @@ func (s *Syslog) configureRsyslogIfNeeded(scheme, host string) {
 	}
 
 	content := generateRsyslogConfig(cfg)
+
+	// Serialize the host-global write+validate+restart against other pipelines and
+	// against Stop-time cleanup, so a concurrent drop-in cannot fail this pipeline's
+	// `rsyslogd -N1` and cause a spurious rollback.
+	rsyslogOpMu.Lock()
+	defer rsyslogOpMu.Unlock()
+
 	changed, oldContent, writeErr := writeRsyslogConfig(configName, content)
 	if writeErr != nil {
 		logger.Warning(ctx, selfmonitor.ServiceSyslogRsyslogConfigAlarm,
@@ -295,6 +316,44 @@ func (s *Syslog) configureRsyslogIfNeeded(scheme, host string) {
 	}
 }
 
+// cleanupRsyslogConfig removes the auto-generated rsyslog config on Stop and restarts
+// rsyslogd so the forwarding action (and its disk-assisted retry queue) is torn down
+// instead of lingering and endlessly retrying against a port nobody listens on. It only
+// restarts when a file was actually removed, and skips silently when not running as root.
+func (s *Syslog) cleanupRsyslogConfig() {
+	ctx := s.context.GetRuntimeContext()
+
+	if !isRoot() {
+		logger.Warning(ctx, selfmonitor.ServiceSyslogRsyslogConfigAlarm,
+			"AutoConfigRsyslog cleanup requires root privileges, skipping rsyslog config removal",
+			"Address", s.Address)
+		return
+	}
+
+	configName := s.context.GetConfigName()
+
+	rsyslogOpMu.Lock()
+	defer rsyslogOpMu.Unlock()
+
+	removed, err := removeRsyslogConfig(configName)
+	if err != nil {
+		logger.Warning(ctx, selfmonitor.ServiceSyslogRsyslogConfigAlarm,
+			"failed to remove rsyslog config on stop", err,
+			"configName", configName)
+		return
+	}
+	if !removed {
+		return
+	}
+
+	logger.Info(ctx, "rsyslog config removed on stop, restarting rsyslogd",
+		"configName", configName)
+	if restartErr := restartRsyslog(ctx); restartErr != nil {
+		logger.Warning(ctx, selfmonitor.ServiceSyslogRsyslogRestartAlarm,
+			"failed to restart rsyslogd after config cleanup", restartErr)
+	}
+}
+
 // parseTargetPort splits "host:port" into target and port strings.
 func parseTargetPort(host string) (target, port string, err error) {
 	target, port, err = net.SplitHostPort(host)
@@ -322,16 +381,13 @@ func getAddressParts(a string) (string, string, error) {
 		return parts[0], parts[1], nil
 	}
 
-	var host string
-	if u.Hostname() != "" {
-		host = u.Hostname()
+	port := u.Port()
+	if port == "" {
+		port = "6514"
 	}
-	host += ":"
-	if u.Port() == "" {
-		host += "6514"
-	} else {
-		host += u.Port()
-	}
+	// net.JoinHostPort brackets IPv6 hosts (e.g. "[::1]:6514") so both net.Listen
+	// and the downstream net.SplitHostPort in parseTargetPort accept the result.
+	host := net.JoinHostPort(u.Hostname(), port)
 
 	return u.Scheme, host, nil
 }

--- a/plugins/input/syslog/syslog_test.go
+++ b/plugins/input/syslog/syslog_test.go
@@ -32,6 +32,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGetAddressPartsHostFormat(t *testing.T) {
+	cases := []struct {
+		address    string
+		wantScheme string
+		wantHost   string
+	}{
+		{"tcp://127.0.0.1:9000", "tcp", "127.0.0.1:9000"},
+		{"udp://127.0.0.1", "udp", "127.0.0.1:6514"}, // default port
+		{"tcp6://[::1]:9000", "tcp6", "[::1]:9000"},   // IPv6 must stay bracketed
+		{"tcp6://[::1]", "tcp6", "[::1]:6514"},        // IPv6 + default port
+	}
+	for _, c := range cases {
+		scheme, host, err := getAddressParts(c.address)
+		require.NoError(t, err, "address=%q", c.address)
+		assert.Equal(t, c.wantScheme, scheme, "address=%q", c.address)
+		assert.Equal(t, c.wantHost, host, "address=%q", c.address)
+
+		// The produced host must round-trip through net.SplitHostPort, which is what
+		// parseTargetPort relies on to derive the rsyslog target.
+		_, _, splitErr := net.SplitHostPort(host)
+		require.NoError(t, splitErr, "address=%q host=%q", c.address, host)
+	}
+}
+
 func TestStartAndStop(t *testing.T) {
 	ctx := &pluginmanager.ContextImp{}
 	ctx.InitContext("test_project", "test_logstore", "test_configname")

--- a/plugins/input/syslog/syslog_test.go
+++ b/plugins/input/syslog/syslog_test.go
@@ -40,8 +40,8 @@ func TestGetAddressPartsHostFormat(t *testing.T) {
 	}{
 		{"tcp://127.0.0.1:9000", "tcp", "127.0.0.1:9000"},
 		{"udp://127.0.0.1", "udp", "127.0.0.1:6514"}, // default port
-		{"tcp6://[::1]:9000", "tcp6", "[::1]:9000"},   // IPv6 must stay bracketed
-		{"tcp6://[::1]", "tcp6", "[::1]:6514"},        // IPv6 + default port
+		{"tcp6://[::1]:9000", "tcp6", "[::1]:9000"},  // IPv6 must stay bracketed
+		{"tcp6://[::1]", "tcp6", "[::1]:6514"},       // IPv6 + default port
 	}
 	for _, c := range cases {
 		scheme, host, err := getAddressParts(c.address)


### PR DESCRIPTION
## 概述

  为 `service_syslog` 插件新增 **自动配置 rsyslog 转发** 能力（`AutoConfigRsyslog`）。开启后，LoongCollector
  会根据采集配置的监听地址/端口，自动在宿主机 `/etc/rsyslog.d/` 下生成 rsyslog v8+ 转发规则并按需重启 rsyslogd，让主机上的 syslog
  流量转发到本插件监听的端口，实现「开箱即用」的 syslog 采集。原始设计参见：https://alidocs.dingtalk.com/i/nodes/kDnRL6jAJMLgNkw7tXdRg1vaVyMoPYe1

  同时为插件框架新增了一个可选的 **管道永久删除清理钩子**
  `pipeline.PipelineRemovedCleaner`，用于在采集配置被真正删除时安全地回收插件安装的宿主机全局状态（这里就是 rsyslog 转发配置）。

  ## 主要改动

  ### 1. service_syslog 新增配置项

  | 配置项 | 类型 / 默认值 | 说明 |
  |--------|--------------|------|
  | `AutoConfigRsyslog` | bool，`false` | 是否自动配置 rsyslog 转发。仅支持 TCP/UDP，需要 root 权限。 |
  | `RsyslogFilters` | string 数组，默认转发全部（`*.*`） | rsyslog `facility.severity` 过滤规则（如 `auth.warning`、`kern.err`），仅在
  `AutoConfigRsyslog=true` 时生效。 |

  ### 2. rsyslog 自动配置逻辑（`plugins/input/syslog/rsyslog.go`、`syslog.go`）

  - **生成配置**：采用 rsyslog v8+ 的 `action(type="omfwd" ...)` 语法，参考 Azure Monitor Agent（AMA）模板，包含传统转发格式模板 + 
  磁盘辅助队列 + 无限重试（`action.resumeRetryCount="-1"`），保证 LoongCollector 重启期间日志不丢。
  - **文件命名**：`10-loongcollector-{configName}.conf`，其中 `configName` 会被清洗——所有非 `[a-zA-Z0-9_-]` 字符替换为 `_`。
  - **前置校验（任一不满足则告警并跳过，不影响插件正常采集）**：
    - 协议必须是 TCP/UDP（不支持 unixgram）；
    - 必须以 root 运行；
    - rsyslog 版本 ≥ v8；
    - `RsyslogFilters` 不含换行等可注入字符。
  - **写入即校验，失败即回滚**：写入后先跑 `rsyslogd -N1` 
  校验整份有效配置；校验失败则回滚到旧内容（区分「原文件不存在→删除」与「原文件为空→恢复空文件」），**绝不因为一份坏配置而搞垮 rsyslog 
  已有的转发链路**。
  - **并发安全**：所有「写 + 校验 + 重启 / 删除」的宿主机全局操作都串行化在 `rsyslogOpMu` 
  锁下，避免多个管道并发时互相干扰导致误校验失败或重启相互覆盖。
  - **init 系统自适应**：有 systemd 标记走 `systemctl restart rsyslog`，否则走 `service rsyslog restart`；所有外部命令均带超时。

  ### 3. 管道删除清理钩子（`pkg/pipeline/input.go`、`pluginmanager/plugin_manager.go`）

  - 新增可选接口 `pipeline.PipelineRemovedCleaner{ OnPipelineRemoved() }`。
  - `plugin_manager` 在 `Stop(configName, removedFlag)` 与 `DeleteLogstoreConfigFromLogtailConfig` 中，**仅当 
  `removedFlag=true`（即真正删除配置）** 时，在管道停止之后、runner 被置空之前，回调所有 service 插件的 `OnPipelineRemoved()`。
  - `Syslog.OnPipelineRemoved()` 据此删除自动生成的 rsyslog 配置文件并重启
  rsyslogd，回收转发规则和磁盘队列，避免持续向已停止的端口投递、堆积磁盘。

  ### 4. 其他

  - 新增两个自监控告警类型：`SERVICE_SYSLOG_RSYSLOG_CONFIG_ALARM`、`SERVICE_SYSLOG_RSYSLOG_RESTART_ALARM`。
  - 修复 `getAddressParts` 对 IPv6 地址的拼接（改用 `net.JoinHostPort`，正确加方括号）。
  - 补充中文文档、单元测试（rsyslog 生成/清洗/回滚、删除钩子路由等）。

  ## ⭐ 重点：管道「热加载」 vs 「删除」 与 Stop / 重启的关系

  这是本次改动最关键、也最容易踩坑的语义。核心原则：**rsyslogd 重启是宿主机全局副作用，必须尽量少触发；rsyslog 
  转发配置只在采集配置被真正删除时才清理。**

  背景：rsyslog v8+ 的 `reload`/`SIGHUP` **不会重载配置**，应用或撤销转发规则只能通过 **重启 rsyslogd**
  实现，而这会短暂影响该主机上所有基于 rsyslog 的日志链路。因此我们必须精确区分「Stop 是因为什么而发生的」。

  管道的 `Stop` 会在多种场景下被调用，但通过 `removedFlag` 区分「是否为真正删除」：

  | 场景 | `Stop(removedFlag)` | 是否触发 `OnPipelineRemoved` | rsyslog 配置文件 | rsyslogd 重启次数 |
  |------|--------------------|------------------------------|------------------|-------------------|
  | **热加载 / 重启同一配置**（`removedFlag=false`） | 是（false） | **否** | 保留 | 视内容而定见下表 |
  | **进程退出 / 升级重启**（`StopAllPipelines`） | 不走单配置删除路径 | **否** | 保留 | 0 |

  **为什么这样设计：**
  
  - **热加载不清理**：配置热加载时 `Stop` 的 `removedFlag=false`，我们**不**回调 `OnPipelineRemoved`，rsyslog 转发配置原样保留。重新
  `Start`
  时通过**内容比对**决定是否重启——只有当转发相关内容（地址/端口/`RsyslogFilters`）真正变化时才重写并重启，与转发无关的改动（如某个
  processor/flusher）不会导致 rsyslogd 重启。这样避免了「无关编辑抖动 rsyslog」。
  - **删除才清理**：只有 `removedFlag=true` 才代表配置被永久删除，此时才回调 `OnPipelineRemoved`
  删除转发配置并重启，回收残留规则和磁盘队列。
  - **进程退出故意不清理**：整机退出/升级走 `StopAllPipelines`，不触发删除钩子，**故意保留** rsyslog 转发配置，让日志在 rsyslog
  磁盘队列中继续缓冲，待 agent 恢复后补送，避免升级窗口丢日志。
  - **调用时机**：删除钩子在管道**已停止之后、`DeleteLogstoreConfig` 将 runner 置空之前**调用，保证还能访问到 service 插件实例。

  ### 各场景 rsyslogd 重启次数一览
  
  | 场景 | rsyslogd 重启次数 |
  |------|------|
  | 修改采集配置中与 syslog/rsyslog 转发**无关**的部分 | 0（内容不变，比对后跳过重启） |
  | 修改影响转发的部分（监听地址/端口、`RsyslogFilters`） | 1（内容变化，重写并重启） |
  | 删除采集配置 | 1（删除配置并重启） |
  | LoongCollector 进程退出 / 升级重启 | 0（保留配置，日志继续在磁盘队列缓冲） |

  ## 前提条件
  
  - 需要 root 权限运行 LoongCollector；
  - 仅支持 TCP / UDP 协议（不支持 unixgram）；
  - 目标机器需安装 rsyslogd v8 及以上版本。