### PR TITLE
feat(agentsight): support raw HTTPS fallback events

### DIFF
--- a/core/ebpf/Config.cpp
+++ b/core/ebpf/Config.cpp
@@ -690,6 +690,7 @@ bool SecurityOptions::Init(SecurityProbeType probeType,
         mAgentsightHttp.clear();
         mAgentsightEventStreamFormat = true;
         mAgentsightMessageDeltaOnly = true;
+        mAgentsightEnableRawHttps = false;
     }
 
     SecurityOption thisSecurityOption;
@@ -748,6 +749,11 @@ bool SecurityOptions::Init(SecurityProbeType probeType,
                 }
                 if (innerConfig.isMember("MessageDeltaOnly")) {
                     if (!GetOptionalBoolParam(innerConfig, "MessageDeltaOnly", mAgentsightMessageDeltaOnly, errorMsg)) {
+                        warnOptionalParse();
+                    }
+                }
+                if (innerConfig.isMember("EnableRawHttps")) {
+                    if (!GetOptionalBoolParam(innerConfig, "EnableRawHttps", mAgentsightEnableRawHttps, errorMsg)) {
                         warnOptionalParse();
                     }
                 }

--- a/core/ebpf/Config.h
+++ b/core/ebpf/Config.h
@@ -71,6 +71,8 @@ public:
     bool mAgentsightEventStreamFormat = true;
     /// When true, omit system instructions, tool definitions, and full input messages (per dedup).
     bool mAgentsightMessageDeltaOnly = true;
+    /// When true, forward raw HTTPS fallback events (unparsable traffic from attached processes).
+    bool mAgentsightEnableRawHttps = false;
 };
 
 /////////////////////  /////////////////////

--- a/core/ebpf/EBPFAdapter.cpp
+++ b/core/ebpf/EBPFAdapter.cpp
@@ -257,6 +257,8 @@ bool EBPFAdapter::tryLoadAgentSightDylib() {
         tmpLib->LoadMethod("agentsight_config_set_verbose", symErr));
     sym.config_set_log_path = reinterpret_cast<decltype(sym.config_set_log_path)>(
         tmpLib->LoadMethod("agentsight_config_set_log_path", symErr));
+    sym.config_set_enable_raw_https = reinterpret_cast<decltype(sym.config_set_enable_raw_https)>(
+        tmpLib->LoadMethod("agentsight_config_set_enable_raw_https", symErr));
     sym.config_add_cmdline_rule = reinterpret_cast<decltype(sym.config_add_cmdline_rule)>(
         tmpLib->LoadMethod("agentsight_config_add_cmdline_rule", symErr));
     sym.config_add_https
