### PR TITLE
feat(common): add working_interface flag for host IP resolution

### DIFF
--- a/core/app_config/AppConfig.cpp
+++ b/core/app_config/AppConfig.cpp
@@ -1206,6 +1206,16 @@ void AppConfig::LoadResourceConf(const Json::Value& confJson) {
     mSendRequestGlobalConcurrency = mSendRequestConcurrency * (1 + GLOBAL_CONCURRENCY_FREE_PERCENTAGE_FOR_ONE_REGION);
 }
 
+const std::string& AppConfig::GetBindInterface() const {
+    // When working_interface is configured, it takes precedence over bind_interface so that
+    // outgoing data sockets (curl CURLOPT_INTERFACE) bind to the same interface used to resolve
+    // the reported host IP (GetHostIp), keeping the reported IP and the actual egress consistent.
+    if (!STRING_FLAG(working_interface).empty()) {
+        return STRING_FLAG(working_interface);
+    }
+    return mBindInterface;
+}
+
 bool AppConfig::CheckAndResetProxyEnv() {
     // envs capitalized prioritize those in lower case
     string httpProxy = ToString(getenv("HTTP_PROXY"));

--- a/core/app_config/AppConfig.cpp
+++ b/core/app_config/AppConfig.cpp
@@ -1195,6 +1195,12 @@ void AppConfig::LoadResourceConf(const Json::Value& confJson) {
             mBindInterface.clear();
         LOG_INFO(sLogger, ("bind_interface", mBindInterface));
     }
+    // working_interface takes precedence over bind_interface, so the egress binding matches the
+    // interface GetHostIp resolves the reported IP from. The flag is already parsed at this point.
+    if (!STRING_FLAG(working_interface).empty()) {
+        mBindInterface = STRING_FLAG(working_interface);
+        LOG_INFO(sLogger, ("bind_interface overridden by working_interface", mBindInterface));
+    }
 
     // mSendRequestConcurrency was limited
     if (mSendRequestConcurrency < MIN_SEND_REQUEST_CONCURRENCY) {
@@ -1204,16 +1210,6 @@ void AppConfig::LoadResourceConf(const Json::Value& confJson) {
         mSendRequestConcurrency = MAX_SEND_REQUEST_CONCURRENCY;
     }
     mSendRequestGlobalConcurrency = mSendRequestConcurrency * (1 + GLOBAL_CONCURRENCY_FREE_PERCENTAGE_FOR_ONE_REGION);
-}
-
-const std::string& AppConfig::GetBindInterface() const {
-    // When working_interface is configured, it takes precedence over bind_interface so that
-    // outgoing data sockets (curl CURLOPT_INTERFACE) bind to the same interface used to resolve
-    // the reported host IP (GetHostIp), keeping the reported IP and the actual egress consistent.
-    if (!STRING_FLAG(working_interface).empty()) {
-        return STRING_FLAG(working_interface);
-    }
-    return mBindInterface;
 }
 
 bool AppConfig::CheckAndResetProxyEnv() {

--- a/core/app_config/AppConfig.h
+++ b/core/app_config/AppConfig.h
@@ -534,10 +534,7 @@ public:
 
     const Json::Value& GetConfig() const { return mLocalInstanceConfig; }
 
-    // Returns the interface used to bind outgoing data sockets (curl CURLOPT_INTERFACE).
-    // When working_interface is configured, it takes precedence so that the reported host IP
-    // (GetHostIp) and the actual data egress interface stay consistent.
-    const std::string& GetBindInterface() const;
+    const std::string& GetBindInterface() const { return mBindInterface; }
 
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class SenderUnittest;

--- a/core/app_config/AppConfig.h
+++ b/core/app_config/AppConfig.h
@@ -534,7 +534,10 @@ public:
 
     const Json::Value& GetConfig() const { return mLocalInstanceConfig; }
 
-    const std::string& GetBindInterface() const { return mBindInterface; }
+    // Returns the interface used to bind outgoing data sockets (curl CURLOPT_INTERFACE).
+    // When working_interface is configured, it takes precedence so that the reported host IP
+    // (GetHostIp) and the actual data egress interface stay consistent.
+    const std::string& GetBindInterface() const;
 
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class SenderUnittest;

--- a/core/common/LogtailCommonFlags.cpp
+++ b/core/common/LogtailCommonFlags.cpp
@@ -35,6 +35,12 @@ DEFINE_FLAG_STRING(
     "JSON key ignored_interfaces in ilogtail_config.json; env ignored_interfaces or LOONG_IGNORED_INTERFACES.",
     "kube-ipvs0,nodelocaldns,docker0");
 
+// When non-empty, resolve host IP from this interface first (GetHostIpByInterface), then fall back to hostname.
+DEFINE_FLAG_STRING(working_interface,
+                   "Interface name used to resolve host IP first when non-empty (Linux); "
+                   "falls back to hostname resolution if the interface yields no valid IP.",
+                   "");
+
 // checkpoint
 DEFINE_FLAG_INT32(unused_checkpoints_clear_interval_sec, "", 600);
 

--- a/core/common/LogtailCommonFlags.cpp
+++ b/core/common/LogtailCommonFlags.cpp
@@ -36,9 +36,12 @@ DEFINE_FLAG_STRING(
     "kube-ipvs0,nodelocaldns,docker0");
 
 // When non-empty, resolve host IP from this interface first (GetHostIpByInterface), then fall back to hostname.
+// It also takes precedence over bind_interface, so outgoing data sockets bind to the same interface,
+// keeping the reported host IP and the actual data egress consistent.
 DEFINE_FLAG_STRING(working_interface,
                    "Interface name used to resolve host IP first when non-empty (Linux); "
-                   "falls back to hostname resolution if the interface yields no valid IP.",
+                   "falls back to hostname resolution if the interface yields no valid IP. "
+                   "Takes precedence over bind_interface for outgoing data egress binding.",
                    "");
 
 // checkpoint

--- a/core/common/LogtailCommonFlags.h
+++ b/core/common/LogtailCommonFlags.h
@@ -26,6 +26,7 @@ DECLARE_FLAG_INT32(mem_limit_num);
 DECLARE_FLAG_DOUBLE(cpu_usage_up_limit);
 DECLARE_FLAG_INT64(memory_usage_up_limit);
 DECLARE_FLAG_STRING(ignored_interfaces);
+DECLARE_FLAG_STRING(working_interface);
 
 // checkpoint
 DECLARE_FLAG_INT32(unused_checkpoints_clear_interval_sec);

--- a/core/common/MachineInfoUtil.cpp
+++ b/core/common/MachineInfoUtil.cpp
@@ -341,13 +341,13 @@ std::string GetHostIpByInterface(const std::string& intf) {
 std::string GetHostIp(const std::string& intf) {
 #if defined(__linux__)
     // When working_interface is configured, resolve the IP from that interface first;
-    // only fall back to hostname resolution if the interface yields no valid IP.
+    // if it yields no valid IP, fall through to the existing hostname + interface fallback.
     if (!STRING_FLAG(working_interface).empty()) {
         std::string ip = GetHostIpByInterface(STRING_FLAG(working_interface));
         if (!ip.empty() && ip.find("127.") != 0) {
             return ip;
         }
-        return GetHostIpByHostName();
+        // interface yielded no valid IP, fall through to hostname + interface fallback below
     }
 #endif
     std::string ip = GetHostIpByHostName();

--- a/core/common/MachineInfoUtil.cpp
+++ b/core/common/MachineInfoUtil.cpp
@@ -339,6 +339,17 @@ std::string GetHostIpByInterface(const std::string& intf) {
 }
 
 std::string GetHostIp(const std::string& intf) {
+#if defined(__linux__)
+    // When working_interface is configured, resolve the IP from that interface first;
+    // only fall back to hostname resolution if the interface yields no valid IP.
+    if (!STRING_FLAG(working_interface).empty()) {
+        std::string ip = GetHostIpByInterface(STRING_FLAG(working_interface));
+        if (!ip.empty() && ip.find("127.") != 0) {
+            return ip;
+        }
+        return GetHostIpByHostName();
+    }
+#endif
     std::string ip = GetHostIpByHostName();
 #if defined(__linux__)
     if (ip.empty() || ip.find("127.") == 0) {

--- a/core/unittest/app_config/AppConfigUnittest.cpp
+++ b/core/unittest/app_config/AppConfigUnittest.cpp
@@ -289,19 +289,32 @@ void AppConfigUnittest::TestBindInterfaceWorkingInterfacePrecedence() {
     std::string savedWorking = STRING_FLAG(working_interface);
     std::string savedBind = cfg->mBindInterface;
 
-    // working_interface empty: GetBindInterface returns the configured bind_interface as-is.
+    // working_interface empty: LoadResourceConf keeps the configured bind_interface as-is.
     STRING_FLAG(working_interface) = "";
-    cfg->mBindInterface = "eth0";
-    APSARA_TEST_EQUAL(cfg->GetBindInterface(), "eth0");
+    {
+        Json::Value conf;
+        conf["bind_interface"] = "eth0";
+        cfg->LoadResourceConf(conf);
+        APSARA_TEST_EQUAL(cfg->GetBindInterface(), "eth0");
+    }
 
-    // working_interface set: it takes precedence over bind_interface so data egress binds to the
-    // same interface used to resolve the reported host IP.
+    // working_interface set: it overrides bind_interface at load time, so GetBindInterface (and thus
+    // the curl egress binding) uses the same interface from which GetHostIp resolves the reported IP.
     STRING_FLAG(working_interface) = "eth1";
-    APSARA_TEST_EQUAL(cfg->GetBindInterface(), "eth1");
+    {
+        Json::Value conf;
+        conf["bind_interface"] = "eth0";
+        cfg->LoadResourceConf(conf);
+        APSARA_TEST_EQUAL(cfg->GetBindInterface(), "eth1");
+    }
 
-    // Still wins even when bind_interface is empty.
-    cfg->mBindInterface = "";
-    APSARA_TEST_EQUAL(cfg->GetBindInterface(), "eth1");
+    // The override applies even when bind_interface is absent from the config.
+    cfg->mBindInterface = "eth2";
+    {
+        Json::Value conf; // no bind_interface key
+        cfg->LoadResourceConf(conf);
+        APSARA_TEST_EQUAL(cfg->GetBindInterface(), "eth1");
+    }
 
     STRING_FLAG(working_interface) = savedWorking;
     cfg->mBindInterface = savedBind;

--- a/core/unittest/app_config/AppConfigUnittest.cpp
+++ b/core/unittest/app_config/AppConfigUnittest.cpp
@@ -46,6 +46,7 @@ public:
     void TestGenerateFileTagsDir();
     void TestIgnoredInterfacesConfig();
     void TestIgnoredInterfacesEnv();
+    void TestBindInterfaceWorkingInterfacePrecedence();
 
 private:
     static Json::Value MakeDefaultIgnoredInterfacesConfig() {
@@ -283,6 +284,29 @@ void AppConfigUnittest::TestIgnoredInterfacesEnv() {
     cfg->ParseJsonToFlags(MakeDefaultIgnoredInterfacesConfig());
 }
 
+void AppConfigUnittest::TestBindInterfaceWorkingInterfacePrecedence() {
+    AppConfig* cfg = AppConfig::GetInstance();
+    std::string savedWorking = STRING_FLAG(working_interface);
+    std::string savedBind = cfg->mBindInterface;
+
+    // working_interface empty: GetBindInterface returns the configured bind_interface as-is.
+    STRING_FLAG(working_interface) = "";
+    cfg->mBindInterface = "eth0";
+    APSARA_TEST_EQUAL(cfg->GetBindInterface(), "eth0");
+
+    // working_interface set: it takes precedence over bind_interface so data egress binds to the
+    // same interface used to resolve the reported host IP.
+    STRING_FLAG(working_interface) = "eth1";
+    APSARA_TEST_EQUAL(cfg->GetBindInterface(), "eth1");
+
+    // Still wins even when bind_interface is empty.
+    cfg->mBindInterface = "";
+    APSARA_TEST_EQUAL(cfg->GetBindInterface(), "eth1");
+
+    STRING_FLAG(working_interface) = savedWorking;
+    cfg->mBindInterface = savedBind;
+}
+
 void AppConfigUnittest::TestGenerateFileTagsDir() {
     {
         STRING_FLAG(ALIYUN_LOG_FILE_TAGS) = "";
@@ -336,6 +360,7 @@ UNIT_TEST_CASE(AppConfigUnittest, TestLoadSingleValueEnvConfig);
 UNIT_TEST_CASE(AppConfigUnittest, TestLoadStringParameter);
 UNIT_TEST_CASE(AppConfigUnittest, TestIgnoredInterfacesConfig);
 UNIT_TEST_CASE(AppConfigUnittest, TestIgnoredInterfacesEnv);
+UNIT_TEST_CASE(AppConfigUnittest, TestBindInterfaceWorkingInterfacePrecedence);
 UNIT_TEST_CASE(AppConfigUnittest, TestGenerateFileTagsDir);
 
 } // namespace logtail

--- a/core/unittest/common/MachineInfoUtilUnittest.cpp
+++ b/core/unittest/common/MachineInfoUtilUnittest.cpp
@@ -16,9 +16,15 @@
 #include "unittest/Unittest.h"
 
 #if defined(__linux__)
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+
+#include <string>
+
 #include "json/value.h"
 
 #include "app_config/AppConfig.h"
+#include "common/LogtailCommonFlags.h"
 #endif
 
 namespace logtail {
@@ -168,9 +174,59 @@ public:
         EXPECT_TRUE(IsIgnoredInterfaceForHostIdentity("kube-ipvs0"));
         (void)GetAnyAvailableIP();
     }
+
+    // Find an interface whose IPv4 address is neither empty nor loopback, so the working_interface
+    // branch of GetHostIp can be exercised deterministically. Returns "" if none is available.
+    static std::string FindInterfaceWithValidIp() {
+        struct ifaddrs* ifaddr = nullptr;
+        if (getifaddrs(&ifaddr) != 0) {
+            return "";
+        }
+        std::string result;
+        for (struct ifaddrs* ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+            if (ifa->ifa_addr == nullptr || ifa->ifa_addr->sa_family != AF_INET) {
+                continue;
+            }
+            std::string name = ifa->ifa_name;
+            std::string ip = GetHostIpByInterface(name);
+            if (!ip.empty() && ip.find("127.") != 0) {
+                result = name;
+                break;
+            }
+        }
+        freeifaddrs(ifaddr);
+        return result;
+    }
+
+    void TestGetHostIpWithWorkingInterface() {
+        std::string savedFlag = STRING_FLAG(working_interface);
+
+        // Case 1: working_interface points to a non-existent NIC. GetHostIpByInterface yields "",
+        // so GetHostIp must fall through to the original hostname + interface fallback chain and
+        // return exactly what it returns when working_interface is empty.
+        STRING_FLAG(working_interface) = "";
+        std::string baseline = GetHostIp();
+        STRING_FLAG(working_interface) = "loongcollector_nonexistent_iface";
+        EXPECT_EQ(GetHostIp(), baseline);
+
+        // Case 2: working_interface points to a NIC with a valid (non-loopback) IP. GetHostIp must
+        // prioritize that interface and return its IP directly, regardless of hostname resolution.
+        std::string goodIntf = FindInterfaceWithValidIp();
+        if (!goodIntf.empty()) {
+            std::string expectedIp = GetHostIpByInterface(goodIntf);
+            STRING_FLAG(working_interface) = goodIntf;
+            EXPECT_EQ(GetHostIp(), expectedIp);
+            // The passed-in intf argument must not override the working_interface priority.
+            EXPECT_EQ(GetHostIp("loongcollector_nonexistent_iface"), expectedIp);
+        }
+        // else: no non-loopback IPv4 interface in this environment; the valid-IP case is skipped.
+
+        STRING_FLAG(working_interface) = savedFlag;
+    }
 };
 
 UNIT_TEST_CASE(MachineInfoUtilLinuxUnittest, TestNicIpv4AndHostIdentityHelpers);
+UNIT_TEST_CASE(MachineInfoUtilLinuxUnittest, TestGetHostIpWithWorkingInterface);
 #endif
 
 } // end of namespace logtail


### PR DESCRIPTION
Introduce a working_interface flag that, when set, resolves the host IP from the given network interface first via GetHostIpByInterface, falling back to GetHostIpByHostName only when the interface yields no valid IP. When the flag is empty, the original resolution logic (hostname first, interface as fallback) stays unchanged.

This lets deployments pin host IP resolution to a specific interface in environments where hostname resolution returns an unwanted or loopback address.