@@ -272,8 +274,9 @@ bool EBPFAdapter::tryLoadAgentSightDylib() {
     sym.handle_read = reinterpret_cast<decltype(sym.handle_read)>(tmpLib->LoadMethod("agentsight_read", symErr));
 
     const bool ok = sym.last_error && sym.config_new && sym.config_free && sym.config_set_verbose
-        && sym.config_set_log_path && sym.handle_new && sym.handle_free && sym.handle_start && sym.handle_stop
-        && sym.handle_get_eventfd && sym.handle_read && sym.config_add_https && sym.config_add_http;
+        && sym.config_set_log_path && sym.config_set_enable_raw_https && sym.handle_new && sym.handle_free
+        && sym.handle_start && sym.handle_stop && sym.handle_get_eventfd && sym.handle_read && sym.config_add_https
+        && sym.config_add_http;
 
     if (!ok) {
         LOG_WARNING(sLogger,

--- a/core/ebpf/EBPFAdapter.h
+++ b/core/ebpf/EBPFAdapter.h
@@ -36,6 +36,7 @@ struct AgentSightSymbolTable {
     void (*config_free)(AgentsightConfigHandle*) = nullptr;
     void (*config_set_verbose)(AgentsightConfigHandle*, int) = nullptr;
     void (*config_set_log_path)(AgentsightConfigHandle*, const char*) = nullptr;
+    void (*config_set_enable_raw_https)(AgentsightConfigHandle*, int) = nullptr;
     void (*config_add_cmdline_rule)(AgentsightConfigHandle*, const char* const*, const char*, int) = nullptr;
     void (*config_add_https)(AgentsightConfigHandle*, const char*) = nullptr;
     int (*config_add_http)(AgentsightConfigHandle*, const char*) = nullptr;

--- a/core/ebpf/plugin/agentsight/AgentsightEvents.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightEvents.cpp
@@ -76,4 +76,22 @@ AgentsightLlmRecord::AgentsightLlmRecord(std::string pipelineConfigName, const A
     mToolDefinitionsJson = CopyBuffer(d.tools, d.tools_len);
 }
 
+// Deep-copies from AgentsightHttpsData: headers/body are (ptr, len) buffers that are only valid
+// during the FFI callback; method/path are NUL-terminated C strings.
+AgentsightHttpsRecord::AgentsightHttpsRecord(std::string pipelineConfigName, const AgentsightHttpsData& d)
+    : CommonEvent(KernelEventType::AGENTSIGHT_HTTPS_RECORD), mPipelineConfigName(std::move(pipelineConfigName)) {
+    mPid = d.pid;
+    mTimestampNs = d.timestamp_ns;
+    mDurationNs = d.duration_ns;
+    mStatusCode = d.status_code;
+    mIsSse = d.is_sse;
+    mProcessName = CopyProcessName(d.process_name);
+    mMethod = CopyCStr(d.method);
+    mPath = CopyCStr(d.path);
+    mRequestHeaders = CopyBuffer(d.request_headers, d.request_headers_len);
+    mRequestBody = CopyBuffer(d.request_body, d.request_body_len);
+    mResponseHeaders = CopyBuffer(d.response_headers, d.response_headers_len);
+    mResponseBody = CopyBuffer(d.response_body, d.response_body_len);
+}
+
 } // namespace logtail::ebpf

--- a/core/ebpf/plugin/agentsight/AgentsightEvents.h
+++ b/core/ebpf/plugin/agentsight/AgentsightEvents.h
@@ -68,4 +68,30 @@ public:
     std::string mToolDefinitionsJson;
 };
 
+/// Raw HTTPS exchange reported when captured traffic could not be parsed into LLM semantics
+/// (coolbpf fallback path). Deep-copies all fields from AgentsightHttpsData.
+class AgentsightHttpsRecord : public CommonEvent {
+public:
+    AgentsightHttpsRecord(std::string pipelineConfigName, const AgentsightHttpsData& d);
+
+    PluginType GetPluginType() const override { return PluginType::AGENTSIGHT_OBSERVE; }
+
+    const std::string& GetPipelineConfigName() const { return mPipelineConfigName; }
+
+    std::string mPipelineConfigName;
+
+    int32_t mPid = 0;
+    uint64_t mTimestampNs = 0;
+    uint64_t mDurationNs = 0;
+    uint16_t mStatusCode = 0;
+    uint8_t mIsSse = 0;
+    std::string mProcessName;
+    std::string mMethod;
+    std::string mPath;
+    std::string mRequestHeaders;
+    std::string mRequestBody;
+    std::string mResponseHeaders;
+    std::string mResponseBody;
+};
+
 } // namespace logtail::ebpf

--- a/core/ebpf/plugin/agentsight/AgentsightManager.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.cpp
@@ -33,12 +33,13 @@
 #include "models/LogEvent.h"
 #include "models/PipelineEventGroup.h"
 #include "monitor/metric_models/ReentrantMetricsRecord.h"
+#include "rapidjson/document.h"
 
 namespace logtail::ebpf {
 
 namespace {
 
-bool ParseHostAndPortFromRequestUrl(const std::string& url, std::string& host, std::string& port) {
+bool ParseHostAndPortFromUrlOrAuthority(const std::string& url, std::string& host, std::string& port) {
     host.clear();
     port.clear();
     const auto schemePos = url.find("://");
@@ -303,7 +304,7 @@ void FillAgentsightServerFromUrl(const AgentsightLlmRecord& rec, SetLogStrFn set
     }
     std::string host;
     std::string port;
-    if (ParseHostAndPortFromRequestUrl(rec.mRequestUrl, host, port)) {
+    if (ParseHostAndPortFromUrlOrAuthority(rec.mRequestUrl, host, port)) {
         setStr(StringView("server.address"), host);
         setStr(StringView("server.port"), port);
     }
@@ -436,6 +437,96 @@ void FillAgentsightModelResponseLog(const AgentsightLlmRecord& rec,
     setStr(StringView("gen_ai.output.messages"), rec.mResponseMessagesJson);
 }
 
+/// Extract the target host from raw HTTPS request headers (JSON object), checking the
+/// HTTP/1.1 `host` and HTTP/2 `:authority` keys. Returns an empty string when headers
+/// are unparseable or no host is present.
+std::string ExtractHostFromHeadersJson(const std::string& headersJson) {
+    if (headersJson.empty()) {
+        return {};
+    }
+    rapidjson::Document doc;
+    doc.Parse(headersJson.c_str(), headersJson.size());
+    if (doc.HasParseError() || !doc.IsObject()) {
+        return {};
+    }
+    static constexpr const char* kHostKeys[] = {"host", ":authority"};
+    for (const char* key : kHostKeys) {
+        const auto it = doc.FindMember(key);
+        if (it != doc.MemberEnd() && it->value.IsString()) {
+            const auto* v = it->value.GetString();
+            if (v != nullptr && v[0] != '\0') {
+                return std::string(v, it->value.GetStringLength());
+            }
+        }
+    }
+    return {};
+}
+
+void FillAgentsightHttpCommon(const AgentsightHttpsRecord& rec,
+                              SetLogStrFn setStr,
+                              logtail::LogEvent* log,
+                              const std::string& eventId,
+                              uint64_t timestampNs) {
+    SetLogTimestampFromNs(log, timestampNs);
+    FillAgentsightOtlpTimeFields(log, timestampNs);
+    log->SetContent(StringView("event.id"), StringView(eventId));
+    if (rec.mPid != 0) {
+        log->SetContent("pid", std::to_string(rec.mPid));
+    }
+    setStr(StringView("comm"), rec.mProcessName);
+    log->SetContent(StringView("url.scheme"), StringView("https"));
+}
+
+void FillAgentsightHttpRequestLog(const AgentsightHttpsRecord& rec,
+                                  logtail::LogEvent* log,
+                                  const std::string& eventId) {
+    auto setStr = [&](StringView k, const std::string& v) {
+        if (!v.empty()) {
+            log->SetContent(k, StringView(v.data(), v.size()));
+        }
+    };
+
+    FillAgentsightHttpCommon(rec, setStr, log, eventId, rec.mTimestampNs);
+    log->SetContent(StringView("event.name"), StringView("http.request"));
+    setStr(StringView("http.request.method"), rec.mMethod);
+    setStr(StringView("url.path"), rec.mPath);
+
+    const std::string authority = ExtractHostFromHeadersJson(rec.mRequestHeaders);
+    std::string host;
+    std::string port;
+    if (ParseHostAndPortFromUrlOrAuthority(authority, host, port)) {
+        setStr(StringView("server.address"), host);
+        setStr(StringView("server.port"), port);
+    }
+
+    setStr(StringView("http.request.header"), rec.mRequestHeaders);
+    setStr(StringView("http.request.body.content"), rec.mRequestBody);
+    if (!rec.mRequestBody.empty()) {
+        log->SetContent("http.request.body.size", std::to_string(rec.mRequestBody.size()));
+    }
+}
+
+void FillAgentsightHttpResponseLog(const AgentsightHttpsRecord& rec,
+                                   logtail::LogEvent* log,
+                                   const std::string& eventId) {
+    auto setStr = [&](StringView k, const std::string& v) {
+        if (!v.empty()) {
+            log->SetContent(k, StringView(v.data(), v.size()));
+        }
+    };
+
+    FillAgentsightHttpCommon(rec, setStr, log, eventId, rec.mTimestampNs + rec.mDurationNs);
+    log->SetContent(StringView("event.name"), StringView("http.response"));
+    log->SetContent("http.response.status_code", std::to_string(rec.mStatusCode));
+    log->SetContent(StringView("is_sse"), StringView(rec.mIsSse ? "1" : "0"));
+
+    setStr(StringView("http.response.header"), rec.mResponseHeaders);
+    setStr(StringView("http.response.body.content"), rec.mResponseBody);
+    if (!rec.mResponseBody.empty()) {
+        log->SetContent("http.response.body.size", std::to_string(rec.mResponseBody.size()));
+    }
+}
+
 } // namespace
 
 AgentsightManager::AgentsightManager(const std::shared_ptr<ProcessCacheManager>& processCacheManager,
@@ -495,8 +586,8 @@ void AgentsightManager::StopAgentSightLocked() {
 
 bool AgentsightManager::RestartAgentSightLocked(const SecurityOptions& opts) {
     const auto* sym = mEBPFAdapter->GetAgentSightSymbols();
-    if (!sym || !sym->config_new || !sym->handle_new || !sym->handle_start || !sym->handle_read
-        || !sym->handle_get_eventfd) {
+    if (!sym || !sym->config_new || !sym->config_set_enable_raw_https || !sym->handle_new || !sym->handle_start
+        || !sym->handle_read || !sym->handle_get_eventfd) {
         StopAgentSightLocked();
         LOG_ERROR(sLogger, ("AgentSight", "symbols not available"));
         return false;
@@ -513,6 +604,7 @@ bool AgentsightManager::RestartAgentSightLocked(const SecurityOptions& opts) {
     if (!opts.mLogPath.empty()) {
         sym->config_set_log_path(cfg, opts.mLogPath.c_str());
     }
+    sym->config_set_enable_raw_https(cfg, opts.mAgentsightEnableRawHttps ? 1 : 0);
 
     ApplyAgentsightRulesToConfig(cfg, sym, opts);
 
@@ -551,7 +643,12 @@ int AgentsightManager::DrainReadsLocked() {
     }
     int total = 0;
     for (;;) {
-        const int r = sym->handle_read(mHandle, nullptr, nullptr, &AgentsightManager::OnLlmCallback, this, 0);
+        const int r = sym->handle_read(mHandle,
+                                      mEnableRawHttps ? &AgentsightManager::OnHttpsCallback : nullptr,
+                                      mEnableRawHttps ? this : nullptr,
+                                      &AgentsightManager::OnLlmCallback,
+                                      this,
+                                      0);
         if (r <= 0) {
             break;
         }
@@ -589,6 +686,22 @@ void AgentsightManager::OnLlmCallback(const AgentsightLLMData* data, void* user_
     } else {
         ADD_COUNTER(self->mLossKernelEventsTotal, 1);
         LOG_WARNING(sLogger, ("AgentSight LLM event enqueue failed", ""));
+    }
+}
+
+void AgentsightManager::OnHttpsCallback(const AgentsightHttpsData* data, void* user_data) {
+    if (!data || !user_data) {
+        return;
+    }
+    auto* self = static_cast<AgentsightManager*>(user_data);
+    // Same locking constraint as OnLlmCallback: runs under handle_read while mLibMutex is held.
+    const std::string configName = self->mConfigName;
+    auto evt = std::make_shared<AgentsightHttpsRecord>(configName, *data);
+    if (self->mCommonEventQueue.try_enqueue(evt)) {
+        ADD_COUNTER(self->mPluginInEventsTotal, 1);
+    } else {
+        ADD_COUNTER(self->mLossKernelEventsTotal, 1);
+        LOG_WARNING(sLogger, ("AgentSight HTTPS event enqueue failed", ""));
     }
 }
 
@@ -652,6 +765,7 @@ int AgentsightManager::AddOrUpdateConfig(const CollectionPipelineContext* ctx,
     mQueueKey = ctx->GetProcessQueueKey();
     mEventStreamFormat = sec->mAgentsightEventStreamFormat;
     mMessageDeltaOnly = sec->mAgentsightMessageDeltaOnly;
+    mEnableRawHttps = sec->mAgentsightEnableRawHttps;
 
     if (!RestartAgentSightLocked(*sec)) {
         releaseMetricRefs();
@@ -714,6 +828,7 @@ int AgentsightManager::update(const PluginOptions& opt) {
     std::lock_guard<std::mutex> lock(mLibMutex);
     mEventStreamFormat = (*secPtr)->mAgentsightEventStreamFormat;
     mMessageDeltaOnly = (*secPtr)->mAgentsightMessageDeltaOnly;
+    mEnableRawHttps = (*secPtr)->mAgentsightEnableRawHttps;
     return 0;
 }
 
@@ -732,6 +847,7 @@ int AgentsightManager::resume(const PluginOptions& opt) {
     }
     mEventStreamFormat = (*secPtr)->mAgentsightEventStreamFormat;
     mMessageDeltaOnly = (*secPtr)->mAgentsightMessageDeltaOnly;
+    mEnableRawHttps = (*secPtr)->mAgentsightEnableRawHttps;
     if (!RestartAgentSightLocked(**secPtr)) {
         return 1;
     }
@@ -746,10 +862,20 @@ std::unique_ptr<PluginConfig> AgentsightManager::GeneratePluginConfig(const Plug
 }
 
 int AgentsightManager::HandleEvent(const std::shared_ptr<CommonEvent>& event) {
-    if (!event || event->GetKernelEventType() != KernelEventType::AGENTSIGHT_LLM_RECORD) {
+    if (!event) {
         return 0;
     }
-    auto* rec = static_cast<AgentsightLlmRecord*>(event.get());
+    switch (event->GetKernelEventType()) {
+        case KernelEventType::AGENTSIGHT_LLM_RECORD:
+            return HandleLlmEvent(static_cast<AgentsightLlmRecord*>(event.get()));
+        case KernelEventType::AGENTSIGHT_HTTPS_RECORD:
+            return HandleHttpsEvent(static_cast<AgentsightHttpsRecord*>(event.get()));
+        default:
+            return 0;
+    }
+}
+
+int AgentsightManager::HandleLlmEvent(AgentsightLlmRecord* rec) {
     if (!rec) {
         return 1;
     }
@@ -823,6 +949,49 @@ int AgentsightManager::HandleEvent(const std::shared_ptr<CommonEvent>& event) {
         } else {
             FillAgentsightCombinedLlmLog(*rec, log, messageDeltaOnly, emitPayload);
         }
+    }
+
+    std::unique_ptr<ProcessQueueItem> item = std::make_unique<ProcessQueueItem>(std::move(eventGroup), pluginIndex);
+    if (QueueStatus::OK == ProcessQueueManager::GetInstance()->PushQueue(queueKey, std::move(item))) {
+        ADD_COUNTER(mPushLogsTotal, logCount);
+        ADD_COUNTER(mPushLogGroupTotal, 1);
+    } else {
+        if (mPushLogFailedTotal) {
+            ADD_COUNTER(mPushLogFailedTotal, 1);
+        }
+        LOG_WARNING(
+            sLogger,
+            ("Agentsight push queue failed", "")("config", rec->GetPipelineConfigName())("pluginIdx", pluginIndex));
+    }
+    return 0;
+}
+
+int AgentsightManager::HandleHttpsEvent(AgentsightHttpsRecord* rec) {
+    if (!rec) {
+        return 1;
+    }
+
+    logtail::QueueKey queueKey;
+    uint32_t pluginIndex;
+    {
+        std::lock_guard<std::mutex> lock(mLibMutex);
+        if (mPipelineCtx == nullptr) {
+            return 0;
+        }
+        queueKey = mQueueKey;
+        pluginIndex = mPluginIndex;
+    }
+
+    auto sourceBuffer = std::make_shared<SourceBuffer>();
+    PipelineEventGroup eventGroup(sourceBuffer);
+    // A completed request/response pair shares one event.id for downstream correlation. RequestOnly
+    // records (status_code == 0) emit just the request. Duration is represented by the timestamps,
+    // so no separate duration field is emitted (no matching OTel semconv attribute).
+    const std::string eventId = CalculateRandomUUID();
+    FillAgentsightHttpRequestLog(*rec, eventGroup.AddLogEvent(true, mEventPool), eventId);
+    const size_t logCount = rec->mStatusCode == 0 ? 1U : 2U;
+    if (logCount == 2U) {
+        FillAgentsightHttpResponseLog(*rec, eventGroup.AddLogEvent(true, mEventPool), eventId);
     }
 
     std::unique_ptr<ProcessQueueItem> item = std::make_unique<ProcessQueueItem>(std::move(eventGroup), pluginIndex);

--- a/core/ebpf/plugin/agentsight/AgentsightManager.h
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.h
@@ -30,6 +30,9 @@
 
 namespace logtail::ebpf {
 
+class AgentsightLlmRecord;
+class AgentsightHttpsRecord;
+
 class AgentsightManager : public AbstractManager {
 public:
     AgentsightManager() = delete;
@@ -94,6 +97,10 @@ protected:
 
 private:
     static void OnLlmCallback(const AgentsightLLMData* data, void* user_data);
+    static void OnHttpsCallback(const AgentsightHttpsData* data, void* user_data);
+
+    int HandleLlmEvent(AgentsightLlmRecord* rec);
+    int HandleHttpsEvent(AgentsightHttpsRecord* rec);
 
     void StopAgentSightLocked();
     bool RestartAgentSightLocked(const SecurityOptions& opts);
@@ -122,6 +129,9 @@ private:
     bool mRunning = false;
     bool mEventStreamFormat = true;
     bool mMessageDeltaOnly = true;
+    // When false (default), the HTTPS fallback callback is passed as nullptr to agentsight_read,
+    // so unparsable traffic is consumed and dropped (LLM-only collection).
+    bool mEnableRawHttps = false;
 
     CounterPtr mLossKernelEventsTotal;
     CounterPtr mPushLogFailedTotal;

--- a/core/ebpf/type/CommonDataEvent.h
+++ b/core/ebpf/type/CommonDataEvent.h
@@ -40,6 +40,7 @@ enum class KernelEventType {
     FILE_PERMISSION_EVENT_READ,
 
     AGENTSIGHT_LLM_RECORD,
+    AGENTSIGHT_HTTPS_RECORD,
 };
 
 class CommonEvent {

--- a/core/unittest/ebpf/AgentsightEventsUnittest.cpp
+++ b/core/unittest/ebpf/AgentsightEventsUnittest.cpp
@@ -24,6 +24,7 @@ class AgentsightEventsUnittest : public testing::Test {
 public:
     void TestLlmRecordCopiesNonNullSizedBuffers();
     void TestLlmRecordCopiesProcessNameAndCmdline();
+    void TestHttpsRecordCopiesNonNullSizedBuffers();
 };
 
 void AgentsightEventsUnittest::TestLlmRecordCopiesNonNullSizedBuffers() {
@@ -79,5 +80,47 @@ void AgentsightEventsUnittest::TestLlmRecordCopiesProcessNameAndCmdline() {
 
 UNIT_TEST_CASE(AgentsightEventsUnittest, TestLlmRecordCopiesNonNullSizedBuffers)
 UNIT_TEST_CASE(AgentsightEventsUnittest, TestLlmRecordCopiesProcessNameAndCmdline)
+
+void AgentsightEventsUnittest::TestHttpsRecordCopiesNonNullSizedBuffers() {
+    // (ptr, len) buffers without NUL terminators: must be copied by length
+    static const char kReqHdrs[] = {'{', '"', 'h'};
+    static const char kReqBody[] = {'r', 'e', 'q'};
+    static const char kResHdrs[] = {'{', '"', 's'};
+    static const char kResBody[] = {'r', 'e', 's', 'p'};
+
+    AgentsightHttpsData d{};
+    d.pid = 1234;
+    d.timestamp_ns = 100;
+    d.duration_ns = 50;
+    d.status_code = 200;
+    d.is_sse = 1;
+    d.method = "POST";
+    d.path = "/v1/chat";
+    d.request_headers = kReqHdrs;
+    d.request_headers_len = 3;
+    d.request_body = kReqBody;
+    d.request_body_len = 3;
+    d.response_headers = kResHdrs;
+    d.response_headers_len = 3;
+    d.response_body = kResBody;
+    d.response_body_len = 4;
+
+    AgentsightHttpsRecord r("pipe-b", d);
+    APSARA_TEST_EQUAL(r.GetKernelEventType(), KernelEventType::AGENTSIGHT_HTTPS_RECORD);
+    APSARA_TEST_EQUAL(r.mPid, 1234);
+    APSARA_TEST_EQUAL(r.mTimestampNs, 100UL);
+    APSARA_TEST_EQUAL(r.mDurationNs, 50UL);
+    APSARA_TEST_EQUAL(r.mStatusCode, 200);
+    APSARA_TEST_EQUAL(r.mIsSse, 1);
+    APSARA_TEST_EQUAL(r.mMethod, "POST");
+    APSARA_TEST_EQUAL(r.mPath, "/v1/chat");
+    APSARA_TEST_EQUAL(r.mRequestHeaders, "{\"h");
+    APSARA_TEST_EQUAL(r.mRequestBody, "req");
+    APSARA_TEST_EQUAL(r.mResponseHeaders, "{\"s");
+    APSARA_TEST_EQUAL(r.mResponseBody, "resp");
+    APSARA_TEST_EQUAL(r.GetPipelineConfigName(), "pipe-b");
+}
+
+UNIT_TEST_CASE(AgentsightEventsUnittest, TestHttpsRecordCopiesNonNullSizedBuffers)
 
 UNIT_TEST_MAIN

--- a/core/unittest/ebpf/AgentsightManagerUnittest.cpp
+++ b/core/unittest/ebpf/AgentsightManagerUnittest.cpp
@@ -20,11 +20,15 @@
 #include <variant>
 
 #include "collection_pipeline/CollectionPipelineContext.h"
+#include "collection_pipeline/queue/ProcessQueueItem.h"
+#include "collection_pipeline/queue/ProcessQueueManager.h"
+#include "collection_pipeline/queue/QueueKeyManager.h"
 #include "ebpf/Config.h"
 #include "ebpf/EBPFAdapter.h"
 #include "ebpf/plugin/agentsight/AgentsightEvents.h"
 #include "ebpf/plugin/agentsight/AgentsightManager.h"
 #include "ebpf/type/FileEvent.h"
+#include "models/LogEvent.h"
 #include "unittest/Unittest.h"
 #include "unittest/ebpf/ManagerUnittestBase.h"
 
@@ -38,7 +42,7 @@ AgentsightHandle* gFakeHandle = reinterpret_cast<AgentsightHandle*>(0x20U);
 
 struct FakeReadControl {
     int start_ret = 0;
-    /// 0: always 0; 1: return 1 once then 0; 2: call LLM callback once then 0
+    /// 0: always 0; 1: return 1 once then 0; 2: call LLM callback once then 0; 3: call HTTPS callback once then 0
     int read_mode = 0;
     int read_step = 0;
 } gRead;
@@ -74,6 +78,12 @@ int g_ut_cmdline_allow_calls = 0;
 int g_ut_cmdline_deny_calls = 0;
 int g_ut_https_calls = 0;
 int g_ut_http_calls = 0;
+std::vector<int> g_ut_raw_https_values;
+
+void fake_config_set_enable_raw_https(AgentsightConfigHandle* cfg, int enabled) {
+    (void)cfg;
+    g_ut_raw_https_values.push_back(enabled);
+}
 
 void fake_config_add_cmdline_rule(AgentsightConfigHandle* cfg,
                                   const char* const* rule,
@@ -131,10 +141,11 @@ int fake_get_eventfd(AgentsightHandle* h) {
 
 // Static so pointers remain valid in LLM callback
 static AgentsightLLMData sUtLlmData{};
+static AgentsightHttpsData sUtHttpsData{};
 
 int fake_handle_read(AgentsightHandle* h,
-                     agentsight_https_callback_fn,
-                     void*,
+                     agentsight_https_callback_fn https,
+                     void* https_user_data,
                      agentsight_llm_callback_fn llm,
                      void* user_data,
                      int flags) {
@@ -166,6 +177,36 @@ int fake_handle_read(AgentsightHandle* h,
         gRead.read_mode = 0;
         return 1;
     }
+    if (gRead.read_mode == 3) {
+        static const char method[] = "POST";
+        static const char path[] = "/v1/custom";
+        static const char reqHeaders[] = "{\"host\":\"my-svc.example.com:8443\"}";
+        static const char reqBody[] = "{\"q\":1}";
+        static const char respHeaders[] = "{\"content-type\":\"application/octet-stream\"}";
+        static const char respBody[] = "{\"a\":1}";
+        std::memset(&sUtHttpsData, 0, sizeof(sUtHttpsData));
+        sUtHttpsData.pid = 4321;
+        std::memcpy(sUtHttpsData.process_name, "utp", 3U);
+        sUtHttpsData.timestamp_ns = 1700000000000000000ULL;
+        sUtHttpsData.duration_ns = 1500000000ULL;
+        sUtHttpsData.method = method;
+        sUtHttpsData.path = path;
+        sUtHttpsData.status_code = 502;
+        sUtHttpsData.is_sse = 1;
+        sUtHttpsData.request_headers = reqHeaders;
+        sUtHttpsData.request_headers_len = static_cast<uint32_t>(sizeof(reqHeaders) - 1U);
+        sUtHttpsData.request_body = reqBody;
+        sUtHttpsData.request_body_len = static_cast<uint32_t>(sizeof(reqBody) - 1U);
+        sUtHttpsData.response_headers = respHeaders;
+        sUtHttpsData.response_headers_len = static_cast<uint32_t>(sizeof(respHeaders) - 1U);
+        sUtHttpsData.response_body = respBody;
+        sUtHttpsData.response_body_len = static_cast<uint32_t>(sizeof(respBody) - 1U);
+        if (https != nullptr) {
+            https(&sUtHttpsData, https_user_data);
+        }
+        gRead.read_mode = 0;
+        return 1;
+    }
     return 0;
 }
 
@@ -176,6 +217,7 @@ std::unique_ptr<AgentSightSymbolTable> makeFullSymbolTable() {
     t->config_free = fake_config_free;
     t->config_set_verbose = fake_config_set_verbose;
     t->config_set_log_path = fake_config_set_log_path;
+    t->config_set_enable_raw_https = fake_config_set_enable_raw_https;
     t->config_add_cmdline_rule = fake_config_add_cmdline_rule;
     t->config_add_https = fake_config_add_https;
     t->config_add_http = fake_config_add_http;
@@ -196,6 +238,36 @@ std::shared_ptr<AgentsightLlmRecord> makeMinimalLlmRecord(const char* configName
     data.response_id = "resp-ut";
     data.timestamp_ns = 1U;
     return std::make_shared<AgentsightLlmRecord>(std::string(configName), data);
+}
+
+std::shared_ptr<AgentsightHttpsRecord> makeHttpsRecord(
+    const char* configName,
+    const char* requestHeaders = "{\"host\":\"my-svc.example.com:8443\",\"content-type\":\"application/json\"}",
+    uint16_t statusCode = 502) {
+    static const char method[] = "POST";
+    static const char path[] = "/v1/custom";
+    static const char reqBody[] = "{\"unparsable\":true}";
+    static const char respHeaders[] = "{\"content-type\":\"application/octet-stream\"}";
+    static const char respBody[] = "{\"raw\":\"bytes\"}";
+    static AgentsightHttpsData d{};
+    std::memset(&d, 0, sizeof(d));
+    d.pid = 4321;
+    std::memcpy(d.process_name, "ut-agent", 8U);
+    d.timestamp_ns = 1700000000000000000ULL;
+    d.duration_ns = statusCode == 0 ? 0 : 1500000000ULL;
+    d.method = method;
+    d.path = path;
+    d.status_code = statusCode;
+    d.is_sse = statusCode == 0 ? 0 : 1;
+    d.request_headers = requestHeaders;
+    d.request_headers_len = static_cast<uint32_t>(std::strlen(requestHeaders));
+    d.request_body = reqBody;
+    d.request_body_len = static_cast<uint32_t>(sizeof(reqBody) - 1U);
+    d.response_headers = statusCode == 0 ? nullptr : respHeaders;
+    d.response_headers_len = statusCode == 0 ? 0 : static_cast<uint32_t>(sizeof(respHeaders) - 1U);
+    d.response_body = statusCode == 0 ? nullptr : respBody;
+    d.response_body_len = statusCode == 0 ? 0 : static_cast<uint32_t>(sizeof(respBody) - 1U);
+    return std::make_shared<AgentsightHttpsRecord>(std::string(configName), d);
 }
 
 class AgentSightTestEBPFAdapter : public EBPFAdapter {
@@ -239,6 +311,7 @@ public:
         g_ut_cmdline_deny_calls = 0;
         g_ut_https_calls = 0;
         g_ut_http_calls = 0;
+        g_ut_raw_https_values.clear();
         auto& o = agentsightOptions();
         o.mAgentsightCmdlineWhitelist.clear();
         o.mAgentsightCmdlineBlacklist.clear();
@@ -264,6 +337,7 @@ public:
         o.mProbeType = SecurityProbeType::AGENTSIGHT_OBSERVE;
         o.mVerbose = 0;
         o.mLogPath.clear();
+        o.mAgentsightEnableRawHttps = false;
         return o;
     }
 
@@ -294,14 +368,19 @@ public:
 
     void TestAddOrUpdateValidation();
     void TestAddOrUpdateNoSymbols();
+    void TestMissingRawHttpsSetter();
     void TestRestartStartFailure();
     void TestConfigNewNull();
     void TestAddRemoveDestroy();
     void TestSecondAddOrUpdate();
     void TestOnEpollDrain();
+    void TestOnEpollDrainHttps();
+    void TestOnEpollDrainHttpsGatedOff();
     void TestOnEpollNoHandle();
     void TestAddOrUpdateInvalidEventFd();
     void TestHandleEventBranches();
+    void TestHandleHttpsEvent();
+    void TestHandleHttpsRequestOnlyAndIpv6();
     void TestResumeInvalidOptions();
     void TestResumeWithNoRegistration();
     void TestSuspend();
@@ -356,6 +435,22 @@ void AgentsightManagerUnittest::TestAddOrUpdateNoSymbols() {
     mAgentSightAdapter->setAgentSightSymbols(makeFullSymbolTable());
 }
 
+void AgentsightManagerUnittest::TestMissingRawHttpsSetter() {
+    auto symbols = makeFullSymbolTable();
+    symbols->config_set_enable_raw_https = nullptr;
+    mAgentSightAdapter->setAgentSightSymbols(std::move(symbols));
+
+    auto mgr = makeManager();
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName("p1");
+    ctx.SetProcessQueueKey(1);
+    APSARA_TEST_NOT_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 0, nullptr, asVariant()));
+    APSARA_TEST_EQUAL(0, mgr->RegisteredConfigCount());
+    mgr->Destroy();
+
+    mAgentSightAdapter->setAgentSightSymbols(makeFullSymbolTable());
+}
+
 void AgentsightManagerUnittest::TestRestartStartFailure() {
     gRead.start_ret = 1;
     auto mgr = makeManager();
@@ -396,9 +491,17 @@ void AgentsightManagerUnittest::TestSecondAddOrUpdate() {
     CollectionPipelineContext ctx;
     ctx.SetConfigName("p1");
     ctx.SetProcessQueueKey(1);
-    APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 0, nullptr, asVariant()));
-    APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 1, nullptr, asVariant()));
+    auto& opts = agentsightOptions();
+    APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 0, nullptr, PluginOptions(&opts)));
+    opts.mAgentsightEnableRawHttps = true;
+    APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 1, nullptr, PluginOptions(&opts)));
+    opts.mAgentsightEnableRawHttps = false;
+    APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 1, nullptr, PluginOptions(&opts)));
     APSARA_TEST_EQUAL(1, mgr->RegisteredConfigCount());
+    APSARA_TEST_EQUAL(3UL, g_ut_raw_https_values.size());
+    APSARA_TEST_EQUAL(0, g_ut_raw_https_values[0]);
+    APSARA_TEST_EQUAL(1, g_ut_raw_https_values[1]);
+    APSARA_TEST_EQUAL(0, g_ut_raw_https_values[2]);
     mgr->RemoveConfig("p1");
     mgr->Destroy();
 }
@@ -437,6 +540,60 @@ void AgentsightManagerUnittest::TestOnEpollDrain() {
     mgr->Destroy();
 }
 
+void AgentsightManagerUnittest::TestOnEpollDrainHttps() {
+    auto mgr = makeManager();
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName("p1");
+    ctx.SetProcessQueueKey(1);
+    auto& opts = agentsightOptions();
+    opts.mAgentsightEnableRawHttps = true; // gate on: HTTPS callback registered
+    APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 0, nullptr, PluginOptions(&opts)));
+
+    gRead.read_mode = 3;
+    APSARA_TEST_NOT_EQUAL(0, mgr->OnEpollReadable());
+    gRead = decltype(gRead){};
+
+    // The HTTPS callback must have enqueued exactly one deep-copied record.
+    std::shared_ptr<CommonEvent> evt;
+    APSARA_TEST_TRUE(mEventQueue->try_dequeue(evt));
+    auto* rec = static_cast<AgentsightHttpsRecord*>(evt.get());
+    APSARA_TEST_EQUAL(KernelEventType::AGENTSIGHT_HTTPS_RECORD, evt->GetKernelEventType());
+    APSARA_TEST_EQUAL("p1", rec->GetPipelineConfigName());
+    APSARA_TEST_EQUAL(4321, rec->mPid);
+    APSARA_TEST_EQUAL("utp", rec->mProcessName);
+    APSARA_TEST_EQUAL(1700000000000000000ULL, rec->mTimestampNs);
+    APSARA_TEST_EQUAL(1500000000ULL, rec->mDurationNs);
+    APSARA_TEST_EQUAL("POST", rec->mMethod);
+    APSARA_TEST_EQUAL("/v1/custom", rec->mPath);
+    APSARA_TEST_EQUAL(502, rec->mStatusCode);
+    APSARA_TEST_EQUAL(1, rec->mIsSse);
+    APSARA_TEST_EQUAL("{\"host\":\"my-svc.example.com:8443\"}", rec->mRequestHeaders);
+    APSARA_TEST_EQUAL("{\"q\":1}", rec->mRequestBody);
+    APSARA_TEST_EQUAL("{\"content-type\":\"application/octet-stream\"}", rec->mResponseHeaders);
+    APSARA_TEST_EQUAL("{\"a\":1}", rec->mResponseBody);
+
+    mgr->Destroy();
+}
+
+void AgentsightManagerUnittest::TestOnEpollDrainHttpsGatedOff() {
+    auto mgr = makeManager();
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName("p1");
+    ctx.SetProcessQueueKey(1);
+    // Default gate (EnableRawHttps=false): HTTPS callback passed as nullptr, so the fallback
+    // event is consumed by coolbpf and dropped -- nothing must be enqueued.
+    APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 0, nullptr, asVariant()));
+
+    gRead.read_mode = 3;
+    APSARA_TEST_NOT_EQUAL(0, mgr->OnEpollReadable());
+    gRead = decltype(gRead){};
+
+    std::shared_ptr<CommonEvent> evt;
+    APSARA_TEST_FALSE(mEventQueue->try_dequeue(evt));
+
+    mgr->Destroy();
+}
+
 void AgentsightManagerUnittest::TestAddOrUpdateInvalidEventFd() {
     auto mgr = makeManager();
     CollectionPipelineContext ctx;
@@ -470,6 +627,113 @@ void AgentsightManagerUnittest::TestHandleEventBranches() {
     auto rec2 = std::make_shared<AgentsightLlmRecord>(std::string("p1"), d);
     APSARA_TEST_EQUAL(0, mgr->HandleEvent(rec2));
     mgr->Destroy();
+}
+
+void AgentsightManagerUnittest::TestHandleHttpsEvent() {
+    const QueueKey queueKey = QueueKeyManager::GetInstance()->GetKey("p_https");
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName("p_https");
+    ProcessQueueManager::GetInstance()->CreateOrUpdateCountBoundedQueue(queueKey, 0, ctx);
+    ProcessQueueManager::GetInstance()->EnablePop("p_https");
+
+    auto mgr = makeManager();
+    // Before AddOrUpdateConfig, mPipelineCtx is null: event is dropped silently.
+    APSARA_TEST_EQUAL(0, mgr->HandleEvent(makeHttpsRecord("orphan")));
+
+    ctx.SetProcessQueueKey(queueKey);
+    APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 0, nullptr, asVariant()));
+
+    APSARA_TEST_EQUAL(0, mgr->HandleEvent(makeHttpsRecord("p_https")));
+
+    std::unique_ptr<ProcessQueueItem> item;
+    std::string configName;
+    APSARA_TEST_TRUE(ProcessQueueManager::GetInstance()->PopItem(0, item, configName));
+    if (!item) {
+        return;
+    }
+    APSARA_TEST_EQUAL("p_https", configName);
+    const auto& events = item->mEventGroup.GetEvents();
+    APSARA_TEST_EQUAL(2UL, events.size());
+
+    const auto* req = events[0].Get<LogEvent>();
+    const auto* resp = events[1].Get<LogEvent>();
+
+    // Shared correlation id and request-side fields.
+    APSARA_TEST_TRUE(req->HasContent("event.id"));
+    APSARA_TEST_EQUAL(req->GetContent("event.id").to_string(), resp->GetContent("event.id").to_string());
+    APSARA_TEST_EQUAL("http.request", req->GetContent("event.name"));
+    APSARA_TEST_EQUAL("http.response", resp->GetContent("event.name"));
+    APSARA_TEST_EQUAL("4321", req->GetContent("pid"));
+    APSARA_TEST_EQUAL("ut-agent", req->GetContent("comm"));
+    APSARA_TEST_EQUAL("https", req->GetContent("url.scheme"));
+    APSARA_TEST_EQUAL("POST", req->GetContent("http.request.method"));
+    APSARA_TEST_EQUAL("/v1/custom", req->GetContent("url.path"));
+    APSARA_TEST_EQUAL("my-svc.example.com", req->GetContent("server.address"));
+    APSARA_TEST_EQUAL("8443", req->GetContent("server.port"));
+    APSARA_TEST_TRUE(req->HasContent("http.request.header"));
+    APSARA_TEST_EQUAL("{\"unparsable\":true}", req->GetContent("http.request.body.content"));
+    APSARA_TEST_EQUAL(std::to_string(std::string("{\"unparsable\":true}").size()),
+                      req->GetContent("http.request.body.size"));
+
+    // Response-side fields.
+    APSARA_TEST_EQUAL("https", resp->GetContent("url.scheme"));
+    APSARA_TEST_EQUAL("502", resp->GetContent("http.response.status_code"));
+    APSARA_TEST_EQUAL("1", resp->GetContent("is_sse"));
+    APSARA_TEST_TRUE(resp->HasContent("http.response.header"));
+    APSARA_TEST_EQUAL("{\"raw\":\"bytes\"}", resp->GetContent("http.response.body.content"));
+    APSARA_TEST_EQUAL(std::to_string(std::string("{\"raw\":\"bytes\"}").size()),
+                      resp->GetContent("http.response.body.size"));
+
+    // Timestamps: request at timestamp_ns, response at timestamp_ns + duration_ns.
+    APSARA_TEST_EQUAL(1700000000, req->GetTimestamp());
+    APSARA_TEST_EQUAL(1700000000 + 1, resp->GetTimestamp());
+    APSARA_TEST_TRUE(resp->GetTimestampNanosecond().has_value());
+    APSARA_TEST_EQUAL(500000000U, resp->GetTimestampNanosecond().value());
+
+    mgr->Destroy();
+    ProcessQueueManager::GetInstance()->DeleteQueue(queueKey);
+}
+
+void AgentsightManagerUnittest::TestHandleHttpsRequestOnlyAndIpv6() {
+    const QueueKey queueKey = QueueKeyManager::GetInstance()->GetKey("p_https_edges");
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName("p_https_edges");
+    ctx.SetProcessQueueKey(queueKey);
+    ProcessQueueManager::GetInstance()->CreateOrUpdateCountBoundedQueue(queueKey, 0, ctx);
+    ProcessQueueManager::GetInstance()->EnablePop("p_https_edges");
+
+    auto mgr = makeManager();
+    APSARA_TEST_EQUAL(0, mgr->AddOrUpdateConfig(&ctx, 0, nullptr, asVariant()));
+
+    APSARA_TEST_EQUAL(
+        0,
+        mgr->HandleEvent(makeHttpsRecord("p_https_edges", "{\":authority\":\"[2001:db8::1]:9443\"}", 200)));
+    std::unique_ptr<ProcessQueueItem> item;
+    std::string configName;
+    APSARA_TEST_TRUE(ProcessQueueManager::GetInstance()->PopItem(0, item, configName));
+    APSARA_TEST_TRUE(item != nullptr);
+    if (item) {
+        const auto& events = item->mEventGroup.GetEvents();
+        APSARA_TEST_EQUAL(2UL, events.size());
+        const auto* request = events[0].Get<LogEvent>();
+        APSARA_TEST_EQUAL("2001:db8::1", request->GetContent("server.address"));
+        APSARA_TEST_EQUAL("9443", request->GetContent("server.port"));
+    }
+
+    APSARA_TEST_EQUAL(0, mgr->HandleEvent(makeHttpsRecord("p_https_edges", "{\"host\":\"request-only\"}", 0)));
+    item.reset();
+    APSARA_TEST_TRUE(ProcessQueueManager::GetInstance()->PopItem(0, item, configName));
+    APSARA_TEST_TRUE(item != nullptr);
+    if (item) {
+        const auto& events = item->mEventGroup.GetEvents();
+        APSARA_TEST_EQUAL(1UL, events.size());
+        const auto* request = events[0].Get<LogEvent>();
+        APSARA_TEST_EQUAL("http.request", request->GetContent("event.name"));
+        APSARA_TEST_EQUAL("request-only", request->GetContent("server.address"));
+    }
+
+    mgr->Destroy();
+    ProcessQueueManager::GetInstance()->DeleteQueue(queueKey);
 }
 
 void AgentsightManagerUnittest::TestResumeInvalidOptions() {
@@ -623,14 +887,19 @@ void AgentsightManagerUnittest::TestSessionInputCacheLruEviction() {
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestGetPluginType);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestAddOrUpdateValidation);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestAddOrUpdateNoSymbols);
+UNIT_TEST_CASE(AgentsightManagerUnittest, TestMissingRawHttpsSetter);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestRestartStartFailure);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestConfigNewNull);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestAddRemoveDestroy);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestSecondAddOrUpdate);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestOnEpollNoHandle);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestOnEpollDrain);
+UNIT_TEST_CASE(AgentsightManagerUnittest, TestOnEpollDrainHttps);
+UNIT_TEST_CASE(AgentsightManagerUnittest, TestOnEpollDrainHttpsGatedOff);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestAddOrUpdateInvalidEventFd);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestHandleEventBranches);
+UNIT_TEST_CASE(AgentsightManagerUnittest, TestHandleHttpsEvent);
+UNIT_TEST_CASE(AgentsightManagerUnittest, TestHandleHttpsRequestOnlyAndIpv6);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestResumeInvalidOptions);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestResumeWithNoRegistration);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestSuspend);

--- a/core/unittest/ebpf/SecurityOptionsUnittest.cpp
+++ b/core/unittest/ebpf/SecurityOptionsUnittest.cpp
@@ -36,6 +36,7 @@ public:
     void TestAgentsightProbeConfigHttpsHttpInvalidTypes();
     void TestAgentsightEventStreamFormatParse();
     void TestAgentsightMessageDeltaOnlyDefaultAndParse();
+    void TestAgentsightEnableRawHttpsDefaultAndParse();
 };
 
 void SecurityOptionsUnittest::TestAgentsightNoProbeConfigFallsBackToBuiltin() {
@@ -47,6 +48,7 @@ void SecurityOptionsUnittest::TestAgentsightNoProbeConfigFallsBackToBuiltin() {
     APSARA_TEST_TRUE(opt.mAgentsightCmdlineWhitelist.empty());
     APSARA_TEST_TRUE(opt.mAgentsightMessageDeltaOnly);
     APSARA_TEST_TRUE(opt.mAgentsightEventStreamFormat);
+    APSARA_TEST_FALSE(opt.mAgentsightEnableRawHttps);
 }
 
 void SecurityOptionsUnittest::TestAgentsightMessageDeltaOnlyDefaultAndParse() {
@@ -62,6 +64,26 @@ void SecurityOptionsUnittest::TestAgentsightMessageDeltaOnlyDefaultAndParse() {
     APSARA_TEST_TRUE(ParseJsonTable(R"({"ProbeConfig":{"MessageDeltaOnly":true}})", config, err));
     APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
     APSARA_TEST_TRUE(opt.mAgentsightMessageDeltaOnly);
+}
+
+void SecurityOptionsUnittest::TestAgentsightEnableRawHttpsDefaultAndParse() {
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName("cfg1");
+    SecurityOptions opt;
+    std::string err;
+    Json::Value config;
+    // Default when absent: false (LLM-only collection).
+    APSARA_TEST_TRUE(ParseJsonTable(R"({"ProbeConfig":{}})", config, err));
+    APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
+    APSARA_TEST_FALSE(opt.mAgentsightEnableRawHttps);
+
+    APSARA_TEST_TRUE(ParseJsonTable(R"({"ProbeConfig":{"EnableRawHttps":true}})", config, err));
+    APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
+    APSARA_TEST_TRUE(opt.mAgentsightEnableRawHttps);
+
+    APSARA_TEST_TRUE(ParseJsonTable(R"({"ProbeConfig":{"EnableRawHttps":false}})", config, err));
+    APSARA_TEST_TRUE(opt.Init(SecurityProbeType::AGENTSIGHT_OBSERVE, config, &ctx, "input_agentsight"));
+    APSARA_TEST_FALSE(opt.mAgentsightEnableRawHttps);
 }
 
 void SecurityOptionsUnittest::TestAgentsightProbeConfigWrongTypeFallsBackToBuiltin() {
@@ -257,5 +279,6 @@ UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightProbeConfigParsesHttpsAndH
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightProbeConfigHttpsHttpInvalidTypes)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightEventStreamFormatParse)
 UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightMessageDeltaOnlyDefaultAndParse)
+UNIT_TEST_CASE(SecurityOptionsUnittest, TestAgentsightEnableRawHttpsDefaultAndParse)
 
 UNIT_TEST_MAIN

--- a/docs/cn/plugins/input/native/input_agentsight.md
+++ b/docs/cn/plugins/input/native/input_agentsight.md
@@ -34,6 +34,7 @@ dev
 |  ProbeConfig.Http  |  array  |  否  |  `[]`（关闭）  |  HTTP 明文流量的目标列表（字符串数组）。每项可为 `:端口`、`IP`、`IP:端口` 或域名（如 `model-svc.default.svc`、`*.internal.svc`）。**留空时不采集明文 HTTP 流量**。  |
 |  ProbeConfig.EventStreamFormat  |  bool  |  否  |  `true`  |  为 `true` 时，每次 LLM 调用在同一 `PipelineEventGroup` 内输出两条日志（各有 `event.id`）：`event.name=gen_ai.model.request`（请求开始时间戳）与 `gen_ai.model.response`（请求结束时间戳）。为 `false` 时输出单条合并日志，**无** `event.name` / `event.id`。  |
 |  ProbeConfig.MessageDeltaOnly  |  bool  |  否  |  `true`  |  为 `true` 时**不**输出全量 `gen_ai.input.messages`；仍输出 `gen_ai.input.messages_delta`、`gen_ai.system_instructions_hash` / `gen_ai.tool.definitions_hash`（非空时），以及 hash 相对上一轮变化时的 `gen_ai.system_instructions` / `gen_ai.tool.definitions`。为 `false` 时**每次**输出非空的全量 `gen_ai.input.messages`。**不影响** `gen_ai.output.messages`；`messages_delta` 及 session 状态维护**不受**本开关影响。  |
+|  ProbeConfig.EnableRawHttps  |  bool  |  否  |  `false`  |  是否上报**不可解析的 raw HTTPS 流量**。默认 `false`，即只采集可识别为 LLM API 调用的流量；为 `true` 时，被纳入采集的进程发出的、无法解析为 LLM 语义的 HTTPS 流量会以 fallback 事件（`http.request`/`http.response`）额外上报，见下文。  |
 
 ### `AgentType` 取值命名规范
 
@@ -329,6 +330,19 @@ Http:
 - 每次 LLM 调用 **一条** 日志，**无** `event.name`、**无** `event.id`；时间戳为请求开始时刻。
 - **有**：关联字段、HTTP/`usage` 元数据、`gen_ai.input.messages_delta`（非空时）、system/tools hash（非空时）、hash 变化时的 system/tools 全文、`gen_ai.output.messages`。
 - **无**：全量 `gen_ai.input.messages`、拆分后的 `gen_ai.model.request` / `gen_ai.model.response`。
+
+### 不可解析 HTTPS 流量（fallback）
+
+**默认关闭**。仅当 `ProbeConfig.EnableRawHttps: true` 时启用：被纳入采集的进程（见「黑白名单判定逻辑」）发出的 HTTPS 流量，若无法解析为 LLM API 调用，会以 **fallback 事件** 形式上报原始 HTTP 报文，**不受** `Https` 域名列表、`EventStreamFormat` 与 `MessageDeltaOnly` 影响。关闭时（默认）底层不会构造或入队这类 fallback 事件。收到完整响应的 HTTPS 交互输出 **两条** 日志，共享同一 `event.id`：
+
+| `event.name` | 时间戳 | 主要字段 |
+| :--- | :--- | :--- |
+| `http.request` | 请求开始时刻 | `url.scheme=https`、`http.request.method`、`url.path`、`server.address` / `server.port`（从请求头 `host`/`:authority` 提取，可提取时）、`http.request.header`（请求头整包 JSON）、`http.request.body.content` / `http.request.body.size`（非空时） |
+| `http.response` | 请求开始 + 耗时 | `url.scheme=https`、`http.response.status_code`、`is_sse`、`http.response.header`（响应头整包 JSON）、`http.response.body.content` / `http.response.body.size`（非空时） |
+
+两条日志均包含：`event.id`、`pid`、`comm`、`time_unix_nano`、`observed_time_unix_nano`。
+
+若只捕获到请求、尚未收到响应（RequestOnly），仅输出 `http.request`，不生成 `http.response`。
 
 ## 样例
 


### PR DESCRIPTION
## Summary

- Add `ProbeConfig.EnableRawHttps`, disabled by default, to control raw HTTPS fallback collection.
- Handle `AGENTSIGHT_EVENT_HTTPS` records and deep-copy all FFI-owned buffers before the read batch is released.
- Emit correlated `http.request` and `http.response` logs with timestamps, headers, bodies, status, SSE metadata, and parsed server address/port.
- Support request-only events without producing a synthetic response log.
- Document the option, output fields, default behavior, and fallback-event semantics.

## Behavior

The default behavior is unchanged: only HTTPS traffic recognized as an LLM API call is reported.

When `ProbeConfig.EnableRawHttps` is set to `true`, HTTPS traffic from selected processes that cannot be parsed into LLM semantics is reported as fallback HTTP events. A completed interaction produces request and response logs sharing one `event.id`; a request-only interaction produces only the request log.

Raw fallback events are independent of `ProbeConfig.Https`, `EventStreamFormat`, and `MessageDeltaOnly`.

## Implementation

- Parse and retain the new configuration flag.
- Resolve and invoke the new `agentsight_config_set_enable_raw_https` FFI symbol.
- Add the HTTPS kernel event type and owning C++ record representation.
- Convert raw HTTPS records into pipeline event groups using OTLP-style HTTP attributes.
- Add coverage for configuration defaults/parsing, FFI buffer ownership, event dispatch, request/response generation, request-only handling, host parsing, and queue behavior.

## Validation

- `git diff --check` passed.
- Pre-commit and pre-push sensitive-information scans passed.
- The seven changed C++ implementation/test translation units compiled successfully using CMake-generated compile commands.
- Full linked unit-test targets were not completed locally because the workspace's invalid `LC_ALL=C.UTF-8` setting contaminates coolbpf architecture detection commands; Docker is unavailable in this environment.

## coolbpf dependency

The `core/_thirdparty/coolbpf` gitlink is intentionally unchanged in this PR. The corresponding coolbpf change will be submitted separately once its final commit ID is available. That change must export `agentsight_config_set_enable_raw_https` and emit `AGENTSIGHT_EVENT_HTTPS` fallback records; the LoongCollector gitlink can then be updated in a follow-up commit.
